### PR TITLE
Expose FileDescriptorSet to ServiceGenerator

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -44,6 +44,7 @@ impl<'a> CodeGenerator<'a> {
         message_graph: &MessageGraph,
         extern_paths: &ExternPaths,
         file: FileDescriptorProto,
+        descriptor_set: &Vec<FileDescriptorProto>,
         buf: &mut String,
     ) {
         let mut source_info = file
@@ -101,7 +102,7 @@ impl<'a> CodeGenerator<'a> {
             code_gen.path.push(6);
             for (idx, service) in file.service.into_iter().enumerate() {
                 code_gen.path.push(idx as i32);
-                code_gen.push_service(service);
+                code_gen.push_service(service, descriptor_set);
                 code_gen.path.pop();
             }
 
@@ -111,7 +112,7 @@ impl<'a> CodeGenerator<'a> {
                 .service_generator
                 .as_mut()
                 .map(|service_generator| {
-                    service_generator.finalize(buf);
+                    service_generator.finalize(&descriptor_set, buf);
                 });
 
             code_gen.path.pop();
@@ -627,7 +628,7 @@ impl<'a> CodeGenerator<'a> {
         self.buf.push_str(",\n");
     }
 
-    fn push_service(&mut self, service: ServiceDescriptorProto) {
+    fn push_service(&mut self, service: ServiceDescriptorProto, descriptor_set: &Vec<FileDescriptorProto>) {
         let name = service.name().to_owned();
         debug!("  service: {:?}", name);
 
@@ -681,7 +682,7 @@ impl<'a> CodeGenerator<'a> {
         self.config
             .service_generator
             .as_mut()
-            .map(move |service_generator| service_generator.generate(service, buf));
+            .map(move |service_generator| service_generator.generate(service,  descriptor_set, buf));
     }
 
     fn push_indent(&mut self) {


### PR DESCRIPTION
More or less what the title says. I ran into an issue where I needed more information about the types being used by RPC services when generating service code (besides just the proto name and rust name) -- but changing the Service and Method types would add a lot of complication and potentially break existing ServiceGenerator code. So as a bit of an escape hatch I added the protoc output as a param to `generate` and `finalize`.

More specifically, we use some custom proto3 options to control what kind of code is generated, some of which is influenced by the actual proto types being sent in and out. In those cases, I actually need the protoc output to be able to introspect the value of those options (which is accomplished using a patched `proto-types` crate).

I have another PR in the pipeline (making proto-types "self hosted", allowing direct access to proto3 extensions to inbuilt protoc types) which may make the usefulness of this PR way more apparent.