### PR TITLE
FIx: `oneof` deserializes defaulted fields

### DIFF
--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -400,7 +400,10 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
                     _ => {
                         let mut owned_value = ::core::default::Default::default();
                         let value = &mut owned_value;
-                        #merge.map(|_| *field = ::core::option::Option::Some(#ident::#variant_ident(owned_value)))
+                        #merge
+                        // We have a tag so if we don't get any value from the merge,
+                        // the contents are all defaults
+                        *field = ::core::option::Option::Some(#ident::#variant_ident(owned_value))
                     },
                 }
             }

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -400,10 +400,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
                     _ => {
                         let mut owned_value = ::core::default::Default::default();
                         let value = &mut owned_value;
-                        #merge
-                        // We have a tag so if we don't get any value from the merge,
-                        // the contents are all defaults
-                        *field = ::core::option::Option::Some(#ident::#variant_ident(owned_value))
+                        #merge.map(|_| *field = ::core::option::Option::Some(#ident::#variant_ident(owned_value)))
                     },
                 }
             }

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -71,6 +71,14 @@ fn main() {
         .unwrap();
 
     config
+        .compile_protos(&[src.join("oneof_defaults.proto")], includes)
+        .unwrap();
+
+    config
+        .compile_protos(&[src.join("oneof_defaults.proto")], includes)
+        .unwrap();
+
+    config
         .compile_protos(&[src.join("no_unused_results.proto")], includes)
         .unwrap();
 

--- a/tests/src/oneof_defaults.proto
+++ b/tests/src/oneof_defaults.proto
@@ -1,0 +1,21 @@
+syntax = "proto3";
+
+// Testing oneof default values.
+
+package oneof_defaults;
+
+message MsgRequest {
+    repeated Msg msgs = 1;
+}
+
+message Msg {
+    oneof field {
+        string a = 1;
+        PriorityLevel priority = 2;
+    }
+
+    message PriorityLevel {
+        uint32 priority_level = 1;
+        uint32 test_level = 2;
+    }
+}


### PR DESCRIPTION
This manifests itself if you send a `oneof` value where the internal contents of the message are all defaults. We still have a tag, so it should be assumed that we have an entry.

Workaround: add a `has_data` boolean field and always set the value to True in the oneof messages, thereby avoiding all fields as default.

e.g.
```protobuf
message UpsertRequest {
    fixed64 id = 1;
    repeated UpdatePayload updates = 2;
}

message UpdatePayload {
    oneof update_payload {
      UpdateA a = 1;
      UpdateB b =2;
    }

    message UpdateA { A new_a = 1; }
    message UpdateB { B new_b = 1; }
}
```

Python client state:
```python
In [15]: req.to_proto()
Out[15]: 
id: 12345
updates {
  a {
  }
}

In [16]: req.SerializeToString()
Out[16]: b'\t90\x00\x00\x00\x00\x00\x00\x12\x03\x92\x01\x00'

In [21]: UpsertRequest.FromString(s)
Out[21]: 
id: 12345
updates {
  a {
  }
}
```

Rust server
```rust
fn upsert(&self, request: Request<proto::UpsertGuildRequest>) -> Result<proto::UpsertGuildResponse> {
  let request = request.inner();
  let mut upsert = Upsert::new(request.id);
  
  for update in request.updates {
    if let Some(update_payload) = update.update_payload {
        update_payload.apply_update(&upsert);
    }
    // For the example given, if a is default values only, update_payload is None
  }
}
```