### PR TITLE
Replace tempdir dependency with tempfile

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -19,7 +19,7 @@ multimap = { version = "0.4", default-features = false }
 petgraph = { version = "0.4", default-features = false }
 prost = { version = "0.4.0", path = ".." }
 prost-types = { version = "0.4.0", path = "../prost-types" }
-tempdir = "0.3"
+tempfile = "3"
 
 [build-dependencies]
 which = "2"

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -117,7 +117,7 @@ extern crate multimap;
 extern crate petgraph;
 extern crate prost;
 extern crate prost_types;
-extern crate tempdir;
+extern crate tempfile;
 
 #[macro_use]
 extern crate log;
@@ -534,7 +534,9 @@ impl Config {
         // this figured out.
         // [1]: http://doc.crates.io/build-script.html#outputs-of-the-build-script
 
-        let tmp = tempdir::TempDir::new("prost-build")?;
+        let tmp = tempfile::Builder::new()
+            .prefix("prost-build")
+            .tempdir()?;
         let descriptor_set = tmp.path().join("prost-descriptor-set");
 
         let mut cmd = Command::new(protoc());

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -16,4 +16,4 @@ curl = "0.4"
 flate2 = "1.0"
 prost-build = { path = "../prost-build" }
 tar = "0.4"
-tempdir = "0.3"
+tempfile = "3"

--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -2,7 +2,7 @@ extern crate curl;
 extern crate flate2;
 extern crate prost_build;
 extern crate tar;
-extern crate tempdir;
+extern crate tempfile;
 
 use std::env;
 use std::fs;
@@ -13,7 +13,6 @@ use std::process::Command;
 use curl::easy::Easy;
 use flate2::bufread::GzDecoder;
 use tar::Archive;
-use tempdir::TempDir;
 
 const VERSION: &'static str = "3.6.0.1";
 
@@ -49,8 +48,10 @@ fn main() {
     let protobuf_dir = &out_dir.join(format!("protobuf-{}", VERSION));
 
     if !protobuf_dir.exists() {
-        let tempdir = TempDir::new_in(out_dir, "protobuf")
-                              .expect("failed to create temporary directory");
+        let tempdir = tempfile::Builder::new()
+            .prefix("protobuf")
+            .tempdir_in(out_dir)
+            .expect("failed to create temporary directory");
 
         let src_dir = &download_protobuf(tempdir.path());
         let prefix_dir = &src_dir.join("prefix");

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -23,7 +23,7 @@ protobuf = { path = "../protobuf" }
 [dev-dependencies]
 diff = "0.1"
 prost-build = { path = "../prost-build" }
-tempdir = "0.3"
+tempfile = "3"
 
 [build-dependencies]
 env_logger = { version = "0.5", default-features = false }

--- a/tests/src/bootstrap.rs
+++ b/tests/src/bootstrap.rs
@@ -3,7 +3,7 @@ use std::io::Read;
 use std::io::Write;
 use std::path::Path;
 
-use tempdir;
+use tempfile;
 use prost_build;
 
 /// Test which bootstraps protobuf.rs and compiler.rs from the .proto definitions in the Protobuf
@@ -12,7 +12,10 @@ use prost_build;
 fn bootstrap() {
     let protobuf = Path::new(prost_build::protoc_include()).join("google").join("protobuf");
 
-    let tempdir = tempdir::TempDir::new("prost-types-bootstrap").unwrap();
+    let tempdir = tempfile::Builder::new()
+        .prefix("prost-types-bootstrap")
+        .tempdir()
+        .unwrap();
 
     let mut config = prost_build::Config::new();
     config.compile_well_known_types();

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -5,7 +5,7 @@ extern crate protobuf;
 
 #[macro_use] extern crate prost_derive;
 
-#[cfg(test)] extern crate tempdir;
+#[cfg(test)] extern crate tempfile;
 #[cfg(test)] extern crate prost_build;
 
 pub mod extern_paths;


### PR DESCRIPTION
`prost-build` currently depends on the the `tempdir` crate, which is
deprecated. Users of `tempdir` are encouraged to migrate to `tempfile`. 

This branch replaces all the uses of `tempdir` in PROST with `tempfile`.

Signed-off-by: Eliza Weisman <eliza@buoyant.io>