### PR TITLE
[WIP] wasm-bindgen support

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -19,9 +19,14 @@ petgraph = { version = "0.5", default-features = false }
 prost = { version = "0.6.1", path = "..", default-features = false }
 prost-types = { version = "0.6.1", path = "../prost-types", default-features = false }
 tempfile = "3"
+wasm-bindgen = { version = "0.2", optional = true }
 
 [build-dependencies]
 which = { version = "4", default-features = false }
 
 [dev-dependencies]
 env_logger = { version = "0.8", default-features = false }
+
+[features]
+default = []
+use-wasm-bindgen = []


### PR DESCRIPTION
Hey!

I am trying to add wasm-bindgen support and stumbled across several problems. This PR is still very wip.

- I don't know how to define a feature for a sub-crate for conditional compilation. See commented out cfg! code
- wasm-bindgen does not support pub vectors within structs, so I just removed the pub for them (see https://github.com/rustwasm/wasm-bindgen/issues/439)
- probably the biggest problem so far: oneof gets converted to enums holding data, which isn't supported by wasm-bindgen and it will probably take a lot of effort to support them within wasm-bindgen (see https://github.com/rustwasm/wasm-bindgen/issues/31). It might be easier to change code generation of proto files for oneofs instead