### PR TITLE
use minimal features for regex crate

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -23,7 +23,7 @@ prost = { version = "0.9.0", path = "..", default-features = false }
 prost-types = { version = "0.9.0", path = "../prost-types", default-features = false }
 tempfile = "3"
 lazy_static = "1.4.0"
-regex = "1.5.4"
+regex = { version = "1.5.4", default-features = false, features = ["std"] }
 
 [build-dependencies]
 which = { version = "4", default-features = false }


### PR DESCRIPTION
#510 introduced `regex` crate to `Cargo.toml`. This PR disables the unrequired features to only use the required ones. This speeds up the build time by upto 8 seconds