### PR TITLE
Prepare 0.10 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Tokio Contributors <team@tokio.rs>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ std = []
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-prost-derive = { version = "0.9.0", path = "prost-derive", optional = true }
+prost-derive = { version = "0.10.0", path = "prost-derive", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ First, add `prost` and its public dependencies to your `Cargo.toml`:
 
 ```
 [dependencies]
-prost = "0.9"
+prost = "0.10"
 # Only necessary if using Protobuf well-known types:
-prost-types = "0.9"
+prost-types = "0.10"
 ```
 
 The recommended way to add `.proto` compilation to a Cargo project is to use the

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -23,8 +23,8 @@ itertools = "0.10"
 log = "0.4"
 multimap = { version = "0.8", default-features = false }
 petgraph = { version = "0.6", default-features = false }
-prost = { version = "0.9.0", path = "..", default-features = false }
-prost-types = { version = "0.9.0", path = "../prost-types", default-features = false }
+prost = { version = "0.10.0", path = "..", default-features = false }
+prost-types = { version = "0.10.0", path = "../prost-types", default-features = false }
 tempfile = "3"
 lazy_static = "1.4.0"
 regex = { version = "1.5.5", default-features = false, features = ["std", "unicode-bool"] }

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost-build"
-version = "0.9.1"
+version = "0.10.0"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Tokio Contributors <team@tokio.rs>",

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-build/0.9.1")]
+#![doc(html_root_url = "https://docs.rs/prost-build/0.10.0")]
 #![allow(clippy::option_as_ref_deref)]
 
 //! `prost-build` compiles `.proto` files into Rust.

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost-derive"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Tokio Contributors <team@tokio.rs>",

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-derive/0.9.0")]
+#![doc(html_root_url = "https://docs.rs/prost-derive/0.10.0")]
 // The `quote!` macro requires deep recursion.
 #![recursion_limit = "4096"]
 

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost-types"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Tokio Contributors <team@tokio.rs>",

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -21,7 +21,7 @@ std = ["prost/std"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-prost = { version = "0.9.0", path = "..", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.10.0", path = "..", default-features = false, features = ["prost-derive"] }
 
 [dev-dependencies]
 proptest = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost/0.9.0")]
+#![doc(html_root_url = "https://docs.rs/prost/0.10.0")]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 // Re-export the alloc crate for use within derived code.


### PR DESCRIPTION
# Release Notes

 _PROST!_ is a [Protocol Buffers](https://developers.google.com/protocol-buffers/) implementation for the [Rust Language](https://www.rust-lang.org/). `prost` generates simple, idiomatic Rust code from `proto2` and `proto3` files.

Release 0.10 brings a few new ....

- `protoc` is no longer bundled but is now compiled from bundled source
- Minor performance improvements
- Methods exposed to allow third party protobuf generation libraries