### PR TITLE
Fix hyperlinks in doc

### DIFF
--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -32,6 +32,7 @@ impl Duration {
     /// Normalizes the duration to a canonical format.
     ///
     /// Based on [`google::protobuf::util::CreateNormalized`][1].
+    ///
     /// [1]: https://github.com/google/protobuf/blob/v3.3.2/src/google/protobuf/util/time_util.cc#L79-L100
     pub fn normalize(&mut self) {
         // Make sure nanos is in the range.
@@ -125,6 +126,7 @@ impl Timestamp {
     /// Normalizes the timestamp to a canonical format.
     ///
     /// Based on [`google::protobuf::util::CreateNormalized`][1].
+    ///
     /// [1]: https://github.com/google/protobuf/blob/v3.3.2/src/google/protobuf/util/time_util.cc#L59-L77
     #[cfg(feature = "std")]
     pub fn normalize(&mut self) {


### PR DESCRIPTION
There are two broken hyperlinks ([first](https://docs.rs/prost-types/latest/prost_types/struct.Duration.html#method.normalize), [second](https://docs.rs/prost-types/latest/prost_types/struct.Timestamp.html#method.normalize)) in the documentation of the `normalize` functions for `Duration` and `Timestamp` in `prost-types` due to a missing empty line. This PR fixes them.

When rendered with `cargo doc`

Before: 

> Normalizes the timestamp to a canonical format.
> 
> Based on \[`google::protobuf::util::CreateNormalized`\]\[1\]. \[1\]: https://github.com/google/protobuf/blob/v3.3.2/src/google/protobuf/util/time_util.cc#L59-L77

After:

> Normalizes the timestamp to a canonical format.
>
> Based on [google::protobuf::util::CreateNormalized][1] 
>
> [1]: https://github.com/google/protobuf/blob/v3.3.2/src/google/protobuf/util/time_util.cc#L59-L77