### PR TITLE
Improve encode_var/decode_varint performance

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -30,7 +30,7 @@ where
     loop {
         if value < 0x80 {
             buf.put_u8(value as u8);
-            break
+            break;
         } else {
             buf.put_u8(((value & 0x7F) | 0x80) as u8);
             value >>= 7;

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -27,40 +27,19 @@ pub fn encode_varint<B>(mut value: u64, buf: &mut B)
 where
     B: BufMut,
 {
-    // Safety notes:
-    //
-    // - ptr::write is an unsafe raw pointer write. The use here is safe since the length of the
-    //   uninit slice is checked.
-    // - advance_mut is unsafe because it could cause uninitialized memory to be advanced over. The
-    //   use here is safe since each byte which is advanced over has been written to in the
-    //   previous loop iteration.
-    unsafe {
-        let mut i;
-        'outer: loop {
-            i = 0;
-
-            let uninit_slice = buf.chunk_mut();
-            for offset in 0..uninit_slice.len() {
-                i += 1;
-                let ptr = uninit_slice.as_mut_ptr().add(offset);
-                if value < 0x80 {
-                    ptr.write(value as u8);
-                    break 'outer;
-                } else {
-                    ptr.write(((value & 0x7F) | 0x80) as u8);
-                    value >>= 7;
-                }
-            }
-
-            buf.advance_mut(i);
-            debug_assert!(buf.has_remaining_mut());
+    loop {
+        if value < 0x80 {
+            buf.put_u8(value as u8);
+            break
+        } else {
+            buf.put_u8(((value & 0x7F) | 0x80) as u8);
+            value >>= 7;
         }
-
-        buf.advance_mut(i);
     }
 }
 
 /// Decodes a LEB128-encoded variable length integer from the buffer.
+#[inline]
 pub fn decode_varint<B>(buf: &mut B) -> Result<u64, DecodeError>
 where
     B: Buf,
@@ -71,12 +50,12 @@ where
         return Err(DecodeError::new("invalid varint"));
     }
 
-    let byte = unsafe { *bytes.get_unchecked(0) };
+    let byte = bytes[0];
     if byte < 0x80 {
         buf.advance(1);
         Ok(u64::from(byte))
     } else if len > 10 || bytes[len - 1] < 0x80 {
-        let (value, advance) = unsafe { decode_varint_slice(bytes) }?;
+        let (value, advance) = decode_varint_slice(bytes)?;
         buf.advance(advance);
         Ok(value)
     } else {
@@ -96,30 +75,34 @@ where
 ///
 /// [1]: https://github.com/google/protobuf/blob/3.3.x/src/google/protobuf/io/coded_stream.cc#L365-L406
 #[inline]
-unsafe fn decode_varint_slice(bytes: &[u8]) -> Result<(u64, usize), DecodeError> {
+fn decode_varint_slice(bytes: &[u8]) -> Result<(u64, usize), DecodeError> {
     // Fully unrolled varint decoding loop. Splitting into 32-bit pieces gives better performance.
+
+    // Use assertions to ensure memory safety, but it should always be optimized after inline.
+    assert!(!bytes.is_empty());
+    assert!(bytes.len() > 10 || bytes[bytes.len() - 1] < 0x80);
 
     let mut b: u8;
     let mut part0: u32;
-    b = *bytes.get_unchecked(0);
+    b = unsafe { *bytes.get_unchecked(0) };
     part0 = u32::from(b);
     if b < 0x80 {
         return Ok((u64::from(part0), 1));
     };
     part0 -= 0x80;
-    b = *bytes.get_unchecked(1);
+    b = unsafe { *bytes.get_unchecked(1) };
     part0 += u32::from(b) << 7;
     if b < 0x80 {
         return Ok((u64::from(part0), 2));
     };
     part0 -= 0x80 << 7;
-    b = *bytes.get_unchecked(2);
+    b = unsafe { *bytes.get_unchecked(2) };
     part0 += u32::from(b) << 14;
     if b < 0x80 {
         return Ok((u64::from(part0), 3));
     };
     part0 -= 0x80 << 14;
-    b = *bytes.get_unchecked(3);
+    b = unsafe { *bytes.get_unchecked(3) };
     part0 += u32::from(b) << 21;
     if b < 0x80 {
         return Ok((u64::from(part0), 4));
@@ -128,25 +111,25 @@ unsafe fn decode_varint_slice(bytes: &[u8]) -> Result<(u64, usize), DecodeError>
     let value = u64::from(part0);
 
     let mut part1: u32;
-    b = *bytes.get_unchecked(4);
+    b = unsafe { *bytes.get_unchecked(4) };
     part1 = u32::from(b);
     if b < 0x80 {
         return Ok((value + (u64::from(part1) << 28), 5));
     };
     part1 -= 0x80;
-    b = *bytes.get_unchecked(5);
+    b = unsafe { *bytes.get_unchecked(5) };
     part1 += u32::from(b) << 7;
     if b < 0x80 {
         return Ok((value + (u64::from(part1) << 28), 6));
     };
     part1 -= 0x80 << 7;
-    b = *bytes.get_unchecked(6);
+    b = unsafe { *bytes.get_unchecked(6) };
     part1 += u32::from(b) << 14;
     if b < 0x80 {
         return Ok((value + (u64::from(part1) << 28), 7));
     };
     part1 -= 0x80 << 14;
-    b = *bytes.get_unchecked(7);
+    b = unsafe { *bytes.get_unchecked(7) };
     part1 += u32::from(b) << 21;
     if b < 0x80 {
         return Ok((value + (u64::from(part1) << 28), 8));
@@ -155,13 +138,13 @@ unsafe fn decode_varint_slice(bytes: &[u8]) -> Result<(u64, usize), DecodeError>
     let value = value + ((u64::from(part1)) << 28);
 
     let mut part2: u32;
-    b = *bytes.get_unchecked(8);
+    b = unsafe { *bytes.get_unchecked(8) };
     part2 = u32::from(b);
     if b < 0x80 {
         return Ok((value + (u64::from(part2) << 56), 9));
     };
     part2 -= 0x80;
-    b = *bytes.get_unchecked(9);
+    b = unsafe { *bytes.get_unchecked(9) };
     part2 += u32::from(b) << 7;
     if b < 0x80 {
         return Ok((value + (u64::from(part2) << 56), 10));
@@ -174,6 +157,7 @@ unsafe fn decode_varint_slice(bytes: &[u8]) -> Result<(u64, usize), DecodeError>
 /// Decodes a LEB128-encoded variable length integer from the buffer, advancing the buffer as
 /// necessary.
 #[inline(never)]
+#[cold]
 fn decode_varint_slow<B>(buf: &mut B) -> Result<u64, DecodeError>
 where
     B: Buf,


### PR DESCRIPTION
* using `put_u8` simplifies the `encode_varint` code. this slightly changed behavior, but it should have no effect on prost. It improve performance while reducing unsafe code.
* inline `decode_varint` and remove some unnecessary unsafe.

bench
```
varint/small/encode     time:   [214.82 ns 214.91 ns 215.00 ns]
                        change: [-69.573% -69.350% -69.126%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  4 (4.00%) low mild
  3 (3.00%) high mild
  8 (8.00%) high severe

varint/small/decode     time:   [231.53 ns 231.84 ns 232.21 ns]
                        change: [-17.817% -16.309% -14.947%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  6 (6.00%) high mild
  8 (8.00%) high severe

varint/small/encoded_len
                        time:   [144.18 ns 144.37 ns 144.61 ns]
                        change: [-3.0551% -2.0177% -1.0496%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 15 outliers among 100 measurements (15.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  12 (12.00%) high severe

varint/medium/encode    time:   [1.1107 us 1.1183 us 1.1284 us]
                        change: [-18.071% -17.222% -16.488%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

varint/medium/decode    time:   [414.66 ns 414.86 ns 415.12 ns]
                        change: [-9.6812% -9.1417% -8.4957%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  8 (8.00%) high severe

varint/medium/encoded_len
                        time:   [143.71 ns 143.79 ns 143.89 ns]
                        change: [-3.8550% -2.6239% -1.6465%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

varint/large/encode     time:   [2.2581 us 2.2611 us 2.2657 us]
                        change: [-3.1001% -2.2864% -1.5194%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 14 outliers among 100 measurements (14.00%)
  1 (1.00%) low severe
  3 (3.00%) low mild
  4 (4.00%) high mild
  6 (6.00%) high severe

varint/large/decode     time:   [724.83 ns 725.05 ns 725.27 ns]
                        change: [-15.970% -14.724% -13.584%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  6 (6.00%) high severe

varint/large/encoded_len
                        time:   [143.66 ns 143.69 ns 143.73 ns]
                        change: [-0.4454% -0.2427% -0.0520%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 15 outliers among 100 measurements (15.00%)
  15 (15.00%) high severe

varint/mixed/encode     time:   [1.2272 us 1.2283 us 1.2301 us]
                        change: [-39.637% -39.005% -38.424%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low mild
  2 (2.00%) high mild
  7 (7.00%) high severe

varint/mixed/decode     time:   [551.94 ns 552.91 ns 553.89 ns]
                        change: [-14.778% -14.118% -13.479%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

varint/mixed/encoded_len
                        time:   [144.99 ns 145.68 ns 146.49 ns]
                        change: [-6.6187% -5.6221% -4.6395%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe
```