### PR TITLE
Bump MSRV to 1.51

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -46,7 +46,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.46.0
+          - 1.51.0
         os:
           - ubuntu-latest
           - macos-latest


### PR DESCRIPTION
Required because one of our dependencies brought in `resolver = 2` which was introduced in rust 1.51. In general, the tokio project allows the MSRV to be no closer than 6months ago which fits 1.51 as 1.56 was released yesterday.