### PR TITLE
Implement a way to cast serde_json values into prost_types values.

### DIFF
--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -17,3 +17,4 @@ test = false
 [dependencies]
 bytes = "0.4.7"
 prost = { version = "0.5.0", path = ".." }
+serde_json = { version = "1.0", optional = true }

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -148,3 +148,33 @@ impl From<Timestamp> for Result<time::SystemTime, time::Duration> {
         }
     }
 }
+
+#[cfg(feature = "serde_json")]
+impl From<serde_json::Value> for Value {
+    fn from(value: serde_json::Value) -> Self {
+        match value {
+            serde_json::Value::Null => Self {
+                kind: Some(value::Kind::NullValue(0)),
+            },
+            serde_json::Value::Bool(b) => Self {
+                kind: Some(value::Kind::BoolValue(b)),
+            },
+            serde_json::Value::Number(n) => Value {
+                kind: Some(value::Kind::NumberValue(n.as_f64().unwrap())),
+            },
+            serde_json::Value::String(s) => Self {
+                kind: Some(value::Kind::StringValue(s)),
+            },
+            serde_json::Value::Array(a) => Self {
+                kind: Some(value::Kind::ListValue(ListValue {
+                    values: a.into_iter().map(|val| val.into()).collect(),
+                })),
+            },
+            serde_json::Value::Object(map) => Self {
+                kind: Some(value::Kind::StructValue(Struct {
+                    fields: map.into_iter().map(|(k, v)| (k, v.into())).collect(),
+                })),
+            },
+        }
+    }
+}


### PR DESCRIPTION
I'm loading jsonb values from the database as serde_json values. Then I'm trying to cast these into google.protobuf.Struct to send down the wire. Via a `From` implementation, these values can be cross-cast easily.