### PR TITLE
chore: update regex dependency

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -23,7 +23,7 @@ prost = { version = "0.9.0", path = "..", default-features = false }
 prost-types = { version = "0.9.0", path = "../prost-types", default-features = false }
 tempfile = "3"
 lazy_static = "1.4.0"
-regex = { version = "1.5.4", default-features = false, features = ["std"] }
+regex = { version = "1.5.5", default-features = false, features = ["std", "unicode-bool"] }
 
 [build-dependencies]
 which = { version = "4", default-features = false }


### PR DESCRIPTION
This also adds the `unicode-bool` feature required by the `\s` regular expression character class. `unicode-bool` is a more minimal feature than `unicode-bool`. Without either of these features on the `regex` crate, testing `prost-build` will fail.

`regex` crate is updated to 1.5.5 due to [RUSTSEC-2022-0013](https://rustsec.org/advisories/RUSTSEC-2022-0013) security advisory on versions 1.5.4 and lower.