### PR TITLE
Upgrade heck dependency to v0.4

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-heck = "0.3"
+heck = "0.4"
 itertools = "0.10"
 log = "0.4"
 multimap = { version = "0.8", default-features = false }

--- a/prost-build/src/ident.rs
+++ b/prost-build/src/ident.rs
@@ -1,6 +1,6 @@
 //! Utility functions for working with identifiers.
 
-use heck::{ToUpperCamelCase, ToSnakeCase};
+use heck::{ToSnakeCase, ToUpperCamelCase};
 
 /// Converts a `camelCase` or `SCREAMING_SNAKE_CASE` identifier to a `lower_snake` case Rust field
 /// identifier.

--- a/prost-build/src/ident.rs
+++ b/prost-build/src/ident.rs
@@ -1,6 +1,6 @@
 //! Utility functions for working with identifiers.
 
-use heck::{CamelCase, SnakeCase};
+use heck::{ToUpperCamelCase, ToSnakeCase};
 
 /// Converts a `camelCase` or `SCREAMING_SNAKE_CASE` identifier to a `lower_snake` case Rust field
 /// identifier.
@@ -31,7 +31,7 @@ pub fn to_snake(s: &str) -> String {
 
 /// Converts a `snake_case` identifier to an `UpperCamel` case Rust type identifier.
 pub fn to_upper_camel(s: &str) -> String {
-    let mut ident = s.to_camel_case();
+    let mut ident = s.to_upper_camel_case();
 
     // Suffix an underscore for the `Self` Rust keyword as it is not allowed as raw identifier.
     if ident == "Self" {


### PR DESCRIPTION
There's a new version of `heck`. To prevent duplicate dependency
versions, this change updates `prost-build` to use `heck` v0.4