### PR TITLE
[prost-type] Impl `Hash + Eq` traits on `Timestamp`.

### DIFF
--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -165,18 +165,19 @@ impl Timestamp {
     }
 }
 
+/// Implements the unstable/naive version of `Eq`: a basic equality check on the internal fields of the `Timestamp`.
+/// This implies that `normalized_ts != non_normalized_ts` even if `normalized_ts == non_normalized_ts.normalized()`.
 #[cfg(feature = "std")]
+impl Eq for Timestamp {}
+
+#[cfg(feature = "std")]
+#[allow(clippy::derive_hash_xor_eq)] // Derived logic is correct: comparing the 2 feilds for equality
 impl std::hash::Hash for Timestamp {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.seconds.hash(state);
         self.nanos.hash(state);
     }
 }
-
-/// Implements the unstable/naive version of `Eq`: a basic equality check on the internal fields of the `Timestamp`.
-/// This implies that `normalized_ts != non_normalized_ts` even if `normalized_ts == non_normalized_ts.normalized()`.
-#[cfg(feature = "std")]
-impl Eq for Timestamp {}
 
 #[cfg(feature = "std")]
 impl From<std::time::SystemTime> for Timestamp {

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -166,6 +166,19 @@ impl Timestamp {
 }
 
 #[cfg(feature = "std")]
+impl std::hash::Hash for Timestamp {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.seconds.hash(state);
+        self.nanos.hash(state);
+    }
+}
+
+/// Implements the unstable/naive version of `Eq`: a basic equality check on the internal fields of the `Timestamp`.
+/// This implies that `normalized_ts != non_normalized_ts` even if `normalized_ts == non_normalized_ts.normalized()`.
+#[cfg(feature = "std")]
+impl Eq for Timestamp {}
+
+#[cfg(feature = "std")]
 impl From<std::time::SystemTime> for Timestamp {
     fn from(system_time: std::time::SystemTime) -> Timestamp {
         let (seconds, nanos) = match system_time.duration_since(std::time::UNIX_EPOCH) {

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -1828,7 +1828,7 @@ pub enum NullValue {
 /// ) to obtain a formatter capable of generating timestamps in this format.
 ///
 ///
-#[derive(Clone, Hash, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Timestamp {
     /// Represents seconds of UTC time since Unix epoch
     /// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -1828,7 +1828,7 @@ pub enum NullValue {
 /// ) to obtain a formatter capable of generating timestamps in this format.
 ///
 ///
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Hash, PartialEq, ::prost::Message)]
 pub struct Timestamp {
     /// Represents seconds of UTC time since Unix epoch
     /// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to

--- a/tests/src/well_known_types.rs
+++ b/tests/src/well_known_types.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 include!(concat!(env!("OUT_DIR"), "/well_known_types.rs"));
 
 #[test]
@@ -24,8 +22,11 @@ fn test_well_known_types() {
     crate::check_message(&msg);
 }
 
+#[cfg(feature = "std")]
 #[test]
 fn test_timestamp() {
+    use std::collections::HashSet;
+
     let timestamp = ::prost_types::Timestamp {
         seconds: 100,
         nanos: 42,
@@ -37,10 +38,9 @@ fn test_timestamp() {
     };
 
     let mut hashset = HashSet::new();
-    assert_eq!(hashset.insert(timestamp.clone()), true);
-    assert_eq!(
+    assert!(hashset.insert(timestamp.clone()));
+    assert!(
         hashset.insert(non_normalized_timestamp.clone()),
-        true,
         "hash for non-normalized different and should be inserted"
     );
 
@@ -52,5 +52,12 @@ fn test_timestamp() {
     assert_eq!(
         timestamp, non_normalized_timestamp,
         "normalized timestamp matches"
+    );
+
+    let mut hashset = HashSet::new();
+    assert!(hashset.insert(timestamp.clone()));
+    assert!(
+        !hashset.insert(non_normalized_timestamp),
+        "hash for normalized should match and not inserted"
     );
 }

--- a/tests/src/well_known_types.rs
+++ b/tests/src/well_known_types.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 include!(concat!(env!("OUT_DIR"), "/well_known_types.rs"));
 
 #[test]
@@ -20,4 +22,35 @@ fn test_well_known_types() {
     };
 
     crate::check_message(&msg);
+}
+
+#[test]
+fn test_timestamp() {
+    let timestamp = ::prost_types::Timestamp {
+        seconds: 100,
+        nanos: 42,
+    };
+
+    let mut non_normalized_timestamp = ::prost_types::Timestamp {
+        seconds: 99,
+        nanos: 1_000_000_042,
+    };
+
+    let mut hashset = HashSet::new();
+    assert_eq!(hashset.insert(timestamp.clone()), true);
+    assert_eq!(
+        hashset.insert(non_normalized_timestamp.clone()),
+        true,
+        "hash for non-normalized different and should be inserted"
+    );
+
+    assert_ne!(
+        timestamp, non_normalized_timestamp,
+        "non-nomarlized timestamp considered different"
+    );
+    non_normalized_timestamp.normalize();
+    assert_eq!(
+        timestamp, non_normalized_timestamp,
+        "normalized timestamp matches"
+    );
 }


### PR DESCRIPTION
Implement `Hash` and an unstable/naive version of `Eq` for `Timestamp

## Eq
A basic equality check on the internal fields of the `Timestamp`.
This implies that `normalized_ts != non_normalized_ts` even if `normalized_ts == non_normalized_ts.normalized()`.

This is acceptable to as timestamps across the network are already unstable.

The edge case is when the `Timestamp` is not normalized yet and would have mutated during the `normalize()` call.

- [x] add tests