### PR TITLE
prost: Avoid double-copy on merging string from non bytes

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -843,7 +843,7 @@ pub mod string {
             }
 
             let drop_guard = DropGuard(value.as_mut_vec());
-            bytes::merge(wire_type, drop_guard.0, buf, ctx)?;
+            bytes::merge_one_copy(wire_type, drop_guard.0, buf, ctx)?;
             match str::from_utf8(drop_guard.0) {
                 Ok(_) => {
                     // Success; do not clear the bytes.
@@ -990,7 +990,33 @@ pub mod bytes {
         // > last value it sees.
         //
         // [1]: https://developers.google.com/protocol-buffers/docs/encoding#optional
+        //
+        // This is intended for A and B both being Bytes so it is zero-copy.
+        // Some combinations of A and B types may cause a double-copy,
+        // in which case merge_one_copy() should be used instead.
         value.replace_with(buf.copy_to_bytes(len));
+        Ok(())
+    }
+
+    pub(super) fn merge_one_copy<A, B>(
+        wire_type: WireType,
+        value: &mut A,
+        buf: &mut B,
+        _ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        A: BytesAdapter,
+        B: Buf,
+    {
+        check_wire_type(WireType::LengthDelimited, wire_type)?;
+        let len = decode_varint(buf)?;
+        if len > buf.remaining() as u64 {
+            return Err(DecodeError::new("buffer underflow"));
+        }
+        let len = len as usize;
+
+        // If we must copy, make sure to copy only once.
+        value.replace_with(buf.take(len));
         Ok(())
     }
 


### PR DESCRIPTION
See https://github.com/tokio-rs/prost/issues/571

The optimization in https://github.com/tokio-rs/prost/pull/449 avoids
copies when both the input and output are `Bytes`, but it can cause
double copies when neither the input nor output is `Bytes`.

This is easy to trigger by using `&[u8]` as the input buffer and merging
a `Vec<u8>` or `String`, both of which are generated by `prost-build`.

Introduce `encoding::bytes::merge_one_copy()` and use it to guarantee
that `encoding::string::merge()` copies exactly once. The new function
is only visible to the encoding module so it does not affect the API.

It would also be useful to make `prost-derive` call this for
`#[prost(bytes="vec")]`, but that may require making it public, which
is a more drastic and less justified change. It may be better to wait
for type specialization to be stabilized.