### PR TITLE
Make it possible to only generate the services

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -123,21 +123,23 @@ impl<'a> CodeGenerator<'a> {
             code_gen.package
         );
 
-        code_gen.path.push(4);
-        for (idx, message) in file.message_type.into_iter().enumerate() {
-            code_gen.path.push(idx as i32);
-            code_gen.append_message(message);
+        if !code_gen.config.service_only {
+            code_gen.path.push(4);
+            for (idx, message) in file.message_type.into_iter().enumerate() {
+                code_gen.path.push(idx as i32);
+                code_gen.append_message(message);
+                code_gen.path.pop();
+            }
             code_gen.path.pop();
-        }
-        code_gen.path.pop();
 
-        code_gen.path.push(5);
-        for (idx, desc) in file.enum_type.into_iter().enumerate() {
-            code_gen.path.push(idx as i32);
-            code_gen.append_enum(desc);
+            code_gen.path.push(5);
+            for (idx, desc) in file.enum_type.into_iter().enumerate() {
+                code_gen.path.push(idx as i32);
+                code_gen.append_enum(desc);
+                code_gen.path.pop();
+            }
             code_gen.path.pop();
         }
-        code_gen.path.pop();
 
         if code_gen.config.service_generator.is_some() {
             code_gen.path.push(6);


### PR DESCRIPTION
This make it possible to generate only the messages in one crate (with dependencies only on `prost`) and the services in another crate (with dependencies on the messages crate and some networking crate like `tonic`). This offers more possibilities in workspace organization (separation of concerns and better build parallelization).

For example:
- crate `Messages` (use prost-build with no `service_generator`)
- crate `Business-A` depends on `Messages`
- crate `Services` depends on `Messages` (use tonic-build with `service_only(true)`)
- crate `Binary` depends on `Services` and `Business-A`