### PR TITLE
Remove path type generic for better ergonomic

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -698,10 +698,11 @@ impl Config {
     ///   Ok(())
     /// }
     /// ```
-    pub fn compile_protos<P>(&mut self, protos: &[P], includes: &[P]) -> Result<()>
-    where
-        P: AsRef<Path>,
-    {
+    pub fn compile_protos(
+        &mut self,
+        protos: &[impl AsRef<Path>],
+        includes: &[impl AsRef<Path>],
+    ) -> Result<()> {
         let target: PathBuf = self.out_dir.clone().map(Ok).unwrap_or_else(|| {
             env::var_os("OUT_DIR")
                 .ok_or_else(|| {
@@ -915,10 +916,7 @@ impl fmt::Debug for Config {
 /// [2]: http://doc.crates.io/build-script.html#case-study-code-generation
 /// [3]: https://developers.google.com/protocol-buffers/docs/proto3#importing-definitions
 /// [4]: https://developers.google.com/protocol-buffers/docs/proto#packages
-pub fn compile_protos<P>(protos: &[P], includes: &[P]) -> Result<()>
-where
-    P: AsRef<Path>,
-{
+pub fn compile_protos(protos: &[impl AsRef<Path>], includes: &[impl AsRef<Path>]) -> Result<()> {
     Config::new().compile_protos(protos, includes)
 }
 

--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -67,8 +67,7 @@ fn main() -> Result<()> {
             .iter()
             .map(|proto| datasets_include_dir.join(proto)),
     );
-    prost_build::compile_protos(&benchmark_protos, &[benchmarks_include_dir.to_path_buf()])
-        .unwrap();
+    prost_build::compile_protos(&benchmark_protos, &[benchmarks_include_dir]).unwrap();
 
     let conformance_include_dir = include_dir.join("conformance");
     prost_build::compile_protos(
@@ -91,7 +90,7 @@ fn main() -> Result<()> {
                 test_includes.join("test_messages_proto3.proto"),
                 test_includes.join("unittest.proto"),
             ],
-            &[include_dir.to_path_buf()],
+            &[include_dir],
         )
         .unwrap();
 

--- a/tests/src/bootstrap.rs
+++ b/tests/src/bootstrap.rs
@@ -40,7 +40,7 @@ fn bootstrap() {
                 protobuf.join("timestamp.proto"),
                 protobuf.join("type.proto"),
             ],
-            &[],
+            &[""],
         )
         .unwrap();
 


### PR DESCRIPTION
This could be especially useful when one parameter (e.g. `protos`) is dynamically collected while the other (`includes`) is statically defined. Splitting the type should make `compile_protos` easier to use, I also changed a few instances where type conversion was used to show the impact.