### PR TITLE
Expose generation methods for buf

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -847,25 +847,32 @@ impl Config {
             )
         })?;
 
-        let requests: Vec<_> = file_descriptor_set.file.into_iter().map(|descriptor| {
-            (self.module(&descriptor), descriptor)
-        }).collect();
+        let requests: Vec<_> = file_descriptor_set
+            .file
+            .into_iter()
+            .map(|descriptor| (self.module(&descriptor), descriptor))
+            .collect();
 
-        let file_names: HashMap<Module, String> = requests.iter().map(|req| {
-            let mut file_name = if req.0.is_empty() {
-                self.default_package_filename.clone()
-            } else {
-                req.0.join(".")
-            };
+        let file_names: HashMap<Module, String> = requests
+            .iter()
+            .map(|req| {
+                let mut file_name = if req.0.is_empty() {
+                    self.default_package_filename.clone()
+                } else {
+                    req.0.join(".")
+                };
 
-            file_name.push_str(".rs");
+                file_name.push_str(".rs");
 
-            (req.0.clone(), file_name)
-        }).collect();
+                (req.0.clone(), file_name)
+            })
+            .collect();
 
         let modules = self.generate(requests)?;
         for (module, content) in &modules {
-            let file_name = file_names.get(module).expect("every module should have a filename");
+            let file_name = file_names
+                .get(module)
+                .expect("every module should have a filename");
             let output_path = target.join(file_name);
 
             let previous_content = fs::read(&output_path);
@@ -964,7 +971,10 @@ impl Config {
     /// This is generally used when control over the output should not be managed by Prost,
     /// such as in a flow for a `protoc` code generating plugin. When compiling as part of a
     /// `build.rs` file, instead use [`compile_protos()`].
-    pub fn generate(&mut self, requests: Vec<(Module, FileDescriptorProto)>) -> Result<HashMap<Module, String>> {
+    pub fn generate(
+        &mut self,
+        requests: Vec<(Module, FileDescriptorProto)>,
+    ) -> Result<HashMap<Module, String>> {
         let mut modules = HashMap::new();
         let mut packages = HashMap::new();
 

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -847,13 +847,13 @@ impl Config {
             )
         })?;
 
-        let requests: Vec<_> = file_descriptor_set
+        let requests = file_descriptor_set
             .file
             .into_iter()
             .map(|descriptor| (self.module(&descriptor), descriptor))
-            .collect();
+            .collect::<Vec<_>>();
 
-        let file_names: HashMap<Module, String> = requests
+        let file_names = requests
             .iter()
             .map(|req| {
                 let mut file_name = if req.0.is_empty() {
@@ -866,7 +866,7 @@ impl Config {
 
                 (req.0.clone(), file_name)
             })
-            .collect();
+            .collect::<HashMap<Module, String>>();
 
         let modules = self.generate(requests)?;
         for (module, content) in &modules {

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1053,7 +1053,11 @@ pub struct Module {
 
 impl Module {
     /// Construct a module path from an iterator of parts.
-    pub fn from_parts<I: IntoIterator<Item = S>, S: Into<String>>(parts: I) -> Self {
+    pub fn from_parts<I>(parts: I) -> Self
+    where
+        I: IntoIterator,
+        I::Item: Into<String>,
+    {
         Self {
             components: parts.into_iter().map(|s| s.into()).collect(),
         }

--- a/prost-build/src/message_graph.rs
+++ b/prost-build/src/message_graph.rs
@@ -15,7 +15,7 @@ pub struct MessageGraph {
 }
 
 impl MessageGraph {
-    pub fn new(files: &[FileDescriptorProto]) -> Result<MessageGraph, String> {
+    pub fn new<'a>(files: impl Iterator<Item=&'a FileDescriptorProto>) -> Result<MessageGraph, String> {
         let mut msg_graph = MessageGraph {
             index: HashMap::new(),
             graph: Graph::new(),

--- a/prost-build/src/message_graph.rs
+++ b/prost-build/src/message_graph.rs
@@ -15,7 +15,9 @@ pub struct MessageGraph {
 }
 
 impl MessageGraph {
-    pub fn new<'a>(files: impl Iterator<Item=&'a FileDescriptorProto>) -> Result<MessageGraph, String> {
+    pub fn new<'a>(
+        files: impl Iterator<Item = &'a FileDescriptorProto>,
+    ) -> Result<MessageGraph, String> {
         let mut msg_graph = MessageGraph {
             index: HashMap::new(),
             graph: Graph::new(),


### PR DESCRIPTION
This revives PR #313. With the advent of v1.0 of [buf.build](https://buf.build), the ecosystem for generating polyglot code from protobuf heavily favors the plugin model. It very easily slots into the `buf generate` model. This revival creates a distinct `protoc-gen-prost` crate to host the binary, rather than the prior method of putting the binary in the `prost-build` crate. This makes installation using `cargo install protoc-gen-prost` more convenient.

In my opinion, Prost would benefit from integrating into this model, so I wanted to revive the old protoc plugin. Even with this very basic PR (which doesn't handle options), I have confirmed that puting the binary onto the `PATH` and running `buf generate` results in precisely the Rust code I would expect over a somewhat complicated hierarchy of protobuf files.