### PR TITLE
feat: implement Ord and PartialOrd for Module

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1061,7 +1061,7 @@ impl fmt::Debug for Config {
 }
 
 /// A Rust module path for a Protobuf package.
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Module {
     components: Vec<String>,
 }

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1092,7 +1092,7 @@ impl Module {
         }
     }
 
-    /// An iterator over the parts of the path
+    /// An iterator over the parts of the path.
     pub fn parts(&self) -> impl Iterator<Item = &str> {
         self.components.iter().map(|s| s.as_str())
     }
@@ -1115,6 +1115,11 @@ impl Module {
     /// The number of parts in the module's path.
     pub fn len(&self) -> usize {
         self.components.len()
+    }
+
+    /// Whether the module's path contains any components.
+    pub fn is_empty(&self) -> bool {
+        self.components.is_empty()
     }
 
     fn to_partial_file_name(&self, range: RangeToInclusive<usize>) -> String {

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1061,7 +1061,7 @@ impl fmt::Debug for Config {
 }
 
 /// A Rust module path for a Protobuf package.
-#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Module {
     components: Vec<String>,
 }
@@ -1123,6 +1123,20 @@ impl Module {
 
     fn part(&self, idx: usize) -> &str {
         self.components[idx].as_str()
+    }
+}
+
+impl fmt::Display for Module {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let mut parts = self.parts();
+        if let Some(first) = parts.next() {
+            f.write_str(first)?;
+        }
+        for part in parts {
+            f.write_str("::")?;
+            f.write_str(part)?;
+        }
+        Ok(())
     }
 }
 


### PR DESCRIPTION
This allows a consumer to use `Module` as the key in a `BTreeMap` in addition to a `HashMap`.