### PR TITLE
Fine-grained selection of where to add type or field attributes using filters

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -18,7 +18,7 @@ use crate::ast::{Comments, Method, Service};
 use crate::extern_paths::ExternPaths;
 use crate::ident::{to_snake, to_upper_camel};
 use crate::message_graph::MessageGraph;
-use crate::{BytesType, Config, MapType};
+use crate::{BytesType, Config, FieldSelector, LabelSelector, MapType, TypeFilter, TypeSelector};
 
 #[derive(PartialEq)]
 enum Syntax {
@@ -181,7 +181,7 @@ impl<'a> CodeGenerator<'a> {
             });
 
         self.append_doc(&fq_message_name, None);
-        self.append_type_attributes(&fq_message_name);
+        self.append_type_attributes(&fq_message_name, TypeSelector::ProtobufMessage);
         self.push_indent();
         self.buf
             .push_str("#[derive(Clone, PartialEq, ::prost::Message)]\n");
@@ -259,25 +259,39 @@ impl<'a> CodeGenerator<'a> {
         }
     }
 
-    fn append_type_attributes(&mut self, fq_message_name: &str) {
+    fn append_type_attributes(&mut self, fq_message_name: &str, ty_selector: TypeSelector) {
         assert_eq!(b'.', fq_message_name.as_bytes()[0]);
-        for attribute in self.config.type_attributes.get(fq_message_name) {
-            push_indent(self.buf, self.depth);
-            self.buf.push_str(attribute);
-            self.buf.push('\n');
+        for (attribute, ty_filter) in self.config.type_attributes.get(fq_message_name) {
+            if Self::ty_selector_matches_filter(ty_selector, *ty_filter) {
+                push_indent(self.buf, self.depth);
+                self.buf.push_str(attribute);
+                self.buf.push('\n');
+            }
         }
     }
 
-    fn append_field_attributes(&mut self, fq_message_name: &str, field_name: &str) {
+    fn append_field_attributes(
+        &mut self,
+        fq_message_name: &str,
+        field_name: &str,
+        ty_selector: TypeSelector,
+        lb_selector: LabelSelector,
+        fld_selector: FieldSelector,
+    ) {
         assert_eq!(b'.', fq_message_name.as_bytes()[0]);
-        for attribute in self
+        for (attribute, ty_filter, lb_filter, fld_filter) in self
             .config
             .field_attributes
             .get_field(fq_message_name, field_name)
         {
-            push_indent(self.buf, self.depth);
-            self.buf.push_str(attribute);
-            self.buf.push('\n');
+            let should_add = Self::ty_selector_matches_filter(ty_selector, *ty_filter)
+                && fld_filter.is_set(fld_selector)
+                && lb_filter.is_set(lb_selector);
+            if should_add {
+                push_indent(self.buf, self.depth);
+                self.buf.push_str(attribute);
+                self.buf.push('\n');
+            }
         }
     }
 
@@ -381,7 +395,19 @@ impl<'a> CodeGenerator<'a> {
         }
 
         self.buf.push_str("\")]\n");
-        self.append_field_attributes(fq_message_name, field.name());
+        self.append_field_attributes(
+            fq_message_name,
+            field.name(),
+            TypeSelector::ProtobufMessage,
+            if optional {
+                LabelSelector::Optional
+            } else if repeated {
+                LabelSelector::Repeated
+            } else {
+                LabelSelector::Required
+            },
+            FieldSelector::from(field.r#type()),
+        );
         self.push_indent();
         self.buf.push_str("pub ");
         self.buf.push_str(&to_snake(field.name()));
@@ -440,7 +466,13 @@ impl<'a> CodeGenerator<'a> {
             value_tag,
             field.number()
         ));
-        self.append_field_attributes(fq_message_name, field.name());
+        self.append_field_attributes(
+            fq_message_name,
+            field.name(),
+            TypeSelector::ProtobufMessage,
+            LabelSelector::Required,
+            FieldSelector::MapField,
+        );
         self.push_indent();
         self.buf.push_str(&format!(
             "pub {}: {}<{}, {}>,\n",
@@ -473,7 +505,13 @@ impl<'a> CodeGenerator<'a> {
                 .map(|&(ref field, _)| field.number())
                 .join(", ")
         ));
-        self.append_field_attributes(fq_message_name, oneof.name());
+        self.append_field_attributes(
+            fq_message_name,
+            oneof.name(),
+            TypeSelector::ProtobufMessage,
+            LabelSelector::Optional,
+            FieldSelector::OneofField,
+        );
         self.push_indent();
         self.buf.push_str(&format!(
             "pub {}: ::core::option::Option<{}>,\n",
@@ -496,7 +534,7 @@ impl<'a> CodeGenerator<'a> {
         self.path.pop();
 
         let oneof_name = format!("{}.{}", fq_message_name, oneof.name());
-        self.append_type_attributes(&oneof_name);
+        self.append_type_attributes(&oneof_name, TypeSelector::ProtobufOneof);
         self.push_indent();
         self.buf
             .push_str("#[derive(Clone, PartialEq, ::prost::Oneof)]\n");
@@ -521,7 +559,13 @@ impl<'a> CodeGenerator<'a> {
                 ty_tag,
                 field.number()
             ));
-            self.append_field_attributes(&oneof_name, field.name());
+            self.append_field_attributes(
+                &oneof_name,
+                field.name(),
+                TypeSelector::ProtobufOneof,
+                LabelSelector::Required,
+                FieldSelector::from(field.r#type()),
+            );
 
             self.push_indent();
             let ty = self.resolve_type(&field, fq_message_name);
@@ -602,7 +646,7 @@ impl<'a> CodeGenerator<'a> {
         }
 
         self.append_doc(&fq_proto_enum_name, None);
-        self.append_type_attributes(&fq_proto_enum_name);
+        self.append_type_attributes(&fq_proto_enum_name, TypeSelector::ProtobufEnum);
         self.push_indent();
         self.buf.push_str(
             "#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]\n",
@@ -623,7 +667,13 @@ impl<'a> CodeGenerator<'a> {
             self.path.push(variant.path_idx as i32);
 
             self.append_doc(&fq_proto_enum_name, Some(variant.proto_name));
-            self.append_field_attributes(&fq_proto_enum_name, variant.proto_name);
+            self.append_field_attributes(
+                &fq_proto_enum_name,
+                variant.proto_name,
+                TypeSelector::ProtobufEnum,
+                LabelSelector::Required,
+                FieldSelector::NoDataEnumVariant,
+            );
             self.push_indent();
             self.buf.push_str(&variant.generated_variant_name);
             self.buf.push_str(" = ");
@@ -892,6 +942,22 @@ impl<'a> CodeGenerator<'a> {
             .options
             .as_ref()
             .map_or(false, FieldOptions::deprecated)
+    }
+
+    fn ty_selector_matches_filter(ty_selector: TypeSelector, ty_filter: TypeFilter) -> bool {
+        ty_filter.is_set(ty_selector)
+            || match ty_selector {
+                TypeSelector::ProtobufEnum => {
+                    ty_filter.is_set(TypeSelector::RustEnum)
+                        || ty_filter.is_set(TypeSelector::RustEnumCLike)
+                }
+                TypeSelector::ProtobufOneof => {
+                    ty_filter.is_set(TypeSelector::RustEnum)
+                        || ty_filter.is_set(TypeSelector::RustEnumWithData)
+                }
+                TypeSelector::ProtobufMessage => ty_filter.is_set(TypeSelector::RustStruct),
+                _ => false,
+            }
     }
 }
 

--- a/prost-build/src/filters.rs
+++ b/prost-build/src/filters.rs
@@ -1,0 +1,271 @@
+use core::{
+    convert::TryFrom,
+    fmt,
+    ops::{BitAnd, BitOr, Not},
+};
+use prost_types::field_descriptor_proto::{Label, Type};
+
+macro_rules! implement_conversions {
+    ($filter:ident, $selector:ident { $($var:ident),* $(,)? }) => {
+        impl $filter {
+            pub(crate) fn is_set(&self, en: $selector) -> bool {
+                self.0 & (en as u32) != 0
+            }
+        }
+
+        impl From<$selector> for $filter {
+            fn from(en: $selector) -> Self {
+                $filter(en as u32)
+            }
+        }
+
+        impl Not for $selector {
+            type Output = $filter;
+            fn not(self) -> Self::Output {
+                !$filter::from(self)
+            }
+        }
+
+        impl Not for $filter {
+            type Output = $filter;
+            fn not(self) -> Self::Output {
+                $filter(!self.0)
+            }
+        }
+
+        impl<T: Into<$filter>> BitOr<T> for $selector {
+            type Output = $filter;
+            fn bitor(self, rhs: T) -> Self::Output {
+                $filter::from(self) | <T as Into<$filter>>::into(rhs)
+            }
+        }
+
+        impl<T: Into<$filter>> BitOr<T> for $filter {
+            type Output = $filter;
+            fn bitor(self, rhs: T) -> Self::Output {
+                $filter(self.0 | rhs.into().0)
+            }
+        }
+
+        impl<T: Into<$filter>> BitAnd<T> for $selector {
+            type Output = $filter;
+            fn bitand(self, rhs: T) -> Self::Output {
+                $filter::from(self) & <T as Into<$filter>>::into(rhs)
+            }
+        }
+
+        impl<T: Into<$filter>> BitAnd<T> for $filter {
+            type Output = $filter;
+            fn bitand(self, rhs: T) -> Self::Output {
+                $filter(self.0 & rhs.into().0)
+            }
+        }
+
+        impl fmt::Debug for $filter {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, concat!(stringify!($filter), "( "))?;
+                let mut written = false;
+                for idx in 0..32 {
+                    let mask = 1<<idx;
+                    if mask & self.0 != 0 {
+                        if written { write!(f, " | ")?; }
+                        written = true;
+                        match $selector::try_from(mask) {
+                            Ok(ref x) => fmt::Debug::fmt(x, f)?,
+                            Err(e) => write!(f, "Unknonwn({})", e)?,
+                        }
+                    }
+                }
+                write!(f, " )")
+            }
+        }
+
+        // this would make automatic https://github.com/rust-lang/rust/pull/81642
+        impl TryFrom<u32> for $selector {
+            type Error = u32;
+
+            fn try_from(value: u32) -> Result<Self, Self::Error> {
+                match value {
+                    $( n if n == Self::$var as u32   => Ok(Self::$var), )*
+                    oth => Err(oth)
+                }
+            }
+        }
+    }
+}
+
+macro_rules! impl_from_another {
+    ($another:ident, $selector:ident { $($var:ident),* $(,)? }) => {
+        impl From<$another> for $selector {
+            fn from(another: $another) -> $selector {
+                match another {
+                    $( $another::$var => $selector::$var ),*
+
+                }
+            }
+        }
+    }
+}
+
+/// A collection of `TypeSelector`s. The filter matches if ANY of the
+/// inner `TypeSelector`s match. Can be created by `BitOr`ing together
+/// `TypeSelector`s or calling `Into::into()` on a `TypeSelector`.
+#[derive(Default, Clone, Copy)]
+pub struct TypeFilter(u32);
+
+/// Selects a output object (rust struct or enum) during code
+/// generation based on either the output rust type or the
+/// protobuf type (message, enum oneof) that it represents.
+#[derive(Debug, Clone, Copy)]
+#[repr(u32)]
+pub enum TypeSelector {
+    ProtobufMessage = 1 << 0,
+    ProtobufEnum = 1 << 1,
+    ProtobufOneof = 1 << 2,
+    RustStruct = 1 << 3,
+    RustEnum = 1 << 4,
+    RustEnumCLike = 1 << 5,
+    RustEnumWithData = 1 << 6,
+    Everything = u32::MAX,
+}
+
+implement_conversions!(
+    TypeFilter,
+    TypeSelector {
+        ProtobufMessage,
+        ProtobufEnum,
+        ProtobufOneof,
+        RustStruct,
+        RustEnum,
+        RustEnumCLike,
+        RustEnumWithData,
+    }
+);
+
+#[derive(Default, Clone, Copy)]
+pub struct LabelFilter(u32);
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u32)]
+pub enum LabelSelector {
+    // Protobuf types
+    Optional = 1 << 0,
+    Required = 1 << 1,
+    Repeated = 1 << 2,
+    Everything = u32::MAX,
+}
+
+implement_conversions!(
+    LabelFilter,
+    LabelSelector {
+        Optional,
+        Required,
+        Repeated
+    }
+);
+
+impl_from_another!(
+    Label,
+    LabelSelector {
+        Optional,
+        Required,
+        Repeated
+    }
+);
+
+#[derive(Default, Clone, Copy)]
+pub struct FieldFilter(u32);
+
+#[derive(Debug, Clone, Copy)]
+#[repr(u32)]
+pub enum FieldSelector {
+    // Protobuf types
+    Double = 1 << 0,
+    Float = 1 << 1,
+    Int64 = 1 << 2,
+    Uint64 = 1 << 3,
+
+    Int32 = 1 << 4,
+    Fixed64 = 1 << 5,
+    Fixed32 = 1 << 6,
+    Bool = 1 << 7,
+
+    String = 1 << 8,
+    Group = 1 << 9,
+    Message = 1 << 10,
+    Bytes = 1 << 11,
+
+    Uint32 = 1 << 12,
+    Enum = 1 << 13,
+    Sfixed32 = 1 << 14,
+    Sfixed64 = 1 << 15,
+
+    Sint32 = 1 << 16,
+    Sint64 = 1 << 17,
+
+    /// All protobuf types except Group, Message, Enum
+    ProtobufScalar = 0b11_1101_1001_1111_1111,
+
+    /// Enum variant with no data
+    NoDataEnumVariant = 1 << 19,
+
+    /// oneof field
+    OneofField = 1 << 20,
+
+    /// map field
+    MapField = 1 << 21,
+    Everything = u32::MAX,
+}
+
+implement_conversions!(
+    FieldFilter,
+    FieldSelector {
+        Double,
+        Float,
+        Int64,
+        Uint64,
+        Int32,
+        Fixed64,
+        Fixed32,
+        Bool,
+        String,
+        Group,
+        Message,
+        Bytes,
+        Uint32,
+        Enum,
+        Sfixed32,
+        Sfixed64,
+        Sint32,
+        Sint64,
+
+        ProtobufScalar,
+        NoDataEnumVariant,
+        OneofField,
+        MapField,
+    }
+);
+
+impl_from_another!(
+    Type,
+    FieldSelector {
+        Double,
+        Float,
+        Int64,
+        Uint64,
+        Int32,
+        Fixed64,
+        Fixed32,
+        Bool,
+        String,
+        Group,
+        Message,
+        Bytes,
+        Uint32,
+        Enum,
+        Sfixed32,
+        Sfixed64,
+        Sint32,
+        Sint64,
+    }
+);

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -125,6 +125,7 @@
 mod ast;
 mod code_generator;
 mod extern_paths;
+mod filters;
 mod ident;
 mod message_graph;
 mod path;
@@ -147,6 +148,9 @@ use prost_types::{FileDescriptorProto, FileDescriptorSet};
 pub use crate::ast::{Comments, Method, Service};
 use crate::code_generator::CodeGenerator;
 use crate::extern_paths::ExternPaths;
+pub use crate::filters::{
+    FieldFilter, FieldSelector, LabelFilter, LabelSelector, TypeFilter, TypeSelector,
+};
 use crate::ident::to_snake;
 use crate::message_graph::MessageGraph;
 use crate::path::PathMap;
@@ -236,8 +240,8 @@ pub struct Config {
     service_generator: Option<Box<dyn ServiceGenerator>>,
     map_type: PathMap<MapType>,
     bytes_type: PathMap<BytesType>,
-    type_attributes: PathMap<String>,
-    field_attributes: PathMap<String>,
+    type_attributes: PathMap<(String, TypeFilter)>,
+    field_attributes: PathMap<(String, TypeFilter, LabelFilter, FieldFilter)>,
     prost_types: bool,
     strip_enum_prefix: bool,
     out_dir: Option<PathBuf>,
@@ -405,8 +409,57 @@ impl Config {
         P: AsRef<str>,
         A: AsRef<str>,
     {
-        self.field_attributes
-            .insert(path.as_ref().to_string(), attribute.as_ref().to_string());
+        self.field_attribute_with_filter(
+            path,
+            attribute,
+            TypeSelector::Everything,
+            LabelSelector::Everything,
+            FieldSelector::Everything,
+        )
+    }
+
+    /// Add additional attribute to matched fields if ALL filters match. Each
+    /// filter value is a bitset - Selectors can be combined with bit operations
+    /// `&` or `|` or negated with `!` to create more complex filters.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # let mut config = prost_build::Config::new();
+    /// // Serde should flatten all non-optional fields that
+    /// // are named payload and contain a struct.
+    /// config.field_attribute_with_filter(
+    ///     "payload",
+    ///     "#[serde(flatten)]",
+    ///     prost_build::TypeSelector::RustStruct,
+    ///     prost_build::LabelSelector::Required,
+    ///     prost_build::FieldSelector::Message,
+    /// );
+    /// ```
+    pub fn field_attribute_with_filter<P, A, TF, LF, FF>(
+        &mut self,
+        path: P,
+        attribute: A,
+        type_filter: TF,
+        label_filter: LF,
+        field_filter: FF,
+    ) -> &mut Self
+    where
+        P: AsRef<str>,
+        A: AsRef<str>,
+        TF: Into<TypeFilter>,
+        LF: Into<LabelFilter>,
+        FF: Into<FieldFilter>,
+    {
+        self.field_attributes.insert(
+            path.as_ref().to_string(),
+            (
+                attribute.as_ref().to_string(),
+                type_filter.into(),
+                label_filter.into(),
+                field_filter.into(),
+            ),
+        );
         self
     }
 
@@ -454,8 +507,36 @@ impl Config {
         P: AsRef<str>,
         A: AsRef<str>,
     {
-        self.type_attributes
-            .insert(path.as_ref().to_string(), attribute.as_ref().to_string());
+        self.type_attribute_with_filter(path, attribute, TypeSelector::Everything)
+    }
+
+    /// Add additional attribute to matched messages, enums and one-ofs IF filter
+    /// matches. Usage is similar to [`type_attribute`](#method.type_attribute).
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # let mut config = prost_build::Config::new();
+    /// // Derive serde::Serialize on all enums
+    /// config.type_attribute_with_filter(".", "#[derive(Serialize)]", prost_build::TypeSelector::RustEnum);
+    /// // Use serde's adjacently tagged enum representation for all rust enums, that are not c-like.
+    /// config.type_attribute_with_filter(".", "#[serde(tag = \"kind\", content = \"data\")]", prost_build::TypeSelector::RustEnumWithData);
+    /// ```
+    pub fn type_attribute_with_filter<P, A, F>(
+        &mut self,
+        path: P,
+        attribute: A,
+        filter: F,
+    ) -> &mut Self
+    where
+        P: AsRef<str>,
+        A: AsRef<str>,
+        F: Into<TypeFilter>,
+    {
+        self.type_attributes.insert(
+            path.as_ref().to_string(),
+            (attribute.as_ref().to_string(), filter.into()),
+        );
         self
     }
 


### PR DESCRIPTION
This does not break the external API, it only adds 2 new functions

```rust

pub fn type_attribute_with_filter<P, A, F>(
    &mut self,
    path: P,
    attribute: A,
    filter: F,
) -> &mut Self;
where
    P: AsRef<str>,
    A: AsRef<str>,
    F: Into<TypeFilter>
    
pub fn field_attribute_with_filter<P, A, TF, LF, FF>(
    &mut self,
    path: P,
    attribute: A,
    type_filter: TF,
    label_filter: LF,
    field_filter: FF,
) -> &mut Self;
where
    P: AsRef<str>,
    A: AsRef<str>,
    TF: Into<TypeFilter>,
    LF: Into<LabelFilter>,
    FF: Into<FieldFilter>
```

and 6 types - 3 pairs of Filter and Selector:
```
TypeFilter, TypeSelector,
LabelFilter, LabelSelector, 
FieldFilter, FieldSelector, 
```
Filters are bitsets (newtypes around u32) and Selectors give meaning to values in that bitset (c-like enums with selected discriminator values). Attribute maps contain these filters and attributes are only applied if all filters match.

```rust
    type_attributes: PathMap<(String, TypeFilter)>,
    field_attributes: PathMap<(String, TypeFilter, LabelFilter, FieldFilter)>,
```
This allows very specific selection of where to add attributes, example:

```rust
        .type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]")
        // enums with data should use serde adjacently tagged format
        .type_attribute_with_filter(
            ".",
            "#[serde(tag = \"kind\", content = \"data\")]",
            TypeSelector::RustEnumWithData
        )
        // All c-like enums should have clap::ArgEnum impl
        .type_attribute_with_filter(
            ".",
            "#[derive(clap::ArgEnum)]",
            TypeSelector::RustEnumCLike
        )
        // and structs a clap::Parser impl
        .type_attribute_with_filter(
            ".",
            "#[derive(clap::Parser)]",
            TypeSelector::RustStruct
        )
        // use a trait to find parsers for non-scalar types
        .field_attribute_with_filter(
            ".",
            "#[clap(parse(try_from_str=crate::CustomClapParse::parse))]",
            TypeSelector::RustStruct,
            LabelSelector::Everything,
            !FieldSelector::ProtobufScalar | FieldSelector::Bytes,
        )
        // repeated String also needs the custom parser
        .field_attribute_with_filter(
            ".",
            "#[clap(parse(try_from_str=crate::CustomClapParse::parse))]",
            TypeSelector::RustStruct,
            LabelSelector::Repeated,
            FieldSelector::String
        )
```

This probably needs some tests, but that would be quite pointless if you don't like this feature - if this seems reasonable, I can add a bunch of tests.

Previous pull request had a similar idea, but implemented it differently:
https://github.com/tokio-rs/prost/pull/494

May solve cases like these:
https://github.com/tokio-rs/prost/issues/371
https://github.com/tokio-rs/prost/issues/332