### PR TITLE
Keep unknown fields in decode/encode roundtrips

### DIFF
--- a/conformance/failing_tests.txt
+++ b/conformance/failing_tests.txt
@@ -1,3 +1,0 @@
-# TODO(danburkert/prost#2): prost doesn't preserve unknown fields.
-Required.Proto2.ProtobufInput.UnknownVarint.ProtobufOutput
-Required.Proto3.ProtobufInput.UnknownVarint.ProtobufOutput

--- a/conformance/tests/conformance.rs
+++ b/conformance/tests/conformance.rs
@@ -17,7 +17,6 @@ fn test_conformance() {
 
     let status = Command::new(env!("CONFORMANCE_TEST_RUNNER"))
                          .arg("--enforce_recommended")
-                         .arg("--failure_list").arg("failing_tests.txt")
                          .arg(proto_conformance)
                          .status()
                          .expect("failed to execute conformance-test-runner");

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -198,6 +198,8 @@ impl <'a> CodeGenerator<'a> {
         }
         self.path.pop();
 
+        self.append_unknown_fields_field();
+
         self.depth -= 1;
         self.push_indent();
         self.buf.push_str("}\n");
@@ -435,6 +437,13 @@ impl <'a> CodeGenerator<'a> {
 
         self.push_indent();
         self.buf.push_str("}\n");
+    }
+
+    fn append_unknown_fields_field(&mut self) {
+        self.push_indent();
+        self.buf.push_str("#[prost(unknown_field_set)]\n");
+        self.push_indent();
+        self.buf.push_str("pub unknown_fields: ::prost::UnknownFieldSet,\n");
     }
 
     fn location(&self) -> &Location {

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -139,6 +139,13 @@ impl Field {
         }
     }
 
+    pub fn is_unknown_field_set(&self) -> bool {
+        match *self {
+            Field::UnknownFieldSet(_) => true,
+            _ => false,
+        }
+    }
+
     pub fn default(&self) -> TokenStream {
         match *self {
             Field::Scalar(ref scalar) => scalar.default(),

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -2,6 +2,7 @@ mod map;
 mod message;
 mod oneof;
 mod scalar;
+mod unknown_field_set;
 
 use std::fmt;
 use std::slice;
@@ -29,6 +30,8 @@ pub enum Field {
     Map(map::Field),
     /// A oneof field.
     Oneof(oneof::Field),
+    /// A unknown_field_set pseudo-field.
+    UnknownFieldSet(unknown_field_set::Field),
 }
 
 impl Field {
@@ -50,6 +53,8 @@ impl Field {
             Field::Map(field)
         } else if let Some(field) = oneof::Field::new(&attrs)? {
             Field::Oneof(field)
+        } else if let Some(field) = unknown_field_set::Field::new(&attrs)? {
+            Field::UnknownFieldSet(field)
         } else {
             bail!("no type attribute");
         };
@@ -85,6 +90,7 @@ impl Field {
             Field::Message(ref message) => vec![message.tag],
             Field::Map(ref map) => vec![map.tag],
             Field::Oneof(ref oneof) => oneof.tags.clone(),
+            Field::UnknownFieldSet(ref _set) => vec![],
         }
     }
 
@@ -95,6 +101,7 @@ impl Field {
             Field::Message(ref message) => message.encode(ident),
             Field::Map(ref map) => map.encode(ident),
             Field::Oneof(ref oneof) => oneof.encode(ident),
+            Field::UnknownFieldSet(ref set) => set.encode(ident),
         }
     }
 
@@ -106,6 +113,7 @@ impl Field {
             Field::Message(ref message) => message.merge(ident),
             Field::Map(ref map) => map.merge(ident),
             Field::Oneof(ref oneof) => oneof.merge(ident),
+            Field::UnknownFieldSet(ref set) => set.merge(ident),
         }
     }
 
@@ -116,6 +124,7 @@ impl Field {
             Field::Map(ref map) => map.encoded_len(ident),
             Field::Message(ref msg) => msg.encoded_len(ident),
             Field::Oneof(ref oneof) => oneof.encoded_len(ident),
+            Field::UnknownFieldSet(ref set) => set.encoded_len(ident),
         }
     }
 
@@ -126,6 +135,7 @@ impl Field {
             Field::Message(ref message) => message.clear(ident),
             Field::Map(ref map) => map.clear(ident),
             Field::Oneof(ref oneof) => oneof.clear(ident),
+            Field::UnknownFieldSet(ref set) => set.clear(ident),
         }
     }
 

--- a/prost-derive/src/field/unknown_field_set.rs
+++ b/prost-derive/src/field/unknown_field_set.rs
@@ -18,8 +18,10 @@ impl Field {
     }
 
     /// Returns a statement which encodes the field.
-    pub fn encode(&self, _ident: TokenStream) -> TokenStream {
-        quote! {}
+    pub fn encode(&self, ident: TokenStream) -> TokenStream {
+        quote! {
+            #ident.encode(buf);
+        }
     }
 
     /// Returns an expression which evaluates to the result of decoding the field.
@@ -28,8 +30,10 @@ impl Field {
     }
 
     /// Returns an expression which evaluates to the encoded length of the field.
-    pub fn encoded_len(&self, _ident: TokenStream) -> TokenStream {
-        quote! { 0 }
+    pub fn encoded_len(&self, ident: TokenStream) -> TokenStream {
+        quote! {
+            #ident.encoded_len()
+        }
     }
 
     pub fn clear(&self, ident: TokenStream) -> TokenStream {

--- a/prost-derive/src/field/unknown_field_set.rs
+++ b/prost-derive/src/field/unknown_field_set.rs
@@ -1,0 +1,38 @@
+use failure::Error;
+use proc_macro2::TokenStream;
+use syn::{
+    Meta,
+};
+
+#[derive(Clone)]
+pub struct Field {
+}
+
+impl Field {
+    pub fn new(attrs: &[Meta]) -> Result<Option<Field>, Error> {
+        if attrs.len() != 1 || attrs[0].name() != "unknown_field_set" {
+        	bail!("invalid format for unknown_field_set annotation");
+        }
+
+        Ok(Some(Field {}))
+    }
+
+    /// Returns a statement which encodes the field.
+    pub fn encode(&self, _ident: TokenStream) -> TokenStream {
+        quote! {}
+    }
+
+    /// Returns an expression which evaluates to the result of decoding the field.
+    pub fn merge(&self, _ident: TokenStream) -> TokenStream {
+        quote! {}
+    }
+
+    /// Returns an expression which evaluates to the encoded length of the field.
+    pub fn encoded_len(&self, _ident: TokenStream) -> TokenStream {
+        quote! { 0 }
+    }
+
+    pub fn clear(&self, ident: TokenStream) -> TokenStream {
+        quote!(#ident = ::std::default::Default::default())
+    }
+}

--- a/prost-types/src/compiler.rs
+++ b/prost-types/src/compiler.rs
@@ -11,6 +11,8 @@ pub struct Version {
     /// be empty for mainline stable releases.
     #[prost(string, optional, tag="4")]
     pub suffix: ::std::option::Option<String>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// An encoded CodeGeneratorRequest is written to the plugin's stdin.
 #[derive(Clone, PartialEq, Message)]
@@ -42,6 +44,8 @@ pub struct CodeGeneratorRequest {
     /// The version number of protocol compiler.
     #[prost(message, optional, tag="3")]
     pub compiler_version: ::std::option::Option<Version>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// The plugin writes an encoded CodeGeneratorResponse to stdout.
 #[derive(Clone, PartialEq, Message)]
@@ -58,6 +62,8 @@ pub struct CodeGeneratorResponse {
     pub error: ::std::option::Option<String>,
     #[prost(message, repeated, tag="15")]
     pub file: ::std::vec::Vec<code_generator_response::File>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 pub mod code_generator_response {
     /// Represents a single generated file.
@@ -118,5 +124,7 @@ pub mod code_generator_response {
         /// The file contents.
         #[prost(string, optional, tag="15")]
         pub content: ::std::option::Option<String>,
+        #[prost(unknown_field_set)]
+        pub unknown_fields: ::prost::UnknownFieldSet,
     }
 }

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -11,6 +11,7 @@
 
 #[macro_use]
 extern crate prost_derive;
+extern crate prost;
 
 use std::i32;
 use std::i64;
@@ -60,7 +61,7 @@ impl From<time::Duration> for Duration {
         let seconds = if seconds > i64::MAX as u64 { i64::MAX } else { seconds as i64 };
         let nanos = duration.subsec_nanos();
         let nanos = if nanos > i32::MAX as u32 { i32::MAX } else { nanos as i32 };
-        let mut duration = Duration { seconds, nanos };
+        let mut duration = Duration { seconds, nanos, ..Default::default() };
         duration.normalize();
         duration
     }
@@ -112,6 +113,7 @@ impl From<time::SystemTime> for Timestamp {
         Timestamp {
             seconds: duration.seconds,
             nanos: duration.nanos,
+            ..Default::default()
         }
     }
 }
@@ -129,6 +131,7 @@ impl From<Timestamp> for Result<time::SystemTime, time::Duration> {
             let mut duration = Duration {
                 seconds: -timestamp.seconds,
                 nanos: timestamp.nanos,
+                ..Default::default()
             };
             duration.normalize();
             Err(time::Duration::new(duration.seconds as u64, duration.nanos as u32))

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -4,6 +4,8 @@
 pub struct FileDescriptorSet {
     #[prost(message, repeated, tag="1")]
     pub file: ::std::vec::Vec<FileDescriptorProto>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// Describes a complete .proto file.
 #[derive(Clone, PartialEq, Message)]
@@ -45,6 +47,8 @@ pub struct FileDescriptorProto {
     /// The supported values are "proto2" and "proto3".
     #[prost(string, optional, tag="12")]
     pub syntax: ::std::option::Option<String>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// Describes a message type.
 #[derive(Clone, PartialEq, Message)]
@@ -71,6 +75,8 @@ pub struct DescriptorProto {
     /// A given name may only be reserved once.
     #[prost(string, repeated, tag="10")]
     pub reserved_name: ::std::vec::Vec<String>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 pub mod descriptor_proto {
     #[derive(Clone, PartialEq, Message)]
@@ -81,6 +87,8 @@ pub mod descriptor_proto {
         pub end: ::std::option::Option<i32>,
         #[prost(message, optional, tag="3")]
         pub options: ::std::option::Option<super::ExtensionRangeOptions>,
+        #[prost(unknown_field_set)]
+        pub unknown_fields: ::prost::UnknownFieldSet,
     }
     /// Range of reserved tag numbers. Reserved tag numbers may not be used by
     /// fields or extension ranges in the same message. Reserved ranges may
@@ -93,6 +101,8 @@ pub mod descriptor_proto {
         /// Exclusive.
         #[prost(int32, optional, tag="2")]
         pub end: ::std::option::Option<i32>,
+        #[prost(unknown_field_set)]
+        pub unknown_fields: ::prost::UnknownFieldSet,
     }
 }
 #[derive(Clone, PartialEq, Message)]
@@ -100,6 +110,8 @@ pub struct ExtensionRangeOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// Describes a field within a message.
 #[derive(Clone, PartialEq, Message)]
@@ -144,6 +156,8 @@ pub struct FieldDescriptorProto {
     pub json_name: ::std::option::Option<String>,
     #[prost(message, optional, tag="8")]
     pub options: ::std::option::Option<FieldOptions>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 pub mod field_descriptor_proto {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
@@ -196,6 +210,8 @@ pub struct OneofDescriptorProto {
     pub name: ::std::option::Option<String>,
     #[prost(message, optional, tag="2")]
     pub options: ::std::option::Option<OneofOptions>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// Describes an enum type.
 #[derive(Clone, PartialEq, Message)]
@@ -215,6 +231,8 @@ pub struct EnumDescriptorProto {
     /// be reserved once.
     #[prost(string, repeated, tag="5")]
     pub reserved_name: ::std::vec::Vec<String>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 pub mod enum_descriptor_proto {
     /// Range of reserved numeric values. Reserved values may not be used by
@@ -231,6 +249,8 @@ pub mod enum_descriptor_proto {
         /// Inclusive.
         #[prost(int32, optional, tag="2")]
         pub end: ::std::option::Option<i32>,
+        #[prost(unknown_field_set)]
+        pub unknown_fields: ::prost::UnknownFieldSet,
     }
 }
 /// Describes a value within an enum.
@@ -242,6 +262,8 @@ pub struct EnumValueDescriptorProto {
     pub number: ::std::option::Option<i32>,
     #[prost(message, optional, tag="3")]
     pub options: ::std::option::Option<EnumValueOptions>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// Describes a service.
 #[derive(Clone, PartialEq, Message)]
@@ -252,6 +274,8 @@ pub struct ServiceDescriptorProto {
     pub method: ::std::vec::Vec<MethodDescriptorProto>,
     #[prost(message, optional, tag="3")]
     pub options: ::std::option::Option<ServiceOptions>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// Describes a method of a service.
 #[derive(Clone, PartialEq, Message)]
@@ -272,6 +296,8 @@ pub struct MethodDescriptorProto {
     /// Identifies if server streams multiple server messages
     #[prost(bool, optional, tag="6", default="false")]
     pub server_streaming: ::std::option::Option<bool>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 // ===================================================================
 // Options
@@ -402,6 +428,8 @@ pub struct FileOptions {
     /// See the documentation for the "Options" section above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 pub mod file_options {
     /// Generated classes can be optimized for speed or code size.
@@ -476,6 +504,8 @@ pub struct MessageOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 #[derive(Clone, PartialEq, Message)]
 pub struct FieldOptions {
@@ -547,6 +577,8 @@ pub struct FieldOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 pub mod field_options {
     #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
@@ -571,6 +603,8 @@ pub struct OneofOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 #[derive(Clone, PartialEq, Message)]
 pub struct EnumOptions {
@@ -587,6 +621,8 @@ pub struct EnumOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 #[derive(Clone, PartialEq, Message)]
 pub struct EnumValueOptions {
@@ -599,6 +635,8 @@ pub struct EnumValueOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 #[derive(Clone, PartialEq, Message)]
 pub struct ServiceOptions {
@@ -616,6 +654,8 @@ pub struct ServiceOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 #[derive(Clone, PartialEq, Message)]
 pub struct MethodOptions {
@@ -635,6 +675,8 @@ pub struct MethodOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::std::vec::Vec<UninterpretedOption>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 pub mod method_options {
     /// Is this method side-effect-free (or safe in HTTP parlance), or idempotent,
@@ -673,6 +715,8 @@ pub struct UninterpretedOption {
     pub string_value: ::std::option::Option<Vec<u8>>,
     #[prost(string, optional, tag="8")]
     pub aggregate_value: ::std::option::Option<String>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 pub mod uninterpreted_option {
     /// The name of the uninterpreted option.  Each string represents a segment in
@@ -686,6 +730,8 @@ pub mod uninterpreted_option {
         pub name_part: String,
         #[prost(bool, required, tag="2")]
         pub is_extension: bool,
+        #[prost(unknown_field_set)]
+        pub unknown_fields: ::prost::UnknownFieldSet,
     }
 }
 // ===================================================================
@@ -740,6 +786,8 @@ pub struct SourceCodeInfo {
     ///   be recorded in the future.
     #[prost(message, repeated, tag="1")]
     pub location: ::std::vec::Vec<source_code_info::Location>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 pub mod source_code_info {
     #[derive(Clone, PartialEq, Message)]
@@ -829,6 +877,8 @@ pub mod source_code_info {
         pub trailing_comments: ::std::option::Option<String>,
         #[prost(string, repeated, tag="6")]
         pub leading_detached_comments: ::std::vec::Vec<String>,
+        #[prost(unknown_field_set)]
+        pub unknown_fields: ::prost::UnknownFieldSet,
     }
 }
 /// Describes the relationship between generated code and its original source
@@ -840,6 +890,8 @@ pub struct GeneratedCodeInfo {
     /// of its generating .proto file.
     #[prost(message, repeated, tag="1")]
     pub annotation: ::std::vec::Vec<generated_code_info::Annotation>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 pub mod generated_code_info {
     #[derive(Clone, PartialEq, Message)]
@@ -860,6 +912,8 @@ pub mod generated_code_info {
         /// the last relevant byte (so the length of the text = end - begin).
         #[prost(int32, optional, tag="4")]
         pub end: ::std::option::Option<i32>,
+        #[prost(unknown_field_set)]
+        pub unknown_fields: ::prost::UnknownFieldSet,
     }
 }
 /// `Any` contains an arbitrary serialized protocol buffer message along with a
@@ -971,6 +1025,8 @@ pub struct Any {
     /// Must be a valid serialized protocol buffer of the above specified type.
     #[prost(bytes, tag="2")]
     pub value: Vec<u8>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// `SourceContext` represents information about the source of a
 /// protobuf element, like the file in which it is defined.
@@ -980,6 +1036,8 @@ pub struct SourceContext {
     /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
     #[prost(string, tag="1")]
     pub file_name: String,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// A protocol buffer message type.
 #[derive(Clone, PartialEq, Message)]
@@ -1002,6 +1060,8 @@ pub struct Type {
     /// The source syntax.
     #[prost(enumeration="Syntax", tag="6")]
     pub syntax: i32,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// A single field of a message type.
 #[derive(Clone, PartialEq, Message)]
@@ -1038,6 +1098,8 @@ pub struct Field {
     /// The string value of the default value of this field. Proto2 syntax only.
     #[prost(string, tag="11")]
     pub default_value: String,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 pub mod field {
     /// Basic field types.
@@ -1113,6 +1175,8 @@ pub struct Enum {
     /// The source syntax.
     #[prost(enumeration="Syntax", tag="5")]
     pub syntax: i32,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// Enum value definition.
 #[derive(Clone, PartialEq, Message)]
@@ -1126,6 +1190,8 @@ pub struct EnumValue {
     /// Protocol buffer options.
     #[prost(message, repeated, tag="3")]
     pub options: ::std::vec::Vec<Option>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// A protocol buffer option, which can be attached to a message, field,
 /// enumeration, etc.
@@ -1143,6 +1209,8 @@ pub struct Option {
     /// value using the google.protobuf.Int32Value type.
     #[prost(message, optional, tag="2")]
     pub value: ::std::option::Option<Any>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// The syntax in which a protocol buffer element is defined.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Enumeration)]
@@ -1206,6 +1274,8 @@ pub struct Api {
     /// The source syntax of the service.
     #[prost(enumeration="Syntax", tag="7")]
     pub syntax: i32,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// Method represents a method of an API interface.
 #[derive(Clone, PartialEq, Message)]
@@ -1231,6 +1301,8 @@ pub struct Method {
     /// The source syntax of this method.
     #[prost(enumeration="Syntax", tag="7")]
     pub syntax: i32,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// Declares an API Interface to be included in this interface. The including
 /// interface must redeclare all the methods from the included interface, but
@@ -1319,6 +1391,8 @@ pub struct Mixin {
     /// are rooted.
     #[prost(string, tag="2")]
     pub root: String,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// A Duration represents a signed, fixed-length span of time represented
 /// as a count of seconds and fractions of seconds at nanosecond
@@ -1395,6 +1469,8 @@ pub struct Duration {
     /// to +999,999,999 inclusive.
     #[prost(int32, tag="2")]
     pub nanos: i32,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// `FieldMask` represents a set of symbolic field paths, for example:
 ///
@@ -1608,6 +1684,8 @@ pub struct FieldMask {
     /// The set of field mask paths.
     #[prost(string, repeated, tag="1")]
     pub paths: ::std::vec::Vec<String>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// `Struct` represents a structured data value, consisting of fields
 /// which map to dynamically typed values. In some languages, `Struct`
@@ -1622,6 +1700,8 @@ pub struct Struct {
     /// Unordered map of dynamically typed values.
     #[prost(btree_map="string, message", tag="1")]
     pub fields: ::std::collections::BTreeMap<String, Value>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// `Value` represents a dynamically typed value which can be either
 /// null, a number, a string, a boolean, a recursive struct value, or a
@@ -1634,6 +1714,8 @@ pub struct Value {
     /// The kind of value.
     #[prost(oneof="value::Kind", tags="1, 2, 3, 4, 5, 6")]
     pub kind: ::std::option::Option<value::Kind>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 pub mod value {
     /// The kind of value.
@@ -1667,6 +1749,8 @@ pub struct ListValue {
     /// Repeated field of dynamically typed values.
     #[prost(message, repeated, tag="1")]
     pub values: ::std::vec::Vec<Value>,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }
 /// `NullValue` is a singleton enumeration to represent the null value for the
 /// `Value` type union.
@@ -1768,4 +1852,6 @@ pub struct Timestamp {
     /// inclusive.
     #[prost(int32, tag="2")]
     pub nanos: i32,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,14 @@ extern crate quickcheck;
 mod error;
 mod message;
 mod types;
+mod unknown_field_set;
 
 #[doc(hidden)]
 pub mod encoding;
 
 pub use message::Message;
 pub use error::{DecodeError, EncodeError};
+pub use unknown_field_set::UnknownFieldSet;
 
 use bytes::{
     BufMut,

--- a/src/unknown_field_set.rs
+++ b/src/unknown_field_set.rs
@@ -1,5 +1,18 @@
 //! Runtime library code for storing unknown fields.
 
+use encoding::{
+    bytes,
+    decode_varint,
+    encode_key,
+    encode_varint,
+    fixed32,
+    fixed64,
+    uint64,
+    WireType,
+};
+use bytes::{ Buf, BufMut };
+use DecodeError;
+
 /// A set of Protobuf fields that were not recognized during decoding.
 ///
 /// Every Message struct should have an UnknownFieldSet member. This is how
@@ -15,17 +28,127 @@ pub struct UnknownFieldSet {
     data: Option<Box<Vec<UnknownField>>>,
 }
 
+impl UnknownFieldSet {
+    /// Adds a field to the UnknownFieldSet. Takes the tag, the wire type and
+    /// a buffer that points to where the field itself (excluding the key is).
+    ///
+    /// Mutates the provided buffer to point to after the unknown field ends.
+    #[doc(hidden)]  // Not for external use.
+    pub fn skip_unknown_field<B>(&mut self, tag: u32, wire_type: WireType, buf: &mut B)
+            -> Result<(), DecodeError>  where B : Buf {
+        self.push(UnknownField::parse(tag, wire_type, buf)?);
+        Ok(())
+    }
+
+    fn push(&mut self, field: UnknownField) {
+        match self.data {
+            Some(ref mut vec) => vec.push(field),
+            None => self.data = Some(Box::new(vec![field])),
+        }
+    }
+
+    #[doc(hidden)]  // Not for external use.
+    pub fn encode<B>(&self, buf: &mut B) where B : BufMut {
+        match self.data {
+            Some(ref vec) => {
+                for field in vec.iter() {
+                    field.encode(buf);
+                }
+            },
+            None => {},
+        }
+    }
+
+    #[doc(hidden)]  // Not for external use.
+    pub fn encoded_len(&self) -> usize {
+        match self.data {
+            Some(ref vec) =>
+                vec.iter().map(|ref field| field.encoded_len()).sum(),
+            None => 0,
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct UnknownField {
     tag: u32,
     data: UnknownFieldData,
 }
 
+impl UnknownField {
+    /// Parses an unknown field. Takes the tag, the wire type and a buffer that
+    /// points to where the field itself (excluding the key is). Returns the
+    /// parsed UnknownField.
+    fn parse<B>(tag: u32, wire_type: WireType, buf: &mut B)
+            -> Result<UnknownField, DecodeError> where B : Buf {
+        let data = match wire_type {
+            WireType::Varint =>
+                decode_varint(buf).map(|val| UnknownFieldData::Varint(val))?,
+            WireType::ThirtyTwoBit => {
+                if buf.remaining() < 4 {
+                    return Err(DecodeError::new("buffer underflow"));
+                }
+                UnknownFieldData::ThirtyTwoBit(buf.get_u32_le())
+            },
+            WireType::SixtyFourBit => {
+                if buf.remaining() < 8 {
+                    return Err(DecodeError::new("buffer underflow"));
+                }
+                UnknownFieldData::SixtyFourBit(buf.get_u64_le())
+            }
+            WireType::LengthDelimited => {
+                let mut field_buf = Vec::new();
+                ::encoding::bytes::merge(wire_type, &mut field_buf, buf)?;
+                UnknownFieldData::LengthDelimited(field_buf)
+            }
+        };
+        Ok(UnknownField{ tag, data })
+    }
+
+    fn encode<B>(&self, buf: &mut B) where B : BufMut {
+        match &self.data {
+            UnknownFieldData::Varint(value) => {
+                encode_key(self.tag, WireType::Varint, buf);
+                encode_varint(*value, buf);
+            },
+            UnknownFieldData::SixtyFourBit(value) => {
+                encode_key(self.tag, WireType::SixtyFourBit, buf);
+                buf.put_u64_le(*value);
+            },
+            UnknownFieldData::LengthDelimited(value) => {
+                encode_key(self.tag, WireType::LengthDelimited, buf);
+                encode_varint(value.len() as u64, buf);
+                buf.put_slice(value);
+            },
+            UnknownFieldData::ThirtyTwoBit(value) => {
+                encode_key(self.tag, WireType::ThirtyTwoBit, buf);
+                buf.put_u32_le(*value);
+            },
+        }
+    }
+
+    fn encoded_len(&self) -> usize {
+        match &self.data {
+            UnknownFieldData::Varint(value) => {
+                uint64::encoded_len(self.tag, value)
+            },
+            UnknownFieldData::SixtyFourBit(value) => {
+                fixed64::encoded_len(self.tag, value)
+            },
+            UnknownFieldData::LengthDelimited(value) => {
+                bytes::encoded_len(self.tag, value)
+            },
+            UnknownFieldData::ThirtyTwoBit(value) => {
+                fixed32::encoded_len(self.tag, value)
+            },
+        }
+    }
+}
+
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
 enum UnknownFieldData {
     Varint(u64),
     SixtyFourBit(u64),
-    LengthDelimited(u64),
-    Group(UnknownFieldSet),
+    LengthDelimited(Vec<u8>),
     ThirtyTwoBit(u32),
 }

--- a/src/unknown_field_set.rs
+++ b/src/unknown_field_set.rs
@@ -7,4 +7,25 @@
 /// which is required by the Protobuf spec.
 #[derive(Clone, Debug, PartialEq, Eq, Default, PartialOrd, Ord)]
 pub struct UnknownFieldSet {
+    // The actual data of this struct is wrapped in a Box to ensure that
+    // this struct uses only one machine word of memory unless there are
+    // unknown fields to store.
+    //
+    // If the Option is non-empty, the Vec is also non-empty.
+    data: Option<Box<Vec<UnknownField>>>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct UnknownField {
+    tag: u32,
+    data: UnknownFieldData,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum UnknownFieldData {
+    Varint(u64),
+    SixtyFourBit(u64),
+    LengthDelimited(u64),
+    Group(UnknownFieldSet),
+    ThirtyTwoBit(u32),
 }

--- a/src/unknown_field_set.rs
+++ b/src/unknown_field_set.rs
@@ -1,0 +1,10 @@
+//! Runtime library code for storing unknown fields.
+
+/// A set of Protobuf fields that were not recognized during decoding.
+///
+/// Every Message struct should have an UnknownFieldSet member. This is how
+/// messages make sure to not discard unknown data in a decode/encode cycle,
+/// which is required by the Protobuf spec.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub struct UnknownFieldSet {
+}

--- a/src/unknown_field_set.rs
+++ b/src/unknown_field_set.rs
@@ -5,6 +5,6 @@
 /// Every Message struct should have an UnknownFieldSet member. This is how
 /// messages make sure to not discard unknown data in a decode/encode cycle,
 /// which is required by the Protobuf spec.
-#[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, Default, PartialOrd, Ord)]
 pub struct UnknownFieldSet {
 }

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -59,4 +59,7 @@ fn main() {
 
     prost_build.compile_protos(&["src/default_trait.proto"],
                                &["src"]).unwrap();
+
+    prost_build.compile_protos(&["src/unknown_fields.proto"],
+                               &["src"]).unwrap();
 }

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -56,4 +56,7 @@ fn main() {
 
     prost_build.compile_protos(&["src/no_unused_results.proto"],
                                &["src"]).unwrap();
+
+    prost_build.compile_protos(&["src/default_trait.proto"],
+                               &["src"]).unwrap();
 }

--- a/tests/src/default_trait.proto
+++ b/tests/src/default_trait.proto
@@ -1,0 +1,17 @@
+syntax = "proto3";
+
+package default_trait;
+
+message AMessage {
+	int32 number = 1;
+
+	oneof field {
+		string oneof_a = 2;
+		bytes oneof_b = 3;
+	}
+}
+
+enum AnEnum {
+	A = 0;
+	B = 1;
+}

--- a/tests/src/default_trait.rs
+++ b/tests/src/default_trait.rs
@@ -2,18 +2,18 @@
 //! types.
 
 pub mod default_trait {
-	include!(concat!(env!("OUT_DIR"), "/default_trait.rs"));
+    include!(concat!(env!("OUT_DIR"), "/default_trait.rs"));
 }
 
 #[test]
 fn proto_message() {
-	let _msg : default_trait::AMessage = Default::default();
-	assert_eq!(_msg.number, 0);
-	assert_eq!(_msg.field, None);
+    let _msg : default_trait::AMessage = Default::default();
+    assert_eq!(_msg.number, 0);
+    assert_eq!(_msg.field, None);
 }
 
 #[test]
 fn proto_enum() {
-	let _enum : default_trait::AnEnum = Default::default();
-	assert_eq!(_enum, default_trait::AnEnum::A);
+    let _enum : default_trait::AnEnum = Default::default();
+    assert_eq!(_enum, default_trait::AnEnum::A);
 }

--- a/tests/src/default_trait.rs
+++ b/tests/src/default_trait.rs
@@ -1,0 +1,19 @@
+//! Unit tests that ensure that the Default trait can be used with the generated
+//! types.
+
+pub mod default_trait {
+	include!(concat!(env!("OUT_DIR"), "/default_trait.rs"));
+}
+
+#[test]
+fn proto_message() {
+	let _msg : default_trait::AMessage = Default::default();
+	assert_eq!(_msg.number, 0);
+	assert_eq!(_msg.field, None);
+}
+
+#[test]
+fn proto_enum() {
+	let _enum : default_trait::AnEnum = Default::default();
+	assert_eq!(_enum, default_trait::AnEnum::A);
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -227,9 +227,11 @@ mod tests {
                 foo::bar_baz::foo_bar_baz::FuzzBuster {
                     t: BTreeMap::<i32, foo::bar_baz::FooBarBaz>::new(),
                     nested_self: None,
+                    ..Default::default()
                 },
             ],
             p_i_e: 0,
+            ..Default::default()
         };
 
         // Test enum ident conversion.
@@ -267,6 +269,7 @@ mod tests {
             b: Some(Box::new(B::default())),
             repeated_b: Vec::<B>::new(),
             map_b: BTreeMap::<i32, B>::new(),
+            ..Default::default()
         };
     }
 
@@ -276,9 +279,12 @@ mod tests {
         let _ = A {
             kind: Some(a::Kind::B(Box::new(B {
                 a: Some(Box::new(A {
-                    kind: Some(a::Kind::C(C {}))
-                }))
-            })))
+                    kind: Some(a::Kind::C(C {..Default::default()})),
+                    ..Default::default()
+                })),
+                ..Default::default()
+            }))),
+            ..Default::default()
         };
     }
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -10,6 +10,7 @@ extern crate prost_types;
 pub mod packages;
 pub mod unittest;
 pub mod default_trait;
+pub mod unknown_fields;
 
 #[cfg(test)] mod bootstrap;
 #[cfg(test)] mod debug;

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -9,6 +9,7 @@ extern crate prost_types;
 
 pub mod packages;
 pub mod unittest;
+pub mod default_trait;
 
 #[cfg(test)] mod bootstrap;
 #[cfg(test)] mod debug;

--- a/tests/src/packages/mod.rs
+++ b/tests/src/packages/mod.rs
@@ -20,24 +20,30 @@ fn test() {
     let mut widget_factory = widget::factory::WidgetFactory::default();
     assert_eq!(0, widget_factory.encoded_len());
 
-    widget_factory.inner = Some(widget::factory::widget_factory::Inner {});
+    widget_factory.inner = Some(widget::factory::widget_factory::Inner {
+        ..Default::default()
+    });
     assert_eq!(2, widget_factory.encoded_len());
 
-    widget_factory.root = Some(Root {});
+    widget_factory.root = Some(Root {..Default::default()});
     assert_eq!(4, widget_factory.encoded_len());
 
-    widget_factory.root_inner = Some(root::Inner {});
+    widget_factory.root_inner = Some(root::Inner {..Default::default()});
     assert_eq!(6, widget_factory.encoded_len());
 
-    widget_factory.widget = Some(widget::Widget {});
+    widget_factory.widget = Some(widget::Widget {..Default::default()});
     assert_eq!(8, widget_factory.encoded_len());
 
-    widget_factory.widget_inner = Some(widget::widget::Inner {});
+    widget_factory.widget_inner = Some(widget::widget::Inner {
+        ..Default::default()
+    });
     assert_eq!(10, widget_factory.encoded_len());
 
-    widget_factory.gizmo = Some(gizmo::Gizmo {});
+    widget_factory.gizmo = Some(gizmo::Gizmo {..Default::default()});
     assert_eq!(12, widget_factory.encoded_len());
 
-    widget_factory.gizmo_inner = Some(gizmo::gizmo::Inner {});
+    widget_factory.gizmo_inner = Some(gizmo::gizmo::Inner {
+        ..Default::default()
+    });
     assert_eq!(14, widget_factory.encoded_len());
 }

--- a/tests/src/unknown_fields.proto
+++ b/tests/src/unknown_fields.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package unknown_fields;
+
+message MessageWithAllTypes {
+    int32 varint = 1000;
+    fixed64 sixty_four_bit = 1001;
+    string length_delimited = 1002;
+    fixed32 thirty_two_bit = 1003;
+}

--- a/tests/src/unknown_fields.rs
+++ b/tests/src/unknown_fields.rs
@@ -1,0 +1,11 @@
+#[derive(Clone, PartialEq, Message)]
+pub struct AMessage {
+    #[prost(string, tag="1")]
+    pub name: String,
+    #[prost(int32, tag="2")]
+    pub id: i32,
+    #[prost(string, tag="3")]
+    pub email: String,
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
+}

--- a/tests/src/unknown_fields.rs
+++ b/tests/src/unknown_fields.rs
@@ -1,11 +1,232 @@
+use prost::{
+    EncodeError,
+    Message
+};
+
+pub mod unknown_fields {
+    include!(concat!(env!("OUT_DIR"), "/unknown_fields.rs"));
+}
+
+// Verify that the derive macro supports unknown_field_set properly.
 #[derive(Clone, PartialEq, Message)]
-pub struct AMessage {
+pub struct EmptyMessage {
+    #[prost(unknown_field_set)]
+    pub unknown_fields: ::prost::UnknownFieldSet,
+}
+
+// Verify that the derive macro supports unknown_field_set properly.
+#[derive(Clone, PartialEq, Message)]
+pub struct NonstandardUnknownFieldSetName {
+    #[prost(unknown_field_set)]
+    pub intentionally_nonstandard_name: ::prost::UnknownFieldSet,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct Person {
+    #[prost(string, tag="1")]
+    pub name: String,
+    // UnknownFieldSet intentionally omitted.
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct PersonWithAge {
     #[prost(string, tag="1")]
     pub name: String,
     #[prost(int32, tag="2")]
-    pub id: i32,
-    #[prost(string, tag="3")]
-    pub email: String,
-    #[prost(unknown_field_set)]
-    pub unknown_fields: ::prost::UnknownFieldSet,
+    pub age: i32,
+    // UnknownFieldSet intentionally omitted.
+}
+
+fn encode<T>(msg: &T) -> Result<Vec<u8>, EncodeError> where T: Message {
+    let mut buf = Vec::new();
+    msg.encode(&mut buf)?;
+    Ok(buf)
+}
+
+#[test]
+fn unknown_fields_are_kept() {
+    let person_with_age = PersonWithAge { name:"Pwa".to_string(), age:12 };
+    let unrelated_message = unknown_fields::MessageWithAllTypes::decode(
+        encode(&person_with_age).unwrap()).unwrap();
+    let reparsed_person_with_age =
+        PersonWithAge::decode(encode(&unrelated_message).unwrap()).unwrap();
+
+    assert_eq!(reparsed_person_with_age.name, "Pwa");
+    assert_eq!(reparsed_person_with_age.age, 12);
+    assert_eq!(
+        reparsed_person_with_age.encoded_len(),
+        unrelated_message.encoded_len());
+}
+
+#[test]
+fn struct_without_unknown_field_set_discards_unknown_fields() {
+    // It should be possible to work with structs without an UnknownFieldSet.
+
+    let person_with_age = PersonWithAge { name:"Pwa".to_string(), age:12 };
+    let person = Person::decode(encode(&person_with_age).unwrap()).unwrap();
+    let reparsed_person_with_age =
+        PersonWithAge::decode(encode(&person).unwrap()).unwrap();
+
+    assert_eq!(reparsed_person_with_age.name, "Pwa");
+    assert_eq!(reparsed_person_with_age.age, 0);
+}
+
+#[test]
+fn unknown_fields_of_struct_with_nonstandard_set_name_are_kept() {
+    // It should be possible to call the unknown_field_set something else.
+
+    let person_with_age = PersonWithAge { name:"Pwa".to_string(), age:12 };
+    let unrelated_message = NonstandardUnknownFieldSetName::decode(
+        encode(&person_with_age).unwrap()).unwrap();
+    let reparsed_person_with_age =
+        PersonWithAge::decode(encode(&unrelated_message).unwrap()).unwrap();
+
+    assert_eq!(reparsed_person_with_age.name, "Pwa");
+    assert_eq!(reparsed_person_with_age.age, 12);
+    assert_eq!(
+        reparsed_person_with_age.encoded_len(),
+        unrelated_message.encoded_len());
+}
+
+#[test]
+fn overwrite_unknown_field_set_resets_unknown_fields() {
+    let person_with_age = PersonWithAge { name:"Pwa".to_string(), age:12 };
+
+    let mut unrelated_message = EmptyMessage::decode(
+        encode(&person_with_age).unwrap()).unwrap();
+    unrelated_message.unknown_fields = Default::default();
+
+    let reparsed_person_with_age =
+        PersonWithAge::decode(encode(&unrelated_message).unwrap()).unwrap();
+
+    assert_eq!(reparsed_person_with_age.name, "");
+    assert_eq!(reparsed_person_with_age.age, 0);
+}
+
+#[test]
+fn unknown_varint_fields_are_kept() {
+    let message = unknown_fields::MessageWithAllTypes {
+        varint: 1337,
+        ..Default::default()
+    };
+    let unrelated_message = EmptyMessage::decode(
+        encode(&message).unwrap()).unwrap();
+    let reparsed_message =
+        unknown_fields::MessageWithAllTypes::decode(
+            encode(&unrelated_message).unwrap()).unwrap();
+
+    assert_eq!(reparsed_message.varint, 1337);
+    assert_eq!(
+        reparsed_message.encoded_len(),
+        unrelated_message.unknown_fields.encoded_len());
+}
+
+#[test]
+fn unknown_fixed32_fields_are_kept() {
+    let message = unknown_fields::MessageWithAllTypes {
+        thirty_two_bit: 1337,
+        ..Default::default()
+    };
+    let unrelated_message = EmptyMessage::decode(
+        encode(&message).unwrap()).unwrap();
+    let reparsed_message =
+        unknown_fields::MessageWithAllTypes::decode(
+            encode(&unrelated_message).unwrap()).unwrap();
+
+    assert_eq!(reparsed_message.thirty_two_bit, 1337);
+    assert_eq!(
+        reparsed_message.encoded_len(),
+        unrelated_message.unknown_fields.encoded_len());
+}
+
+#[test]
+fn unknown_fixed64_fields_are_kept() {
+    let message = unknown_fields::MessageWithAllTypes {
+        sixty_four_bit: 1337,
+        ..Default::default()
+    };
+    let unrelated_message = EmptyMessage::decode(
+        encode(&message).unwrap()).unwrap();
+    let reparsed_message =
+        unknown_fields::MessageWithAllTypes::decode(
+            encode(&unrelated_message).unwrap()).unwrap();
+
+    assert_eq!(reparsed_message.sixty_four_bit, 1337);
+    assert_eq!(
+        reparsed_message.encoded_len(),
+        unrelated_message.unknown_fields.encoded_len());
+}
+
+#[test]
+fn unknown_length_delimited_fields_are_kept() {
+    let message = unknown_fields::MessageWithAllTypes {
+        length_delimited: "abc".to_string(),
+        ..Default::default()
+    };
+    let unrelated_message = EmptyMessage::decode(
+        encode(&message).unwrap()).unwrap();
+    let reparsed_message =
+        unknown_fields::MessageWithAllTypes::decode(
+            encode(&unrelated_message).unwrap()).unwrap();
+
+    assert_eq!(reparsed_message.length_delimited, "abc");
+    assert_eq!(
+        reparsed_message.encoded_len(),
+        unrelated_message.unknown_fields.encoded_len());
+}
+
+#[test]
+fn truncated_varint_fields_fail_to_parse() {
+    let message = unknown_fields::MessageWithAllTypes {
+        varint: 1337,
+        ..Default::default()
+    };
+    let mut buf = encode(&message).unwrap();
+    buf.pop();
+
+    let result = EmptyMessage::decode(buf);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn truncated_fixed32_fields_fail_to_parse() {
+    let message = unknown_fields::MessageWithAllTypes {
+        thirty_two_bit: 1337,
+        ..Default::default()
+    };
+    let mut buf = encode(&message).unwrap();
+    buf.pop();
+
+    let result = EmptyMessage::decode(buf);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn truncated_fixed64_fields_fail_to_parse() {
+    let message = unknown_fields::MessageWithAllTypes {
+        sixty_four_bit: 1337,
+        ..Default::default()
+    };
+    let mut buf = encode(&message).unwrap();
+    buf.pop();
+
+    let result = EmptyMessage::decode(buf);
+
+    assert!(result.is_err());
+}
+
+#[test]
+fn truncated_length_delimited_fields_fail_to_parse() {
+    let message = unknown_fields::MessageWithAllTypes {
+        length_delimited: "abc".to_string(),
+        ..Default::default()
+    };
+    let mut buf = encode(&message).unwrap();
+    buf.pop();
+
+    let result = EmptyMessage::decode(buf);
+
+    assert!(result.is_err());
 }


### PR DESCRIPTION
This is a work-in-progress PR for closing #2. I would appreciate a preliminary review of the approach before I spend more time trying to fix more corner casey things.

Remaining things to fix:

* [ ] Make the generation of the `unknown_fields` field of generated structs optional. Should it be on or off by default? I think it should be on by default, at least eventually because otherwise the library is non-conformant by default.
* [ ] Decide what to do with well-known types like BoolValue, UInt32Value etc. They are currently automatically converted to native types which are not able to store unknown fields. To me this auto-conversion seems unnecessary and it might make sense to turn this off by default.
* [ ] Decide what to do with the entry messages of maps; when they are stored as Rust maps they don't retain unknown fields. I think the options here are to have custom map types or to accept that unknown fields there will be discarded. I think for this case the convenience of native Rust maps might be better than keeping unknown fields in this particular case.
* [ ] Decide how to handle known fields of the wrong type. [Relevant ticket](https://github.com/google/proto-lens/issues/125).
* [ ] Decide how to handle oneof fields with more than one set field.
* [ ] Preserve groups (can probably be done in a later PR since it is not supported at all atm).
* [ ] Handle the case of proto messages with a field called `unknown_fields` (the generated field should get a different name then).
* [ ] Address TODOs in the code.
