### PR TITLE
fix edition 2021 clippy errors

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -71,7 +71,7 @@ impl<'a> CodeGenerator<'a> {
 
         let mut code_gen = CodeGenerator {
             config,
-            package: file.package.unwrap_or_else(String::new),
+            package: file.package.unwrap_or_default(),
             source_info,
             syntax,
             message_graph,

--- a/prost-build/src/path.rs
+++ b/prost-build/src/path.rs
@@ -118,6 +118,7 @@ fn sub_path_iter(full_path: &str) -> impl Iterator<Item = &str> {
 /// Example: prefixes(".a.b.c.d") -> [".a.b.c", ".a.b", ".a"]
 fn prefixes(fq_path: &str) -> impl Iterator<Item = &str> {
     std::iter::successors(Some(fq_path), |path| {
+        #[allow(unknown_lints)]
         #[allow(clippy::manual_split_once)]
         path.rsplitn(2, '.').nth(1).filter(|path| !path.is_empty())
     })
@@ -130,6 +131,7 @@ fn prefixes(fq_path: &str) -> impl Iterator<Item = &str> {
 /// Example: suffixes(".a.b.c.d") -> ["a.b.c.d", "b.c.d", "c.d", "d"]
 fn suffixes(fq_path: &str) -> impl Iterator<Item = &str> {
     std::iter::successors(Some(fq_path), |path| {
+        #[allow(unknown_lints)]
         #[allow(clippy::manual_split_once)]
         path.splitn(2, '.').nth(1).filter(|path| !path.is_empty())
     })

--- a/prost-build/src/path.rs
+++ b/prost-build/src/path.rs
@@ -118,8 +118,7 @@ fn sub_path_iter(full_path: &str) -> impl Iterator<Item = &str> {
 /// Example: prefixes(".a.b.c.d") -> [".a.b.c", ".a.b", ".a"]
 fn prefixes(fq_path: &str) -> impl Iterator<Item = &str> {
     std::iter::successors(Some(fq_path), |path| {
-        #[allow(unknown_lints)]
-        #[allow(clippy::manual_split_once)]
+        #[allow(unknown_lints, clippy::manual_split_once)]
         path.rsplitn(2, '.').nth(1).filter(|path| !path.is_empty())
     })
     .skip(1)
@@ -131,8 +130,7 @@ fn prefixes(fq_path: &str) -> impl Iterator<Item = &str> {
 /// Example: suffixes(".a.b.c.d") -> ["a.b.c.d", "b.c.d", "c.d", "d"]
 fn suffixes(fq_path: &str) -> impl Iterator<Item = &str> {
     std::iter::successors(Some(fq_path), |path| {
-        #[allow(unknown_lints)]
-        #[allow(clippy::manual_split_once)]
+        #[allow(unknown_lints, clippy::manual_split_once)]
         path.splitn(2, '.').nth(1).filter(|path| !path.is_empty())
     })
     .skip(1)

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -319,7 +319,7 @@ impl Field {
         };
         match &self.value_ty {
             ValueTy::Scalar(ty) => {
-                if let &scalar::Ty::Bytes(_) = ty {
+                if let scalar::Ty::Bytes(_) = *ty {
                     return quote! {
                         struct #wrapper_name<'a>(&'a dyn ::core::fmt::Debug);
                         impl<'a> ::core::fmt::Debug for #wrapper_name<'a> {

--- a/tests/src/default_enum_value.proto
+++ b/tests/src/default_enum_value.proto
@@ -1,4 +1,4 @@
-// From https://github.com/danburkert/prost/issues/118
+// From https://github.com/tokio-rs/prost/issues/118
 
 syntax = "proto2";
 


### PR DESCRIPTION
This handles clippy errors that showed up when switching over
to edition 2021. Note that we can't move to use edition 2021 until
the MSRV is set to 1.56. See https://github.com/tokio-rs/prost/issues/553 for
more details.