### PR TITLE
Add unicode feature to regex to unblock cargo test

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -23,7 +23,7 @@ prost = { version = "0.9.0", path = "..", default-features = false }
 prost-types = { version = "0.9.0", path = "../prost-types", default-features = false }
 tempfile = "3"
 lazy_static = "1.4.0"
-regex = { version = "1.5.4", default-features = false, features = ["std"] }
+regex = { version = "1.5.4", default-features = false, features = ["std", "unicode"] }
 
 [build-dependencies]
 which = { version = "4", default-features = false }


### PR DESCRIPTION
Not sure if other encounters this? Tried to run `cargo test` under `prost/tests`, but got the following error:

```
   Compiling protobuf v0.0.0 (/repos/prost/protobuf)                     
error: failed to run custom build command for `protobuf v0.0.0 (/repos/prost/protobuf)`                                                                         
                                           
Caused by:                                                                            
  process didn't exit successfully: `/repos/prost/target/debug/build/protobuf-1fe2934115879d6d/build-script-build` (exit status: 101)                           
  --- stderr                          
  thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Syntax(     
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     
  regex parse error:                       
      https?://[^\s)]+                                                                
                 ^^                                                                   
  error: Unicode-aware Perl class not found (make sure the unicode-perl feature is enabled)                                                                                  
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~     
  )', prost-build/src/ast.rs:98:74                                                    
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace       
```

I need to add `unicode` feature to `regex` to unblock it.