### PR TITLE
increase decode_varint performance

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -62,7 +62,7 @@ where
     }
     part0 -= 0x80;
 
-    if bytes.is_empty() {
+    if bytes.len() < 2 {
         return Err(DecodeError::new("invalid varint"));
     }
     let b = unsafe { *bytes.get_unchecked(1) };
@@ -73,7 +73,7 @@ where
     }
     part0 -= 0x80 << 7;
 
-    if bytes.is_empty() {
+    if bytes.len() < 3 {
         return Err(DecodeError::new("invalid varint"));
     }
     let b = unsafe { *bytes.get_unchecked(2) };
@@ -84,7 +84,7 @@ where
     }
     part0 -= 0x80 << 14;
 
-    if bytes.is_empty() {
+    if bytes.len() < 4 {
         return Err(DecodeError::new("invalid varint"));
     }
     let b = unsafe { *bytes.get_unchecked(3) };
@@ -96,7 +96,7 @@ where
     part0 -= 0x80 << 21;
     let value = u64::from(part0);
 
-    if bytes.is_empty() {
+    if bytes.len() < 5 {
         return Err(DecodeError::new("invalid varint"));
     }
     let b = unsafe { *bytes.get_unchecked(4) };
@@ -107,7 +107,7 @@ where
     }
     part1 -= 0x80;
 
-    if bytes.is_empty() {
+    if bytes.len() < 6 {
         return Err(DecodeError::new("invalid varint"));
     }
     let b = unsafe { *bytes.get_unchecked(5) };
@@ -118,7 +118,7 @@ where
     }
     part1 -= 0x80 << 7;
 
-    if bytes.is_empty() {
+    if bytes.len() < 7 {
         return Err(DecodeError::new("invalid varint"));
     }
     let b = unsafe { *bytes.get_unchecked(6) };
@@ -129,7 +129,7 @@ where
     }
     part1 -= 0x80 << 14;
 
-    if bytes.is_empty() {
+    if bytes.len() < 8 {
         return Err(DecodeError::new("invalid varint"));
     }
     let b = unsafe { *bytes.get_unchecked(7) };
@@ -141,7 +141,7 @@ where
     part1 -= 0x80 << 21;
     let value = value + (u64::from(part1) << 28);
 
-    if bytes.is_empty() {
+    if bytes.len() < 9 {
         return Err(DecodeError::new("invalid varint"));
     }
     let b = unsafe { *bytes.get_unchecked(8) };
@@ -152,7 +152,7 @@ where
     }
     part2 -= 0x80;
 
-    if bytes.is_empty() {
+    if bytes.len() < 10 {
         return Err(DecodeError::new("invalid varint"));
     }
     let b = unsafe { *bytes.get_unchecked(9) };


### PR DESCRIPTION
I managed to increase the performance of encoding::decode_varint by removing some branching and getting rid of the slow decode loop. This sounds concerning, but I also added `bytes.len()` checks every step of the way.

This PR mostly came about though trial-and-error, but I suspect it has something to do with a branching/inline interaction. The result, at least on my machine, is sizable performance gains for small varints (I imagine the most common case, at least as far as tags go) and diminishing performance gains as the varints get larger.

Note: My machine is a old AMD FX-8150 running Linux WSL2. I would be interested to see how the performance is on a fancy new cloud machine.

```
varint/small/encode     time:   [254.83 ns 256.70 ns 259.09 ns]
                        change: [-0.2769% +3.2613% +9.8484%] (p = 0.28 > 0.05)
                        No change in performance detected.

varint/small/decode     time:   [224.79 ns 226.81 ns 229.44 ns]
                        change: [-39.192% -36.446% -33.858%] (p = 0.00 < 0.05)
                        Performance has improved.

varint/small/encoded_len
                        time:   [203.60 ns 205.40 ns 207.53 ns]
                        change: [-2.5341% +1.7540% +8.6075%] (p = 0.68 > 0.05)
                        No change in performance detected.


varint/medium/encode    time:   [1.3112 us 1.3206 us 1.3317 us]
                        change: [-10.751% -3.7931% +1.7344%] (p = 0.33 > 0.05)
                        No change in performance detected.

varint/medium/decode    time:   [580.60 ns 584.50 ns 589.62 ns]
                        change: [-30.263% -27.334% -22.984%] (p = 0.00 < 0.05)
                        Performance has improved.

varint/medium/encoded_len
                        time:   [205.49 ns 207.27 ns 209.46 ns]
                        change: [-6.0480% -0.5540% +3.8425%] (p = 0.86 > 0.05)
                        No change in performance detected.

varint/large/encode     time:   [2.5997 us 2.6160 us 2.6387 us]
                        change: [-2.7384% -0.3883% +1.9255%] (p = 0.77 > 0.05)
                        No change in performance detected.

varint/large/decode     time:   [1.0150 us 1.0234 us 1.0337 us]
                        change: [-9.7888% -3.3455% +1.8321%] (p = 0.35 > 0.05)
                        No change in performance detected.

varint/large/encoded_len
                        time:   [204.44 ns 206.36 ns 208.69 ns]
                        change: [-4.0713% -0.7775% +1.9785%] (p = 0.68 > 0.05)
                        No change in performance detected.

varint/mixed/encode     time:   [1.7585 us 1.7739 us 1.7949 us]
                        change: [-2.8892% -0.4886% +1.9897%] (p = 0.70 > 0.05)
                        No change in performance detected.

varint/mixed/decode     time:   [1.2819 us 1.2915 us 1.3041 us]
                        change: [-20.716% -14.960% -10.392%] (p = 0.00 < 0.05)
                        Performance has improved.

varint/mixed/encoded_len
                        time:   [203.70 ns 204.81 ns 206.03 ns]
                        change: [-8.2241% -4.1701% -0.9167%] (p = 0.02 < 0.05)
                        Change within noise threshold.
```

For reference the "before" decode measurements:

```
varint/small/decode     time:   [357.51 ns 360.22 ns 364.29 ns]
varint/medium/decode    time:   [811.81 ns 817.69 ns 823.87 ns]
varint/large/decode     time:   [1.0463 us 1.0545 us 1.0654 us]
varint/mixed/decode     time:   [1.4749 us 1.4832 us 1.4923 us]
```

Taking a page from @quininer (#519), I also tried out `buf.get_u8()`. Unfortunately, its still quite a bit slower than `bytes.len()` + `bytes.get_unchecked(index)` + `buf.advance(len)`. This is likely because of the difference between calling `buf.advance(len)` 1 time vs. calling `buf.advance(1)` `len` times.  
