### PR TITLE
Add missing perl-unicode feature to regex crate

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -23,7 +23,7 @@ prost = { version = "0.9.0", path = "..", default-features = false }
 prost-types = { version = "0.9.0", path = "../prost-types", default-features = false }
 tempfile = "3"
 lazy_static = "1.4.0"
-regex = { version = "1.5.4", default-features = false, features = ["std"] }
+regex = { version = "1.5.4", default-features = false, features = ["std", "unicode-perl"] }
 
 [build-dependencies]
 which = { version = "4", default-features = false }


### PR DESCRIPTION
PR #550 reduced the feature flags of the regex crate on only `["std"]`, however this is not enough, as compiling the used regexps requires the unicode-perl feature flag to compile the `\s` class (likely to match Unicode whitespaces).

Without this flag, `prost-build` panicks with the following message:

```
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Syntax(
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
regex parse error:
    https?://[^\s)]+
               ^^
error: Unicode-aware Perl class not found (make sure the unicode-perl feature is enabled)
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
)'
```
How could this work before, I have no idea, but a minimal example with a blank crate and only the regex dependency panics with trying to compile the regex in `prost-build/src/ast.rs:98`: `https?://[^\s)]+`.