### PR TITLE
enable encode_to_vec for no_std

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -1,4 +1,4 @@
-use alloc::boxed::Box;
+use alloc::{boxed::Box, vec::Vec};
 use core::fmt::Debug;
 use core::usize;
 
@@ -59,7 +59,6 @@ pub trait Message: Debug + Send + Sync {
         Ok(())
     }
 
-    #[cfg(feature = "std")]
     /// Encodes the message to a newly allocated buffer.
     fn encode_to_vec(&self) -> Vec<u8>
     where
@@ -90,7 +89,6 @@ pub trait Message: Debug + Send + Sync {
         Ok(())
     }
 
-    #[cfg(feature = "std")]
     /// Encodes the message with a length-delimiter to a newly allocated buffer.
     fn encode_length_delimited_to_vec(&self) -> Vec<u8>
     where

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,4 +1,6 @@
-use alloc::{boxed::Box, vec::Vec};
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
 use core::fmt::Debug;
 use core::usize;
 


### PR DESCRIPTION
`Message::encode_to_vec` and `Message::encode_length_delimited_to_vec`, introduced in https://github.com/tokio-rs/prost/pull/378, were previously only available with `std`-enabled builds.

I can't see any reason why they shouldn't be present with `no_std` builds. So this PR makes them available to `no_std` builds as well.