### PR TITLE
Clarify docs for includes arg

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -888,7 +888,7 @@ impl fmt::Debug for Config {
 ///
 /// **`includes`** - Paths to directories in which to search for imports. Directories are searched
 /// in order. The `.proto` files passed in **`protos`** must be found in one of the provided
-/// include directories.
+/// include directories. Directories are *not* searched recursively.
 ///
 /// # Errors
 ///


### PR DESCRIPTION
I spent a lot of time confused by why prost wasn't finding my .proto import files. Turns out I had falsely assumed that imports were searched recursively. This is definitely my bad, I'm very new to protobuf, but I think it would help other new users to clarify this.