### PR TITLE
Change `decode_length_delimiter` to a mutable borrow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,11 +67,11 @@ pub fn length_delimiter_len(length: usize) -> usize {
 ///    input is required to decode the full delimiter.
 ///  * If the supplied buffer contains more than 10 bytes, then the buffer contains an invalid
 ///    delimiter, and typically the buffer should be considered corrupt.
-pub fn decode_length_delimiter<B>(mut buf: B) -> Result<usize, DecodeError>
+pub fn decode_length_delimiter<B>(buf: &mut B) -> Result<usize, DecodeError>
 where
     B: Buf,
 {
-    let length = decode_varint(&mut buf)?;
+    let length = decode_varint(buf)?;
     if length > usize::max_value() as u64 {
         return Err(DecodeError::new(
             "length delimiter exceeds maximum usize value",


### PR DESCRIPTION
While it can make sense in some cases to use a clone here, let's not force users to do it since the function does *not need* it.