### PR TITLE
Added Config::field_visibility

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -19,6 +19,7 @@ use crate::extern_paths::ExternPaths;
 use crate::ident::{match_ident, to_snake, to_upper_camel};
 use crate::message_graph::MessageGraph;
 use crate::Config;
+use crate::Visibility;
 
 #[derive(PartialEq)]
 enum Syntax {
@@ -388,7 +389,11 @@ impl<'a> CodeGenerator<'a> {
         self.buf.push_str("\")]\n");
         self.append_field_attributes(msg_name, field.name());
         self.push_indent();
-        self.buf.push_str("pub ");
+        let pub_modifier = match self.get_field_visibility(msg_name, field.name()) {
+            Visibility::Public => "pub ",
+            Visibility::Private => "",
+        };
+        self.buf.push_str(pub_modifier);
         self.buf.push_str(&to_snake(field.name()));
         self.buf.push_str(": ");
         if repeated {
@@ -452,8 +457,13 @@ impl<'a> CodeGenerator<'a> {
         ));
         self.append_field_attributes(msg_name, field.name());
         self.push_indent();
+        let pub_modifier = match self.get_field_visibility(msg_name, field.name()) {
+            Visibility::Public => "pub",
+            Visibility::Private => "",
+        };
         self.buf.push_str(&format!(
-            "pub {}: {}::{}<{}, {}>,\n",
+            "{} {}: {}::{}<{}, {}>,\n",
+            pub_modifier,
             to_snake(field.name()),
             lib_name,
             rust_ty,
@@ -486,8 +496,13 @@ impl<'a> CodeGenerator<'a> {
         ));
         self.append_field_attributes(fq_message_name, oneof.name());
         self.push_indent();
+        let pub_modifier = match self.get_field_visibility(fq_message_name, oneof.name()) {
+            Visibility::Public => "pub",
+            Visibility::Private => "",
+        };
         self.buf.push_str(&format!(
-            "pub {}: ::core::option::Option<{}>,\n",
+            "{} {}: ::core::option::Option<{}>,\n",
+            pub_modifier,
             to_snake(oneof.name()),
             name
         ));
@@ -512,7 +527,11 @@ impl<'a> CodeGenerator<'a> {
         self.buf
             .push_str("#[derive(Clone, PartialEq, ::prost::Oneof)]\n");
         self.push_indent();
-        self.buf.push_str("pub enum ");
+        let pub_and_enum = match self.get_field_visibility(msg_name, oneof.name()) {
+            Visibility::Public => "pub enum ",
+            Visibility::Private => "enum ",
+        };
+        self.buf.push_str(pub_and_enum);
         self.buf.push_str(&to_upper_camel(oneof.name()));
         self.buf.push_str(" {\n");
 
@@ -599,7 +618,11 @@ impl<'a> CodeGenerator<'a> {
         self.push_indent();
         self.buf.push_str("#[repr(i32)]\n");
         self.push_indent();
-        self.buf.push_str("pub enum ");
+        let pub_and_name = match self.get_field_visibility(&fq_enum_name, desc.name()) {
+            Visibility::Public => "pub enum ",
+            Visibility::Private => "enum ",
+        };
+        self.buf.push_str(pub_and_name);
         self.buf.push_str(&to_upper_camel(desc.name()));
         self.buf.push_str(" {\n");
 
@@ -853,6 +876,17 @@ impl<'a> CodeGenerator<'a> {
             .options
             .as_ref()
             .map_or(false, FieldOptions::deprecated)
+    }
+
+    fn get_field_visibility(&mut self, msg_name: &str, field_name: &str) -> Visibility {
+        assert_eq!(b'.', msg_name.as_bytes()[0]);
+        // TODO: this clone is dirty, but expedious.
+        for (matcher, visibility) in self.config.field_visibilities.clone() {
+            if match_ident(&matcher, msg_name, Some(field_name)) {
+                return visibility;
+            }
+        }
+        Visibility::Public
     }
 }
 


### PR DESCRIPTION
Some programs may want some fields coming from a Protobuf not to be `pub`, e.g. in case they want to provide their own getters, that add some logic or value-checking from the raw Protobuf value.

This PR provides a `field_visibility` function for this purpose.

Note that i have only properly tested this commit on the 0.6.1 release (it looks like my test program is not yet compatible with the "master" version of prost-build). Please tell me in case you need me to test it more thoroughly.