### PR TITLE
Remove cmake

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -138,3 +138,11 @@ jobs:
       - name: cargo check
         run: cd test-vendored && cargo check
 
+  deny:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "prost-build/third-party/protobuf"]
 	path = prost-build/third-party/protobuf
-	url = git@github.com:protocolbuffers/protobuf
+	url = https://github.com/protocolbuffers/protobuf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost"
-version = "0.10.1"
+version = "0.10.3"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Tokio Contributors <team@tokio.rs>",

--- a/deny.toml
+++ b/deny.toml
@@ -1,3 +1,9 @@
+[advisories]
+ignore = [
+    # serde_cbor is unmaintained, but brought in by criterion
+    "RUSTSEC-2021-0127",
+]
+
 [licenses]
 allow = ["Apache-2.0", "MIT", "BSD-3-Clause"]
 

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,11 @@
+[licenses]
+allow = ["Apache-2.0", "MIT", "BSD-3-Clause"]
+
+[bans]
+deny = [{ name = "cmake" }]
+skip = [
+    # old csv via old criterion
+    { name = "itoa", version = "=0.4.8" },
+    # Proptest includes 2 version :(
+    { name = "quick-error", version = "=1.2.3" },
+]

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -30,9 +30,9 @@ lazy_static = "1.4.0"
 regex = { version = "1.5.5", default-features = false, features = ["std", "unicode-bool"] }
 
 [build-dependencies]
-which = { version = "4", default-features = false }
+cc = { version = "1.0", features = ["parallel"] }
 cfg-if = "1"
-cmake = "0.1"
+which = { version = "4", default-features = false }
 
 [dev-dependencies]
 env_logger = { version = "0.8", default-features = false }

--- a/prost-build/build.rs
+++ b/prost-build/build.rs
@@ -144,7 +144,11 @@ fn compile(stub: bool) -> Option<PathBuf> {
             );
 
             if env::var("CARGO_CFG_TARGET_FAMILY").as_deref() == Ok("windows") {
-                build.file(protobuf_src.join("io/io_win32.cc"));
+                build.files(
+                    ["io/io_win32.cc", "stubs/status.cc"]
+                        .iter()
+                        .map(|fname| protobuf_src.join(fname)),
+                );
             }
         }
 

--- a/prost-build/build.rs
+++ b/prost-build/build.rs
@@ -142,6 +142,10 @@ fn compile(stub: bool) -> Option<PathBuf> {
                 .iter()
                 .map(|fname| protobuf_src.join(fname)),
             );
+
+            if env::var("CARGO_CFG_TARGET_FAMILY").as_deref() == Ok("windows") {
+                build.file(protobuf_src.join("io/io_win32.cc"));
+            }
         }
 
         if stub {

--- a/prost-build/build.rs
+++ b/prost-build/build.rs
@@ -91,6 +91,7 @@ fn compile() -> Option<PathBuf> {
         // intention of changing
         if !build.get_compiler().is_like_msvc() {
             build
+                .flag("-std=c++11")
                 .flag("-Wno-unused-parameter")
                 .flag("-Wno-redundant-move")
                 .flag("-Wno-sign-compare")

--- a/prost-build/build.rs
+++ b/prost-build/build.rs
@@ -93,7 +93,8 @@ fn compile() -> Option<PathBuf> {
             build
                 .flag("-Wno-unused-parameter")
                 .flag("-Wno-redundant-move")
-                .flag("-Wno-sign-compare");
+                .flag("-Wno-sign-compare")
+                .flag("-Wno-stringop-overflow");
         }
 
         build.includes(&[bundle_path().join("protobuf/src")]);

--- a/prost-build/build.rs
+++ b/prost-build/build.rs
@@ -96,7 +96,7 @@ fn compile() -> Option<PathBuf> {
                 .flag("-Wno-sign-compare");
         }
 
-        build.includes([bundle_path().join("protobuf/src")]);
+        build.includes(&[bundle_path().join("protobuf/src")]);
 
         build.files(
             [

--- a/prost-build/build.rs
+++ b/prost-build/build.rs
@@ -145,7 +145,7 @@ fn compile(stub: bool) -> Option<PathBuf> {
 
             if env::var("CARGO_CFG_TARGET_FAMILY").as_deref() == Ok("windows") {
                 build.files(
-                    ["io/io_win32.cc", "stubs/status.cc"]
+                    ["io/io_win32.cc", "stubs/int128.cc", "stubs/status.cc"]
                         .iter()
                         .map(|fname| protobuf_src.join(fname)),
                 );

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -986,7 +986,7 @@ impl Config {
                         p.as_ref()
                             .as_os_str()
                             .encode_wide()
-                            .flatten(|c| [((c & 0xff00) >> 8) as u8, c & 0xff])
+                            .flat_map(|c| [((c & 0xff00) >> 8) as u8, c & 0xff])
                             .collect::<Vec<_>>()
                             .into()
                     })

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1004,12 +1004,15 @@ impl Config {
             #[cfg(windows)]
             {
                 use std::os::windows::ffi::OsStrExt;
-                path.as_ref()
-                    .as_os_str()
-                    .encode_wide()
-                    .flat_map(|c| [((c & 0xff00) >> 8) as u8, (c & 0xff) as u8].into_iter())
-                    .collect::<Vec<_>>()
-                    .into()
+                let os_str = path.as_ref().as_os_str();
+                let mut pv = Vec::with_capacity(os_str.len() * 2);
+
+                for c in os_str.encode_wide() {
+                    pv.push(((c & 0xff00) >> 8) as u8);
+                    pv.push((c & 0xff) as u8);
+                }
+
+                pv.into()
             }
         }
 

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1007,7 +1007,7 @@ impl Config {
                 path.as_ref()
                     .as_os_str()
                     .encode_wide()
-                    .flat_map(|c| [((c & 0xff00) >> 8) as u8, (c & 0xff) as u8])
+                    .flat_map(|c| [((c & 0xff00) >> 8) as u8, (c & 0xff) as u8].into_iter())
                     .collect::<Vec<_>>()
                     .into()
             }

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1007,7 +1007,7 @@ impl Config {
                 path.as_ref()
                     .as_os_str()
                     .encode_wide()
-                    .flat_map(|c| [((c & 0xff00) >> 8) as u8, c & 0xff])
+                    .flat_map(|c| [((c & 0xff00) >> 8) as u8, (c & 0xff) as u8])
                     .collect::<Vec<_>>()
                     .into()
             }

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1003,6 +1003,7 @@ impl Config {
 
             #[cfg(windows)]
             {
+                use std::os::windows::ffi::OsStrExt;
                 path.as_ref()
                     .as_os_str()
                     .encode_wide()

--- a/prost-build/src/libprotoc.cpp
+++ b/prost-build/src/libprotoc.cpp
@@ -336,8 +336,6 @@ extern "C" {
             source_tree->MapPath("", include);
         }
 
-        // Map input files to virtual paths if possible. I'm not sure if this
-        // is even needed since as stated prost really doesn't do virtual paths
         if (!make_inputs_relative(&inputs, source_tree.get())) {
             return 1;
         }

--- a/prost-build/src/libprotoc.cpp
+++ b/prost-build/src/libprotoc.cpp
@@ -1,0 +1,348 @@
+#include <stdio.h>
+#include <string>
+#include <vector>
+
+#include <google/protobuf/compiler/importer.h>
+#include <google/protobuf/descriptor.h>
+#include <google/protobuf/descriptor_database.h>
+#include <google/protobuf/io/coded_stream.h>
+#include <google/protobuf/io/tokenizer.h>
+#include <google/protobuf/repeated_field.h>
+#include <google/protobuf/stubs/stringpiece.h>
+
+#include <google/protobuf/port_def.inc>
+
+
+
+extern "C" {
+    // Small and simple and FFI safe, unlike `StringPiece`
+    struct Path {
+        const char* path;
+        size_t len;
+    };
+
+    typedef void* (*resize)(void*, size_t);
+    typedef size_t (*capacity)(void*);
+
+    // Simple buffer wrapper so that we can write directly to memory allocated
+    // in Rust
+    struct Buffer {
+        resize      resize_buffer;
+        capacity    buffer_capacity;
+        void*       context;
+    };
+}
+
+using google::protobuf::FileDescriptor;
+using google::protobuf::FileDescriptorSet;
+using google::protobuf::DescriptorPool;
+using google::protobuf::MergedDescriptorDatabase;
+using google::protobuf::Message;
+using google::protobuf::FileDescriptorProto;
+using google::protobuf::RepeatedPtrField;
+
+using google::protobuf::compiler::DiskSourceTree;
+using google::protobuf::compiler::SourceTreeDescriptorDatabase;
+
+// Port of CommandLineInterface::ParseInputFiles
+bool parse_input_files(
+    const std::vector<std::string>& input_files,
+    DescriptorPool* descriptor_pool,
+    std::vector<const FileDescriptor*>* parsed_files
+) {
+    for (const auto& input : input_files) {
+        // Import the file.
+        const FileDescriptor* parsed_file = descriptor_pool->FindFileByName(input);
+        if (parsed_file == nullptr) {
+            return false;
+        }
+        parsed_files->push_back(parsed_file);
+    }
+
+    return true;
+}
+
+bool make_inputs_relative(std::vector<std::string>* inputs, DiskSourceTree* source_tree) {
+    for (auto& input_file : *inputs) {
+        std::string virtual_file, shadowing_disk_file;
+
+        auto mapping = source_tree->DiskFileToVirtualFile(
+            input_file,
+            &virtual_file,
+            &shadowing_disk_file);
+
+        switch (mapping) {
+            case DiskSourceTree::SUCCESS: {
+                input_file = virtual_file;
+                break;
+            }
+            case DiskSourceTree::SHADOWED: {
+                fprintf(stderr, "%s: Input is shadowed by an include in \"%s\"."
+                    "Either use the latter file as your input or reorder the"
+                    "includes so that the former file's location comes first.\n",
+                    input_file.c_str(), shadowing_disk_file.c_str()
+                );
+                return false;
+            }
+            case DiskSourceTree::CANNOT_OPEN: {
+                auto error_str = source_tree->GetLastErrorMessage().empty()
+                                  ? strerror(errno)
+                                  : source_tree->GetLastErrorMessage();
+                fprintf(stderr, "Could not map to virtual file: %s: %s\n", input_file.c_str(), error_str.c_str());
+                return false;
+            }
+            case DiskSourceTree::NO_MAPPING: {
+                // Try to interpret the path as a virtual path.
+                std::string disk_file;
+                if (source_tree->VirtualFileToDiskFile(input_file, &disk_file)) {
+                    return true;
+                } else {
+                    // The input file path can't be mapped to any --proto_path and it also
+                    // can't be interpreted as a virtual path.
+                    fprintf(stderr, "%s: File does not reside within any include path.\n", input_file.c_str());
+                    return false;
+                }
+            }
+        }
+    }
+
+    return true;
+}
+
+void get_transitive_deps(
+    const FileDescriptor* file,
+    bool include_json_name,
+    bool include_source_code_info,
+    std::set<const FileDescriptor*>* already_seen,
+    RepeatedPtrField<FileDescriptorProto>* output
+) {
+    if (!already_seen->insert(file).second) {
+        return;
+    }
+
+    for (int i = 0; i < file->dependency_count(); i++) {
+        get_transitive_deps(
+            file->dependency(i),
+            include_json_name,
+            include_source_code_info,
+            already_seen,
+            output
+        );
+    }
+
+    FileDescriptorProto* new_descriptor = output->Add();
+    file->CopyTo(new_descriptor);
+    if (include_json_name) {
+        file->CopyJsonNameTo(new_descriptor);
+    }
+    if (include_source_code_info) {
+        file->CopySourceCodeInfoTo(new_descriptor);
+    }
+}
+
+class BufferOutput : public google::protobuf::io::ZeroCopyOutputStream {
+public:
+    Buffer* impl;
+    void* buffer_base = nullptr;
+    size_t len = 0;
+
+    BufferOutput(Buffer* impl) : impl(impl) {}
+
+    bool Next(void** data, int* size) final {
+        size_t old_size = this->len;
+        size_t cur_cap = this->impl->buffer_capacity(this->impl->context);
+
+        size_t new_size;
+        if (old_size < cur_cap) {
+            new_size = cur_cap;
+        } else {
+            new_size = old_size * 2;
+        }
+
+        // Avoid integer overflow in returned '*size'.
+        new_size = std::min(new_size, old_size + std::numeric_limits<int>::max());
+        this->buffer_base = this->impl->resize_buffer(this->impl->context, new_size);
+
+        *data = ((uint8_t*)buffer_base + old_size);
+        *size = new_size - old_size;
+        this->len = new_size;
+
+        return true;
+    }
+
+    void BackUp(int count) final {
+        this->buffer_base = this->impl->resize_buffer(this->impl->context, this->len - count);
+    }
+
+    int64_t ByteCount() const final {
+        return this->len;
+    }
+};
+
+bool write_descriptor_set(const std::vector<const FileDescriptor*>& parsed_files, Buffer* output) {
+    FileDescriptorSet file_set;
+
+    std::set<const FileDescriptor*> already_seen;
+
+    for (const auto& parsed : parsed_files) {
+        get_transitive_deps(
+            parsed,
+            true,  // Include json_name
+            true, // Include source info, prost requires this
+            &already_seen,
+            file_set.mutable_file()
+        );
+    }
+
+    {
+        BufferOutput zero_copy_stream(output);
+        google::protobuf::io::CodedOutputStream coded_out(&zero_copy_stream);
+
+        // Determinism is useful here because build outputs are sometimes checked
+        // into version control.
+        coded_out.SetSerializationDeterministic(true);
+        if (!file_set.SerializeToCodedStream(&coded_out)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+// A MultiFileErrorCollector that prints errors to stderr.
+class ErrorPrinter
+    : public google::protobuf::compiler::MultiFileErrorCollector
+    , public google::protobuf::io::ErrorCollector
+    , public DescriptorPool::ErrorCollector {
+public:
+    ErrorPrinter(DiskSourceTree* tree = nullptr)
+      : tree_(tree),
+        found_errors_(false),
+        found_warnings_(false) {}
+  ~ErrorPrinter() {}
+
+    // implements MultiFileErrorCollector ------------------------------
+    void AddError(  const std::string& filename, int line, int column,
+                    const std::string& message) override {
+        found_errors_ = true;
+        AddErrorOrWarning(filename, line, column, message, "error", std::cerr);
+    }
+
+    void AddWarning(const std::string& filename, int line, int column,
+                    const std::string& message) override {
+        found_warnings_ = true;
+        AddErrorOrWarning(filename, line, column, message, "warning", std::clog);
+    }
+
+    // implements io::ErrorCollector -----------------------------------
+    void AddError(int line, int column, const std::string& message) final {
+        AddError("input", line, column, message);
+    }
+
+    void AddWarning(int line, int column, const std::string& message) final {
+        AddErrorOrWarning("input", line, column, message, "warning", std::clog);
+    }
+
+    // implements DescriptorPool::ErrorCollector-------------------------
+    void AddError(  const std::string& filename, const std::string& element_name,
+                    const Message* descriptor, ErrorLocation location,
+                    const std::string& message) override {
+        AddErrorOrWarning(filename, -1, -1, message, "error", std::cerr);
+    }
+
+    void AddWarning(const std::string& filename, const std::string& element_name,
+                    const Message* descriptor, ErrorLocation location,
+                    const std::string& message) final {
+        AddErrorOrWarning(filename, -1, -1, message, "warning", std::clog);
+    }
+
+    bool FoundErrors() const { return found_errors_; }
+
+    bool FoundWarnings() const { return found_warnings_; }
+
+private:
+    void AddErrorOrWarning( const std::string& filename, int line, int column,
+                            const std::string& message, const std::string& type,
+                            std::ostream& out) {
+        out << filename;
+
+        // Users typically expect 1-based line/column numbers, so we add 1
+        // to each here.
+        if (line != -1) {
+            out << ":" << (line + 1) << ":" << (column + 1);
+        }
+
+        if (type == "warning") {
+            out << ": warning: " << message << std::endl;
+        } else {
+            out << ": " << message << std::endl;
+        }
+    }
+
+    DiskSourceTree* tree_;
+    bool found_errors_;
+    bool found_warnings_;
+};
+
+extern "C" {
+    int write_descriptor_set(
+        const Path* input_files,
+        size_t num_inputs,
+        const Path* includes_paths,
+        size_t num_includes,
+        Buffer* output
+    ) {
+        // We're forced to reallocate these because some of the following APIs
+        // only take std::string :p
+        std::vector<std::string> inputs(num_inputs);
+        // I'm sure there's some fancier way to initialize this these days but I
+        // prefer to keep the C++ as dumb as possible
+        for (size_t i = 0; i < num_inputs; ++i) {
+            inputs.push_back(std::string(input_files[i].path, input_files[i].len));
+        }
+
+        std::vector<std::string> includes(num_includes);
+        for (size_t i = 0; i < num_includes; ++i) {
+            includes.push_back(std::string(includes_paths[i].path, includes_paths[i].len));
+        }
+
+        // Port of CommandLineInterface::InitializeDiskSourceTree
+        std::unique_ptr<DiskSourceTree> source_tree(new DiskSourceTree());
+        std::unique_ptr<MergedDescriptorDatabase> descriptor_set_in_database;
+
+        // Set up the source tree. Note that the way prost uses protoc, virtual
+        // paths would only be possible if the user is explicitly sending their
+        // own -I args with the ':/;' separated virtual path. I seriously doubt
+        // this happens in practice. (famous last words)
+        for (const auto& include : includes) {
+            source_tree->MapPath(include, "");
+        }
+
+        // Map input files to virtual paths if possible. I'm not sure if this
+        // is even needed since as stated prost really doesn't do virtual paths
+        if (!make_inputs_relative(&inputs, source_tree.get())) {
+            return 1;
+        }
+
+        std::unique_ptr<ErrorPrinter> error_collector(new ErrorPrinter(source_tree.get()));
+        std::unique_ptr<SourceTreeDescriptorDatabase> source_tree_database(
+            new SourceTreeDescriptorDatabase(source_tree.get(), descriptor_set_in_database.get()));
+        source_tree_database->RecordErrorsTo(error_collector.get());
+        std::unique_ptr<DescriptorPool> descriptor_pool(new DescriptorPool(
+            source_tree_database.get(),
+            source_tree_database->GetValidationErrorCollector()));
+        descriptor_pool->EnforceWeakDependencies(true);
+
+        // Try to actually parse all of our inputs, if this
+        std::vector<const FileDescriptor*> parsed(inputs.size());
+        if (!parse_input_files(inputs, descriptor_pool.get(), &parsed)) {
+            return 1;
+        }
+
+        if (!write_descriptor_set(parsed, output)) {
+            return 1;
+        }
+
+        return 0;
+    }
+}

--- a/prost-build/src/libprotoc.cpp
+++ b/prost-build/src/libprotoc.cpp
@@ -1,4 +1,6 @@
 #include <stdio.h>
+
+#ifndef STUB_ONLY
 #include <string>
 #include <vector>
 
@@ -11,8 +13,7 @@
 #include <google/protobuf/stubs/stringpiece.h>
 
 #include <google/protobuf/port_def.inc>
-
-
+#endif // STUB_ONLY
 
 extern "C" {
     // Small and simple and FFI safe, unlike `StringPiece`
@@ -31,8 +32,24 @@ extern "C" {
         capacity    buffer_capacity;
         void*       context;
     };
+
+    #ifdef STUB_ONLY
+    // Expose a function that always fails in case the user has configured
+    // the `vendored` feature, but has also set the `PROTOC_NO_VENDOR`
+    // env var, meaning we still need to link the lib, but it won't actually be used
+    int write_descriptor_set(
+        const Path* input_files,
+        size_t num_inputs,
+        const Path* includes_paths,
+        size_t num_includes,
+        Buffer* output
+    ) {
+        return 1;
+    }
+    #endif // STUB_ONLY
 }
 
+#ifndef STUB_ONLY
 using google::protobuf::FileDescriptor;
 using google::protobuf::FileDescriptorSet;
 using google::protobuf::DescriptorPool;
@@ -316,7 +333,7 @@ extern "C" {
         // own -I args with the ':/;' separated virtual path. I seriously doubt
         // this happens in practice. (famous last words)
         for (const auto& include : includes) {
-            source_tree->MapPath(include, "");
+            source_tree->MapPath("", include);
         }
 
         // Map input files to virtual paths if possible. I'm not sure if this
@@ -348,3 +365,4 @@ extern "C" {
         return 0;
     }
 }
+#endif // STUB_ONLY

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -2,7 +2,11 @@
 //!
 //! Meant to be used only from `Message` implementations.
 
-#![allow(clippy::implicit_hasher, clippy::ptr_arg)]
+#![allow(
+    clippy::implicit_hasher,
+    clippy::ptr_arg,
+    clippy::manual_range_contains
+)]
 
 use alloc::collections::BTreeMap;
 use alloc::format;

--- a/tests/single-include/Cargo.toml
+++ b/tests/single-include/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 license = "MIT"
 
 [dependencies]
-prost = { path = "../../../prost" }
+prost = { path = "../.." }
 
 [build-dependencies]
 prost-build = { path = "../../prost-build" }


### PR DESCRIPTION
We noticed due to https://github.com/hyperium/tonic/issues/965 that `cmake` was now a dependency for tonic via prost. We've had cmake banned for quite a while since it is terrible, so I started working on a PR to make prost-build use cc to build protoc instead. However, upon investigation I quickly realized that building and shelling out to protoc is _massive_ overkill for prost's usage, which essentially just boils down to getting a list of the input files and all of their imports. Protoc by contrast includes support for generating multiple different languages (none of which prost uses) and plugin support (again, something that prost doesn't use), so I instead just reimplemented the small part of the command line tool that prost actually depended on into a single C function that is now linked with prost-build, and when compile_protos is called, just invokes that C function to get the output.

### Pros

- No cmake
- Only compiles the minimum amount of C++ code that is actually needed to write the file descriptor set, so the build is significantly faster than compiling the protoc binary
- No shelling out to a separate program and using the filesystem to read/write the output

### Cons

- This does the _one_ thing that "vanilla" prost-build does, so usage of additional protoc arguments that people may be depending on won't do anything. I consider this fine since in those more advances use cases, you can just use an installed protoc compiler.
- Added C++ code. I felt bad while doing it.
- Unsafe, of course, to talk with the C code.

### Other options

- There already exists a Rust native way to read generate FileDescriptorSets at https://github.com/stepancheg/rust-protobuf/tree/master/protobuf-parse, it states that it might not be fully feature complete compared to protoc, but I think it would be fairly trivial to fix any issues there and instead use pure Rust code, allowing prost to completely remove the protobuf code altogether.