### PR TITLE
Protect encoding::decode_varint from overflow

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -1657,11 +1657,12 @@ mod test {
 
     #[test]
     fn varint_overflow() {
-        let mut u64_plus_one: &[u8] = &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x02];
+        let mut u64_max_plus_one: &[u8] =
+            &[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x02];
 
-        decode_varint(&mut u64_plus_one).expect_err("decoding u64::MAX + 1 succeeded");
-
-        decode_varint_slow(&mut u64_plus_one).expect_err("slow decoding u64::MAX + 1 succeeded");
+        decode_varint(&mut u64_max_plus_one).expect_err("decoding u64::MAX + 1 succeeded");
+        decode_varint_slow(&mut u64_max_plus_one)
+            .expect_err("slow decoding u64::MAX + 1 succeeded");
     }
 
     /// This big bowl o' macro soup generates an encoding property test for each combination of map

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -66,7 +66,7 @@ where
 /// Decodes a LEB128-encoded variable length integer from the slice, returning the value and the
 /// number of bytes read.
 ///
-/// Based loosely on [`ReadVarint64FromArray`][1] with a varint overflow check from 
+/// Based loosely on [`ReadVarint64FromArray`][1] with a varint overflow check from
 /// [`ConsumeVarint`][2].
 ///
 /// ## Safety


### PR DESCRIPTION
Fixes the infamous #528. 