### PR TITLE
Fix escape for default string

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -371,10 +371,7 @@ impl<'a> CodeGenerator<'a> {
                 };
                 self.buf.push_str(stripped_prefix);
             } else {
-                // TODO: this is only correct if the Protobuf escaping matches Rust escaping. To be
-                // safer, we should unescape the Protobuf string and re-escape it with the Rust
-                // escaping mechanisms.
-                self.buf.push_str(default);
+                self.buf.push_str(&default.escape_default().to_string());
             }
         }
 

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -86,6 +86,10 @@ fn main() {
         .compile_protos(&[src.join("deprecated_field.proto")], includes)
         .unwrap();
 
+    config
+        .compile_protos(&[src.join("default_string_escape.proto")], includes)
+        .unwrap();
+
     prost_build::Config::new()
         .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(&[src.join("proto3_presence.proto")], includes)

--- a/tests/src/default_string_escape.proto
+++ b/tests/src/default_string_escape.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+
+package default_string_escape;
+
+message Person {
+    required string name = 1 [default = "[\"unknown\"]"];
+    required string age = 2;
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -101,6 +101,10 @@ pub mod invalid {
     }
 }
 
+pub mod default_string_escape {
+    include!(concat!(env!("OUT_DIR"), "/default_string_escape.rs"));
+}
+
 use alloc::format;
 use alloc::vec::Vec;
 
@@ -523,6 +527,12 @@ mod tests {
             msg.privacy_level_4(),
             default_enum_value::PrivacyLevel::PrivacyLevelprivacyLevelFour
         );
+    }
+
+    #[test]
+    fn test_default_string_escape() {
+        let msg = default_string_escape::Person::default();
+        assert_eq!(msg.name, r#"["unknown"]"#);
     }
 
     #[test]


### PR DESCRIPTION
The `default` is already unescaped.