### PR TITLE
Extended field/type attributes

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -253,9 +253,11 @@ impl<'a> CodeGenerator<'a> {
         assert_eq!(b'.', fq_message_name.as_bytes()[0]);
         // TODO: this clone is dirty, but expedious.
         if let Some(attributes) = self.config.type_attributes.get(fq_message_name).cloned() {
-            self.push_indent();
-            self.buf.push_str(&attributes);
-            self.buf.push('\n');
+            for attribute in attributes.borrow().iter() {
+                self.push_indent();
+                self.buf.push_str(&attribute);
+                self.buf.push('\n');
+            }
         }
     }
 
@@ -268,9 +270,11 @@ impl<'a> CodeGenerator<'a> {
             .get_field(fq_message_name, field_name)
             .cloned()
         {
-            self.push_indent();
-            self.buf.push_str(&attributes);
-            self.buf.push('\n');
+            for attribute in attributes.borrow().iter() {
+                self.push_indent();
+                self.buf.push_str(&attribute);
+                self.buf.push('\n');
+            }
         }
     }
 

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -116,6 +116,7 @@ mod ident;
 mod message_graph;
 mod path;
 
+use std::cell::RefCell;
 use std::collections::HashMap;
 use std::default;
 use std::env;
@@ -224,8 +225,8 @@ pub struct Config {
     service_generator: Option<Box<dyn ServiceGenerator>>,
     map_type: PathMap<MapType>,
     bytes_type: PathMap<BytesType>,
-    type_attributes: PathMap<String>,
-    field_attributes: PathMap<String>,
+    type_attributes: PathMap<RefCell<String>>,
+    field_attributes: PathMap<RefCell<String>>,
     prost_types: bool,
     strip_enum_prefix: bool,
     out_dir: Option<PathBuf>,
@@ -390,8 +391,11 @@ impl Config {
         P: AsRef<str>,
         A: AsRef<str>,
     {
-        self.field_attributes
-            .insert(path.as_ref().to_string(), attribute.as_ref().to_string());
+        match self.field_attributes.get(path.as_ref()) {
+            Some(attributes) => attributes.borrow_mut().push(attribute.as_ref().to_string()),
+            None => self.field_attributes.insert(path.as_ref().to_string(), RefCell::new(attribute.as_ref().to_string())),
+        }
+
         self
     }
 
@@ -439,8 +443,11 @@ impl Config {
         P: AsRef<str>,
         A: AsRef<str>,
     {
-        self.type_attributes
-            .insert(path.as_ref().to_string(), attribute.as_ref().to_string());
+        match self.type_attributes.get(path.as_ref()) {
+            Some(attributes) => attributes.borrow_mut().push(attribute.as_ref().to_string()),
+            None => self.type_attributes.insert(path.as_ref().to_string(), RefCell::new(attribute.as_ref().to_string())),
+        }
+
         self
     }
 

--- a/prost-build/src/path.rs
+++ b/prost-build/src/path.rs
@@ -4,9 +4,17 @@ use std::collections::HashMap;
 use std::iter;
 
 /// Maps a fully-qualified Protobuf path to a value using path matchers.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct PathMap<T> {
     matchers: HashMap<String, T>,
+}
+
+impl<T> Default for PathMap<T> {
+    fn default() -> Self {
+        Self {
+            matchers: HashMap::new(),
+        }
+    }
 }
 
 impl<T> PathMap<T> {


### PR DESCRIPTION
I wanted to have the ability to serialize a protobuf document with serde while using the protobuf field ids as keys.

As an example, a message based on the following protobuf definition
```proto
message test {
    int32 int_field = 1;
    string string_field = 2;
}
```

should be serialized as
```json
{
    "1": 123,
    "2": "asd"
}
```

To allow for this, I would need access to the field id when adding a new field/type attribute. In this Pull Request I've created one possible implementation of this. While working on this, I noticed that 79f0dfd seems to have removed/broken the ability to add multiple attributes to a single field/type.

EDIT:

I've not yet added any tests or documentation because I would first like to get some feedback, of whether the way I've implemented this is acceptable or if this should be implemented another way.