### PR TITLE
prost-build lib.rs: Minor doc comment edits

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -36,14 +36,14 @@
 //!
 //! // A snazzy new shirt!
 //! message Shirt {
-//! enum Size {
-//!     SMALL = 0;
-//!     MEDIUM = 1;
-//!     LARGE = 2;
-//! }
+//!     enum Size {
+//!         SMALL = 0;
+//!         MEDIUM = 1;
+//!         LARGE = 2;
+//!     }
 //!
-//! string color = 1;
-//! Size size = 2;
+//!     string color = 1;
+//!     Size size = 2;
 //! }
 //! ```
 //!
@@ -51,8 +51,7 @@
 //! `build.rs` build-script:
 //!
 //! ```rust,no_run
-//! # use std::io::Result;
-//! fn main() -> Result<()> {
+//! fn main() -> Result<(), std::io::Error> {
 //!   prost_build::compile_protos(&["src/items.proto"], &["src/"])?;
 //!   Ok(())
 //! }


### PR DESCRIPTION
Fix the indentation of the example .proto file. Fix build.rs compile error.
Fixes:

error[E0107]: wrong number of type arguments: expected 2, found 1


Feel free to reject this, I am extremely new to Rust so maybe I'm not understanding something. I'm trying to fix the documentation on crates.io here: https://docs.rs/prost-build/0.7.0/prost_build/