### PR TITLE
upgrade regex crate to avoid security issue

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -23,7 +23,7 @@ prost = { version = "0.9.0", path = "..", default-features = false }
 prost-types = { version = "0.9.0", path = "../prost-types", default-features = false }
 tempfile = "3"
 lazy_static = "1.4.0"
-regex = { version = "1.5.4", default-features = false, features = ["std"] }
+regex = { version = "1.5.5", default-features = false, features = ["std"] }
 
 [build-dependencies]
 which = { version = "4", default-features = false }


### PR DESCRIPTION
```
Crate:         regex
Version:       1.5.4
Title:         Regexes with large repetitions on empty sub-expressions take a very long time to parse
Date:          2022-03-08
ID:            RUSTSEC-2022-0013
URL:           https://rustsec.org/advisories/RUSTSEC-2022-0013
Solution:      Upgrade to >=1.5.5
```