### PR TITLE
Add message_path() to Message trait

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -180,6 +180,9 @@ impl<'a> CodeGenerator<'a> {
         self.push_indent();
         self.buf
             .push_str("#[derive(Clone, PartialEq, ::prost::Message)]\n");
+        self.buf.push_str("#[prost(package = \"");
+        self.buf.push_str(&self.package);
+        self.buf.push_str("\")]\n");
         self.push_indent();
         self.buf.push_str("pub struct ");
         self.buf.push_str(&to_upper_camel(&message_name));

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -180,7 +180,8 @@ impl<'a> CodeGenerator<'a> {
         self.push_indent();
         self.buf
             .push_str("#[derive(Clone, PartialEq, ::prost::Message)]\n");
-        self.buf.push_str("#[prost(package = \"");
+        self.push_indent();
+        self.buf.push_str("#[prost(package=\"");
         self.buf.push_str(&self.package);
         self.buf.push_str("\")]\n");
         self.push_indent();

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -732,7 +732,9 @@ impl<'a> CodeGenerator<'a> {
         self.buf.push_str(&to_snake(module));
         self.buf.push_str(" {\n");
 
-        self.package.push('.');
+        if !self.package.is_empty() {
+            self.package.push('.');
+        }
         self.package.push_str(module);
 
         self.depth += 1;
@@ -741,7 +743,7 @@ impl<'a> CodeGenerator<'a> {
     fn pop_mod(&mut self) {
         self.depth -= 1;
 
-        let idx = self.package.rfind('.').unwrap();
+        let idx = self.package.rfind('.').unwrap_or(0);
         self.package.truncate(idx);
 
         self.push_indent();

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -30,7 +30,10 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
             if let Ok(arg) = attr.parse_args::<syn::MetaNameValue>() {
                 if arg.path.is_ident("package") {
                     if let syn::Lit::Str(lit) = arg.lit {
-                        message_path = lit.value() + "." + &ident.to_string();
+                        let package = lit.value();
+                        if !package.is_empty() {
+                            message_path = package + "." + &ident.to_string();
+                        }
                         break;
                     }
                 }

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -24,13 +24,14 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     let ident = input.ident;
     let attrs = input.attrs;
 
-    let mut package = "".to_string();
+    let mut message_path = ident.to_string();
     for attr in attrs {
         if attr.path.is_ident("prost") {
             if let Ok(arg) = attr.parse_args::<syn::MetaNameValue>() {
                 if arg.path.is_ident("package") {
                     if let syn::Lit::Str(lit) = arg.lit {
-                        package = lit.value();
+                        message_path = lit.value() + "." + &ident.to_string();
+                        break;
                     }
                 }
             }
@@ -217,12 +218,8 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
                 #(#clear;)*
             }
 
-            fn package_name() -> &'static str {
-                #package
-            }
-
-            fn message_name() -> &'static str {
-                stringify!(#ident)
+            fn message_path() -> &'static str {
+                #message_path
             }
         }
 

--- a/prost-types/src/compiler.rs
+++ b/prost-types/src/compiler.rs
@@ -1,5 +1,6 @@
 /// The version number of protocol compiler.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf.compiler")]
 pub struct Version {
     #[prost(int32, optional, tag="1")]
     pub major: ::core::option::Option<i32>,
@@ -14,6 +15,7 @@ pub struct Version {
 }
 /// An encoded CodeGeneratorRequest is written to the plugin's stdin.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf.compiler")]
 pub struct CodeGeneratorRequest {
     /// The .proto files that were explicitly listed on the command-line.  The
     /// code generator should generate code only for these files.  Each file's
@@ -45,6 +47,7 @@ pub struct CodeGeneratorRequest {
 }
 /// The plugin writes an encoded CodeGeneratorResponse to stdout.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf.compiler")]
 pub struct CodeGeneratorResponse {
     /// Error message.  If non-empty, code generation failed.  The plugin process
     /// should exit with status code zero even if it reports an error in this way.
@@ -67,6 +70,7 @@ pub struct CodeGeneratorResponse {
 pub mod code_generator_response {
     /// Represents a single generated file.
     #[derive(Clone, PartialEq, ::prost::Message)]
+    #[prost(package="google.protobuf.compiler.CodeGeneratorResponse")]
     pub struct File {
         /// The file name, relative to the output directory.  The name must not
         /// contain "." or ".." components and must be relative, not be absolute (so,

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -1,12 +1,14 @@
 /// The protocol compiler can output a FileDescriptorSet containing the .proto
 /// files it parses.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct FileDescriptorSet {
     #[prost(message, repeated, tag="1")]
     pub file: ::prost::alloc::vec::Vec<FileDescriptorProto>,
 }
 /// Describes a complete .proto file.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct FileDescriptorProto {
     /// file name, relative to root of source tree
     #[prost(string, optional, tag="1")]
@@ -48,6 +50,7 @@ pub struct FileDescriptorProto {
 }
 /// Describes a message type.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct DescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -75,6 +78,7 @@ pub struct DescriptorProto {
 /// Nested message and enum types in `DescriptorProto`.
 pub mod descriptor_proto {
     #[derive(Clone, PartialEq, ::prost::Message)]
+    #[prost(package="google.protobuf.DescriptorProto")]
     pub struct ExtensionRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
@@ -89,6 +93,7 @@ pub mod descriptor_proto {
     /// fields or extension ranges in the same message. Reserved ranges may
     /// not overlap.
     #[derive(Clone, PartialEq, ::prost::Message)]
+    #[prost(package="google.protobuf.DescriptorProto")]
     pub struct ReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
@@ -99,6 +104,7 @@ pub mod descriptor_proto {
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct ExtensionRangeOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
@@ -106,6 +112,7 @@ pub struct ExtensionRangeOptions {
 }
 /// Describes a field within a message.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct FieldDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -220,6 +227,7 @@ pub mod field_descriptor_proto {
 }
 /// Describes a oneof.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct OneofDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -228,6 +236,7 @@ pub struct OneofDescriptorProto {
 }
 /// Describes an enum type.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct EnumDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -254,6 +263,7 @@ pub mod enum_descriptor_proto {
     /// is inclusive such that it can appropriately represent the entire int32
     /// domain.
     #[derive(Clone, PartialEq, ::prost::Message)]
+    #[prost(package="google.protobufi.EnumDescriptorProto")]
     pub struct EnumReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]
@@ -265,6 +275,7 @@ pub mod enum_descriptor_proto {
 }
 /// Describes a value within an enum.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct EnumValueDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -275,6 +286,7 @@ pub struct EnumValueDescriptorProto {
 }
 /// Describes a service.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct ServiceDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -285,6 +297,7 @@ pub struct ServiceDescriptorProto {
 }
 /// Describes a method of a service.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct MethodDescriptorProto {
     #[prost(string, optional, tag="1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -336,6 +349,7 @@ pub struct MethodDescriptorProto {
 //   to automatically assign option numbers.
 
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct FileOptions {
     /// Sets the Java package where classes generated from this .proto will be
     /// placed.  By default, the proto package is used, but this is often
@@ -461,6 +475,7 @@ pub mod file_options {
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct MessageOptions {
     /// Set true to use the old proto1 MessageSet wire format for extensions.
     /// This is provided for backwards-compatibility with the MessageSet wire
@@ -521,6 +536,7 @@ pub struct MessageOptions {
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct FieldOptions {
     /// The ctype option instructs the C++ code generator to use a different
     /// representation of the field than it normally would.  See the specific
@@ -613,12 +629,14 @@ pub mod field_options {
     }
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct OneofOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag="999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct EnumOptions {
     /// Set this option to true to allow mapping different tag names to the same
     /// value.
@@ -635,6 +653,7 @@ pub struct EnumOptions {
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct EnumValueOptions {
     /// Is this enum value deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
@@ -647,6 +666,7 @@ pub struct EnumValueOptions {
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct ServiceOptions {
     // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
     //   framework.  We apologize for hoarding these numbers to ourselves, but
@@ -664,6 +684,7 @@ pub struct ServiceOptions {
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct MethodOptions {
     // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
     //   framework.  We apologize for hoarding these numbers to ourselves, but
@@ -704,6 +725,7 @@ pub mod method_options {
 /// or produced by Descriptor::CopyTo()) will never have UninterpretedOptions
 /// in them.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct UninterpretedOption {
     #[prost(message, repeated, tag="2")]
     pub name: ::prost::alloc::vec::Vec<uninterpreted_option::NamePart>,
@@ -730,6 +752,7 @@ pub mod uninterpreted_option {
     /// E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
     /// "foo.(bar.baz).qux".
     #[derive(Clone, PartialEq, ::prost::Message)]
+    #[prost(package="google.protobuf.UninterpretedOption")]
     pub struct NamePart {
         #[prost(string, required, tag="1")]
         pub name_part: ::prost::alloc::string::String,
@@ -743,6 +766,7 @@ pub mod uninterpreted_option {
 /// Encapsulates information about the original source file from which a
 /// FileDescriptorProto was generated.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct SourceCodeInfo {
     /// A Location identifies a piece of source code in a .proto file which
     /// corresponds to a particular definition.  This information is intended
@@ -793,6 +817,7 @@ pub struct SourceCodeInfo {
 /// Nested message and enum types in `SourceCodeInfo`.
 pub mod source_code_info {
     #[derive(Clone, PartialEq, ::prost::Message)]
+    #[prost(package="google.protobuf.SourceCodeInfo")]
     pub struct Location {
         /// Identifies which part of the FileDescriptorProto was defined at this
         /// location.
@@ -885,6 +910,7 @@ pub mod source_code_info {
 /// file. A GeneratedCodeInfo message is associated with only one generated
 /// source file, but may contain references to different source .proto files.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct GeneratedCodeInfo {
     /// An Annotation connects some span of text in generated code to an element
     /// of its generating .proto file.
@@ -894,6 +920,7 @@ pub struct GeneratedCodeInfo {
 /// Nested message and enum types in `GeneratedCodeInfo`.
 pub mod generated_code_info {
     #[derive(Clone, PartialEq, ::prost::Message)]
+    #[prost(package="google.protobuf.GeneratedCodeInfo")]
     pub struct Annotation {
         /// Identifies the element in the original source .proto file. This field
         /// is formatted the same as SourceCodeInfo.Location.path.
@@ -997,6 +1024,7 @@ pub mod generated_code_info {
 ///     }
 ///
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Any {
     /// A URL/resource name that uniquely identifies the type of the serialized
     /// protocol buffer message. This string must contain at least
@@ -1035,6 +1063,7 @@ pub struct Any {
 /// `SourceContext` represents information about the source of a
 /// protobuf element, like the file in which it is defined.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct SourceContext {
     /// The path-qualified name of the .proto file that contained the associated
     /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
@@ -1043,6 +1072,7 @@ pub struct SourceContext {
 }
 /// A protocol buffer message type.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Type {
     /// The fully qualified message name.
     #[prost(string, tag="1")]
@@ -1065,6 +1095,7 @@ pub struct Type {
 }
 /// A single field of a message type.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Field {
     /// The field type.
     #[prost(enumeration="field::Kind", tag="1")]
@@ -1160,6 +1191,7 @@ pub mod field {
 }
 /// Enum type definition.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Enum {
     /// Enum type name.
     #[prost(string, tag="1")]
@@ -1179,6 +1211,7 @@ pub struct Enum {
 }
 /// Enum value definition.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct EnumValue {
     /// Enum value name.
     #[prost(string, tag="1")]
@@ -1193,6 +1226,7 @@ pub struct EnumValue {
 /// A protocol buffer option, which can be attached to a message, field,
 /// enumeration, etc.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Option {
     /// The option's name. For protobuf built-in options (options defined in
     /// descriptor.proto), this is the short name. For example, `"map_entry"`.
@@ -1226,6 +1260,7 @@ pub enum Syntax {
 /// this message itself. See https://cloud.google.com/apis/design/glossary for
 /// detailed terminology.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Api {
     /// The fully qualified name of this interface, including package name
     /// followed by the interface's simple name.
@@ -1273,6 +1308,7 @@ pub struct Api {
 }
 /// Method represents a method of an API interface.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Method {
     /// The simple name of this method.
     #[prost(string, tag="1")]
@@ -1375,6 +1411,7 @@ pub struct Method {
 ///       ...
 ///     }
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Mixin {
     /// The fully qualified name of the interface which is included.
     #[prost(string, tag="1")]
@@ -1445,6 +1482,7 @@ pub struct Mixin {
 ///
 ///
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Duration {
     /// Signed seconds of the span of time. Must be from -315,576,000,000
     /// to +315,576,000,000 inclusive. Note: these bounds are computed from:
@@ -1660,6 +1698,7 @@ pub struct Duration {
 /// request should verify the included field paths, and return an
 /// `INVALID_ARGUMENT` error if any path is unmappable.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct FieldMask {
     /// The set of field mask paths.
     #[prost(string, repeated, tag="1")]
@@ -1674,6 +1713,7 @@ pub struct FieldMask {
 ///
 /// The JSON representation for `Struct` is JSON object.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Struct {
     /// Unordered map of dynamically typed values.
     #[prost(btree_map="string, message", tag="1")]
@@ -1686,6 +1726,7 @@ pub struct Struct {
 ///
 /// The JSON representation for `Value` is JSON value.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Value {
     /// The kind of value.
     #[prost(oneof="value::Kind", tags="1, 2, 3, 4, 5, 6")]
@@ -1720,6 +1761,7 @@ pub mod value {
 ///
 /// The JSON representation for `ListValue` is JSON array.
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct ListValue {
     /// Repeated field of dynamically typed values.
     #[prost(message, repeated, tag="1")]
@@ -1829,6 +1871,7 @@ pub enum NullValue {
 ///
 ///
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[prost(package="google.protobuf")]
 pub struct Timestamp {
     /// Represents seconds of UTC time since Unix epoch
     /// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -263,7 +263,7 @@ pub mod enum_descriptor_proto {
     /// is inclusive such that it can appropriately represent the entire int32
     /// domain.
     #[derive(Clone, PartialEq, ::prost::Message)]
-    #[prost(package="google.protobufi.EnumDescriptorProto")]
+    #[prost(package="google.protobuf.EnumDescriptorProto")]
     pub struct EnumReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag="1")]

--- a/src/message.rs
+++ b/src/message.rs
@@ -161,6 +161,7 @@ pub trait Message: Debug + Send + Sync {
     /// Clears the message, resetting all fields to their default.
     fn clear(&mut self);
 
+    /// Gets the full path of the message.
     fn message_path() -> &'static str where Self: Sized;
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -161,9 +161,7 @@ pub trait Message: Debug + Send + Sync {
     /// Clears the message, resetting all fields to their default.
     fn clear(&mut self);
 
-    fn package_name() -> &'static str;
-
-    fn message_name() -> &'static str;
+    fn message_path() -> &'static str where Self: Sized;
 }
 
 impl<M> Message for Box<M>
@@ -194,11 +192,8 @@ where
     fn clear(&mut self) {
         (**self).clear()
     }
-    fn package_name() -> &'static str {
-        M::package_name()
-    }
-    fn message_name() -> &'static str {
-        M::message_name()
+    fn message_path() -> &'static str {
+        M::message_path()
     }
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -160,6 +160,10 @@ pub trait Message: Debug + Send + Sync {
 
     /// Clears the message, resetting all fields to their default.
     fn clear(&mut self);
+
+    fn package_name() -> &'static str;
+
+    fn message_name() -> &'static str;
 }
 
 impl<M> Message for Box<M>
@@ -189,6 +193,12 @@ where
     }
     fn clear(&mut self) {
         (**self).clear()
+    }
+    fn package_name() -> &'static str {
+        M::package_name()
+    }
+    fn message_name() -> &'static str {
+        M::message_name()
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -54,6 +54,12 @@ impl Message for bool {
     fn clear(&mut self) {
         *self = false;
     }
+    fn package_name() -> &'static str {
+        "google.protobuf"
+    }
+    fn message_name() -> &'static str {
+        "BoolValue"
+    }
 }
 
 /// `google.protobuf.UInt32Value`
@@ -91,6 +97,12 @@ impl Message for u32 {
     }
     fn clear(&mut self) {
         *self = 0;
+    }
+    fn package_name() -> &'static str {
+        "google.protobuf"
+    }
+    fn message_name() -> &'static str {
+        "UInt32Value"
     }
 }
 
@@ -130,6 +142,12 @@ impl Message for u64 {
     fn clear(&mut self) {
         *self = 0;
     }
+    fn package_name() -> &'static str {
+        "google.protobuf"
+    }
+    fn message_name() -> &'static str {
+        "UInt64Value"
+    }
 }
 
 /// `google.protobuf.Int32Value`
@@ -167,6 +185,12 @@ impl Message for i32 {
     }
     fn clear(&mut self) {
         *self = 0;
+    }
+    fn package_name() -> &'static str {
+        "google.protobuf"
+    }
+    fn message_name() -> &'static str {
+        "Int32Value"
     }
 }
 
@@ -206,6 +230,12 @@ impl Message for i64 {
     fn clear(&mut self) {
         *self = 0;
     }
+    fn package_name() -> &'static str {
+        "google.protobuf"
+    }
+    fn message_name() -> &'static str {
+        "Int64Value"
+    }
 }
 
 /// `google.protobuf.FloatValue`
@@ -243,6 +273,12 @@ impl Message for f32 {
     }
     fn clear(&mut self) {
         *self = 0.0;
+    }
+    fn package_name() -> &'static str {
+        "google.protobuf"
+    }
+    fn message_name() -> &'static str {
+        "FloatValue"
     }
 }
 
@@ -282,6 +318,12 @@ impl Message for f64 {
     fn clear(&mut self) {
         *self = 0.0;
     }
+    fn package_name() -> &'static str {
+        "google.protobuf"
+    }
+    fn message_name() -> &'static str {
+        "DoubleValue"
+    }
 }
 
 /// `google.protobuf.StringValue`
@@ -319,6 +361,12 @@ impl Message for String {
     }
     fn clear(&mut self) {
         self.clear();
+    }
+    fn package_name() -> &'static str {
+        "google.protobuf"
+    }
+    fn message_name() -> &'static str {
+        "StringValue"
     }
 }
 
@@ -358,6 +406,12 @@ impl Message for Vec<u8> {
     fn clear(&mut self) {
         self.clear();
     }
+    fn package_name() -> &'static str {
+        "google.protobuf"
+    }
+    fn message_name() -> &'static str {
+        "BytesValue"
+    }
 }
 
 /// `google.protobuf.BytesValue`
@@ -396,6 +450,12 @@ impl Message for Bytes {
     fn clear(&mut self) {
         self.clear();
     }
+    fn package_name() -> &'static str {
+        "google.protobuf"
+    }
+    fn message_name() -> &'static str {
+        "BytesValue"
+    }
 }
 
 /// `google.protobuf.Empty`
@@ -421,4 +481,10 @@ impl Message for () {
         0
     }
     fn clear(&mut self) {}
+    fn package_name() -> &'static str {
+        "google.protobuf"
+    }
+    fn message_name() -> &'static str {
+        "Empty"
+    }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -54,11 +54,8 @@ impl Message for bool {
     fn clear(&mut self) {
         *self = false;
     }
-    fn package_name() -> &'static str {
-        "google.protobuf"
-    }
-    fn message_name() -> &'static str {
-        "BoolValue"
+    fn message_path() -> &'static str {
+        "google.protobuf.BoolValue"
     }
 }
 
@@ -98,11 +95,8 @@ impl Message for u32 {
     fn clear(&mut self) {
         *self = 0;
     }
-    fn package_name() -> &'static str {
-        "google.protobuf"
-    }
-    fn message_name() -> &'static str {
-        "UInt32Value"
+    fn message_path() -> &'static str {
+        "google.protobuf.UInt32Value"
     }
 }
 
@@ -142,11 +136,8 @@ impl Message for u64 {
     fn clear(&mut self) {
         *self = 0;
     }
-    fn package_name() -> &'static str {
-        "google.protobuf"
-    }
-    fn message_name() -> &'static str {
-        "UInt64Value"
+    fn message_path() -> &'static str {
+        "google.protobuf.UInt64Value"
     }
 }
 
@@ -186,11 +177,8 @@ impl Message for i32 {
     fn clear(&mut self) {
         *self = 0;
     }
-    fn package_name() -> &'static str {
-        "google.protobuf"
-    }
-    fn message_name() -> &'static str {
-        "Int32Value"
+    fn message_path() -> &'static str {
+        "google.protobuf.Int32Value"
     }
 }
 
@@ -230,11 +218,8 @@ impl Message for i64 {
     fn clear(&mut self) {
         *self = 0;
     }
-    fn package_name() -> &'static str {
-        "google.protobuf"
-    }
-    fn message_name() -> &'static str {
-        "Int64Value"
+    fn message_path() -> &'static str {
+        "google.protobuf.Int64Value"
     }
 }
 
@@ -274,11 +259,8 @@ impl Message for f32 {
     fn clear(&mut self) {
         *self = 0.0;
     }
-    fn package_name() -> &'static str {
-        "google.protobuf"
-    }
-    fn message_name() -> &'static str {
-        "FloatValue"
+    fn message_path() -> &'static str {
+        "google.protobuf.FloatValue"
     }
 }
 
@@ -318,11 +300,8 @@ impl Message for f64 {
     fn clear(&mut self) {
         *self = 0.0;
     }
-    fn package_name() -> &'static str {
-        "google.protobuf"
-    }
-    fn message_name() -> &'static str {
-        "DoubleValue"
+    fn message_path() -> &'static str {
+        "google.protobuf.DoubleValue"
     }
 }
 
@@ -362,11 +341,8 @@ impl Message for String {
     fn clear(&mut self) {
         self.clear();
     }
-    fn package_name() -> &'static str {
-        "google.protobuf"
-    }
-    fn message_name() -> &'static str {
-        "StringValue"
+    fn message_path() -> &'static str {
+        "google.protobuf.StringValue"
     }
 }
 
@@ -406,11 +382,8 @@ impl Message for Vec<u8> {
     fn clear(&mut self) {
         self.clear();
     }
-    fn package_name() -> &'static str {
-        "google.protobuf"
-    }
-    fn message_name() -> &'static str {
-        "BytesValue"
+    fn message_path() -> &'static str {
+        "google.protobuf.BytesValue"
     }
 }
 
@@ -450,11 +423,8 @@ impl Message for Bytes {
     fn clear(&mut self) {
         self.clear();
     }
-    fn package_name() -> &'static str {
-        "google.protobuf"
-    }
-    fn message_name() -> &'static str {
-        "BytesValue"
+    fn message_path() -> &'static str {
+        "google.protobuf.BytesValue"
     }
 }
 
@@ -481,10 +451,7 @@ impl Message for () {
         0
     }
     fn clear(&mut self) {}
-    fn package_name() -> &'static str {
-        "google.protobuf"
-    }
-    fn message_name() -> &'static str {
-        "Empty"
+    fn message_path() -> &'static str {
+        "google.protobuf.Empty"
     }
 }

--- a/tests/src/no_root_packages/mod.rs
+++ b/tests/src/no_root_packages/mod.rs
@@ -46,33 +46,23 @@ fn test() {
 
     assert_eq!(
         "widget.factory.WidgetFactory",
-        widget::factory::WidgetFactory::message_path());
+        widget::factory::WidgetFactory::message_path()
+    );
 
     assert_eq!(
         "widget.factory.WidgetFactory.Inner",
-        widget::factory::widget_factory::Inner::message_path());
+        widget::factory::widget_factory::Inner::message_path()
+    );
 
-    assert_eq!(
-        "Root",
-        Root::message_path());
+    assert_eq!("Root", Root::message_path());
 
-    assert_eq!(
-        "Root.Inner",
-        root::Inner::message_path());
+    assert_eq!("Root.Inner", root::Inner::message_path());
 
-    assert_eq!(
-        "widget.Widget",
-        widget::Widget::message_path());
+    assert_eq!("widget.Widget", widget::Widget::message_path());
 
-    assert_eq!(
-        "widget.Widget.Inner",
-        widget::widget::Inner::message_path());
+    assert_eq!("widget.Widget.Inner", widget::widget::Inner::message_path());
 
-    assert_eq!(
-        "gizmo.Gizmo",
-        gizmo::Gizmo::message_path());
+    assert_eq!("gizmo.Gizmo", gizmo::Gizmo::message_path());
 
-    assert_eq!(
-        "gizmo.Gizmo.Inner",
-        gizmo::gizmo::Inner::message_path());
+    assert_eq!("gizmo.Gizmo.Inner", gizmo::gizmo::Inner::message_path());
 }

--- a/tests/src/no_root_packages/mod.rs
+++ b/tests/src/no_root_packages/mod.rs
@@ -43,4 +43,36 @@ fn test() {
 
     widget_factory.gizmo_inner = Some(gizmo::gizmo::Inner {});
     assert_eq!(14, widget_factory.encoded_len());
+
+    assert_eq!(
+        "widget.factory.WidgetFactory",
+        widget::factory::WidgetFactory::message_path());
+
+    assert_eq!(
+        "widget.factory.WidgetFactory.Inner",
+        widget::factory::widget_factory::Inner::message_path());
+
+    assert_eq!(
+        "Root",
+        Root::message_path());
+
+    assert_eq!(
+        "Root.Inner",
+        root::Inner::message_path());
+
+    assert_eq!(
+        "widget.Widget",
+        widget::Widget::message_path());
+
+    assert_eq!(
+        "widget.Widget.Inner",
+        widget::widget::Inner::message_path());
+
+    assert_eq!(
+        "gizmo.Gizmo",
+        gizmo::Gizmo::message_path());
+
+    assert_eq!(
+        "gizmo.Gizmo.Inner",
+        gizmo::gizmo::Inner::message_path());
 }

--- a/tests/src/packages/mod.rs
+++ b/tests/src/packages/mod.rs
@@ -49,4 +49,36 @@ fn test() {
 
     widget_factory.gizmo_inner = Some(gizmo::gizmo::Inner {});
     assert_eq!(14, widget_factory.encoded_len());
+
+    assert_eq!(
+        "packages.widget.factory.WidgetFactory",
+        widget::factory::WidgetFactory::message_path());
+
+    assert_eq!(
+        "packages.widget.factory.WidgetFactory.Inner",
+        widget::factory::widget_factory::Inner::message_path());
+
+    assert_eq!(
+        "packages.Root",
+        Root::message_path());
+
+    assert_eq!(
+        "packages.Root.Inner",
+        root::Inner::message_path());
+
+    assert_eq!(
+        "packages.widget.Widget",
+        widget::Widget::message_path());
+
+    assert_eq!(
+        "packages.widget.Widget.Inner",
+        widget::widget::Inner::message_path());
+
+    assert_eq!(
+        "packages.gizmo.Gizmo",
+        gizmo::Gizmo::message_path());
+
+    assert_eq!(
+        "packages.gizmo.Gizmo.Inner",
+        gizmo::gizmo::Inner::message_path());
 }

--- a/tests/src/packages/mod.rs
+++ b/tests/src/packages/mod.rs
@@ -52,33 +52,29 @@ fn test() {
 
     assert_eq!(
         "packages.widget.factory.WidgetFactory",
-        widget::factory::WidgetFactory::message_path());
+        widget::factory::WidgetFactory::message_path()
+    );
 
     assert_eq!(
         "packages.widget.factory.WidgetFactory.Inner",
-        widget::factory::widget_factory::Inner::message_path());
+        widget::factory::widget_factory::Inner::message_path()
+    );
 
-    assert_eq!(
-        "packages.Root",
-        Root::message_path());
+    assert_eq!("packages.Root", Root::message_path());
 
-    assert_eq!(
-        "packages.Root.Inner",
-        root::Inner::message_path());
+    assert_eq!("packages.Root.Inner", root::Inner::message_path());
 
-    assert_eq!(
-        "packages.widget.Widget",
-        widget::Widget::message_path());
+    assert_eq!("packages.widget.Widget", widget::Widget::message_path());
 
     assert_eq!(
         "packages.widget.Widget.Inner",
-        widget::widget::Inner::message_path());
+        widget::widget::Inner::message_path()
+    );
 
-    assert_eq!(
-        "packages.gizmo.Gizmo",
-        gizmo::Gizmo::message_path());
+    assert_eq!("packages.gizmo.Gizmo", gizmo::Gizmo::message_path());
 
     assert_eq!(
         "packages.gizmo.Gizmo.Inner",
-        gizmo::gizmo::Inner::message_path());
+        gizmo::gizmo::Inner::message_path()
+    );
 }


### PR DESCRIPTION
This branch annotates package names and adds `message_path()` function to `Message` trait.
This function returns the full path of each proto message.

This is useful for converting each message to `Any`.

Example:
```proto
syntax = "proto3";

package example.proto;

message Example {
    string value = 1;
}
```

```rust
use prost::{DecodeError, Message};
use prost_types::Any;

mod proto {
    include!(concat!(env!("OUT_DIR"), "/example.proto.rs"));
}

fn convert_to_any<T>(message: &T) -> Any where T: Message {
    Any {
        type_url: format!("example.com/{}", T::message_path()),
        value: message.encode_to_vec(),
    }
}

fn convert_from_any<T>(message: &Any) -> Result<T, DecodeError> where T: Message + Default {
    let expected_type_url = format!("example.com/{}", T::message_path());
    if &message.type_url == &expected_type_url {
        T::decode(message.value.as_slice())
    } else {
        Err(DecodeError::new("Invalid type_url"))
    }
}

let message = proto::Example {
    value: "abc".to_string(),
};

let message = convert_to_any(&message);
println!("{:?}", message);
// -> Any { type_url: "example.com/example.proto.Example", value: [10, 3, 97, 98, 99] }

let message: proto::Example = convert_from_any(&message).unwrap();
println!("{:?}", message);
// -> Example { value: "abc" }
```