### PR TITLE
impl Duration::{Display, FromStr} with protobuf format

### DIFF
--- a/prost-types/src/datetime.rs
+++ b/prost-types/src/datetime.rs
@@ -340,7 +340,7 @@ fn parse_digits(s: &str) -> (&str, &str) {
         .as_bytes()
         .iter()
         .position(|c| !c.is_ascii_digit())
-        .unwrap_or_else(|| s.len());
+        .unwrap_or(s.len());
     s.split_at(idx)
 }
 

--- a/prost-types/src/datetime.rs
+++ b/prost-types/src/datetime.rs
@@ -3,6 +3,7 @@
 
 use core::fmt;
 
+use crate::Duration;
 use crate::Timestamp;
 
 /// A point in time, represented as a date and time in the UTC timezone.
@@ -247,6 +248,16 @@ fn parse_time(s: &str) -> Option<(u8, u8, u8, u32, &str)> {
     let s = parse_char(s, b':')?;
     let (second, s) = parse_two_digit_numeric(s)?;
 
+    let (nanos, s) = parse_nanos(s)?;
+
+    Some((hour, minute, second, nanos, s))
+}
+
+/// Parses an optional nanosecond time from ASCII string `s`, returning the nanos and remaining
+/// string.
+fn parse_nanos(s: &str) -> Option<(u32, &str)> {
+    debug_assert!(s.is_ascii());
+
     // Parse the nanoseconds, if present.
     let (nanos, s) = if let Some(s) = parse_char(s, b'.') {
         let (digits, s) = parse_digits(s);
@@ -257,7 +268,7 @@ fn parse_time(s: &str) -> Option<(u8, u8, u8, u32, &str)> {
         (0, s)
     };
 
-    Some((hour, minute, second, nanos, s))
+    Some((nanos, s))
 }
 
 /// Parses a timezone offset in RFC 3339 format from ASCII string `s`, returning the offset hour,
@@ -528,6 +539,40 @@ pub(crate) fn parse_timestamp(s: &str) -> Option<Timestamp> {
     Some(Timestamp { seconds, nanos })
 }
 
+/// Parse a duration in the [Protobuf JSON encoding spec format][1].
+///
+/// [1]: https://developers.google.com/protocol-buffers/docs/proto3#json
+pub(crate) fn parse_duration(s: &str) -> Option<Duration> {
+    // Check that the string is ASCII, since subsequent parsing steps use byte-level indexing.
+    ensure!(s.is_ascii());
+
+    let (is_negative, s) = match parse_char(s, b'-') {
+        Some(s) => (true, s),
+        None => (false, s),
+    };
+
+    let (digits, s) = parse_digits(s);
+    let seconds = digits.parse::<i64>().ok()?;
+
+    let (nanos, s) = parse_nanos(s)?;
+
+    let s = parse_char(s, b's')?;
+    ensure!(s.is_empty());
+    ensure!(nanos < crate::NANOS_PER_SECOND as u32);
+
+    // If the duration is negative, also flip the nanos sign.
+    let (seconds, nanos) = if is_negative {
+        (-seconds, -(nanos as i32))
+    } else {
+        (seconds, nanos as i32)
+    };
+
+    Some(Duration {
+        seconds,
+        nanos: nanos as i32,
+    })
+}
+
 impl From<DateTime> for Timestamp {
     fn from(date_time: DateTime) -> Timestamp {
         let seconds = date_time_to_seconds(&date_time);
@@ -541,6 +586,8 @@ impl From<DateTime> for Timestamp {
 
 #[cfg(test)]
 mod tests {
+
+    use std::convert::TryFrom;
 
     use proptest::prelude::*;
 
@@ -731,16 +778,67 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_duration() {
+        let case = |s: &str, seconds: i64, nanos: i32| {
+            assert_eq!(
+                s.parse::<Duration>().unwrap(),
+                Duration { seconds, nanos },
+                "duration: {}",
+                s
+            );
+        };
+
+        case("0s", 0, 0);
+        case("0.0s", 0, 0);
+        case("0.000s", 0, 0);
+
+        case("-0s", 0, 0);
+        case("-0.0s", 0, 0);
+        case("-0.000s", 0, 0);
+
+        case("-0s", 0, 0);
+        case("-0.0s", 0, 0);
+        case("-0.000s", 0, 0);
+
+        case("0.05s", 0, 50_000_000);
+        case("0.050s", 0, 50_000_000);
+
+        case("-0.05s", 0, -50_000_000);
+        case("-0.050s", 0, -50_000_000);
+
+        case("1s", 1, 0);
+        case("1.0s", 1, 0);
+        case("1.000s", 1, 0);
+
+        case("-1s", -1, 0);
+        case("-1.0s", -1, 0);
+        case("-1.000s", -1, 0);
+
+        case("15s", 15, 0);
+        case("15.1s", 15, 100_000_000);
+        case("15.100s", 15, 100_000_000);
+
+        case("-15s", -15, 0);
+        case("-15.1s", -15, -100_000_000);
+        case("-15.100s", -15, -100_000_000);
+
+        case("100.000000009s", 100, 9);
+        case("-100.000000009s", -100, -9);
+    }
+
+    #[test]
     fn test_parse_non_ascii() {
         assert!("2021️⃣-06-15 00:01:02.123 +0800"
             .parse::<Timestamp>()
             .is_err());
+
+        assert!("1️⃣s".parse::<Duration>().is_err());
     }
 
     proptest! {
         #[cfg(feature = "std")]
         #[test]
-        fn check_parse_to_string_roundtrip(
+        fn check_timestamp_parse_to_string_roundtrip(
             system_time in std::time::SystemTime::arbitrary(),
         ) {
 
@@ -750,6 +848,22 @@ mod tests {
                 ts,
                 ts.to_string().parse::<Timestamp>().unwrap(),
             )
+        }
+
+        #[test]
+        fn check_duration_parse_to_string_roundtrip(
+            duration in core::time::Duration::arbitrary(),
+        ) {
+            let duration = match Duration::try_from(duration) {
+                Ok(duration) => duration,
+                Err(_) => return Err(TestCaseError::reject("duration out of range")),
+            };
+
+            prop_assert_eq!(
+                &duration,
+                &duration.to_string().parse::<Duration>().unwrap(),
+                "{}", duration.to_string()
+            );
         }
     }
 }

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -84,33 +84,25 @@ impl Duration {
     }
 }
 
-/// Converts a `std::time::Duration` to a `Duration`.
-impl From<time::Duration> for Duration {
-    fn from(duration: time::Duration) -> Duration {
-        let seconds = duration.as_secs();
-        let seconds = if seconds > i64::MAX as u64 {
-            i64::MAX
-        } else {
-            seconds as i64
-        };
-        let nanos = duration.subsec_nanos();
-        let nanos = if nanos > i32::MAX as u32 {
-            i32::MAX
-        } else {
-            nanos as i32
-        };
+impl TryFrom<time::Duration> for Duration {
+    type Error = DurationError;
+
+    /// Converts a `std::time::Duration` to a `Duration`, failing if the duration is too large.
+    fn try_from(duration: time::Duration) -> Result<Duration, DurationError> {
+        let seconds = i64::try_from(duration.as_secs()).map_err(|_| DurationError::OutOfRange)?;
+        let nanos = duration.subsec_nanos() as i32;
+
         let mut duration = Duration { seconds, nanos };
         duration.normalize();
-        duration
+        Ok(duration)
     }
 }
 
 impl TryFrom<Duration> for time::Duration {
-    type Error = time::Duration;
+    type Error = DurationError;
 
-    /// Converts a `Duration` to a result containing a positive (`Ok`) or negative (`Err`)
-    /// `std::time::Duration`.
-    fn try_from(mut duration: Duration) -> Result<time::Duration, time::Duration> {
+    /// Converts a `Duration` to a `std::time::Duration`, failing if the duration is negative.
+    fn try_from(mut duration: Duration) -> Result<time::Duration, DurationError> {
         duration.normalize();
         if duration.seconds >= 0 {
             Ok(time::Duration::new(
@@ -118,11 +110,82 @@ impl TryFrom<Duration> for time::Duration {
                 duration.nanos as u32,
             ))
         } else {
-            Err(time::Duration::new(
+            Err(DurationError::NegativeDuration(time::Duration::new(
                 (-duration.seconds) as u64,
                 (-duration.nanos) as u32,
-            ))
+            )))
         }
+    }
+}
+
+impl fmt::Display for Duration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut d = self.clone();
+        d.normalize();
+        if self.seconds < 0 && self.nanos < 0 {
+            write!(f, "-")?;
+        }
+        write!(f, "{}", d.seconds.abs())?;
+
+        // Format subseconds to either nothing, millis, micros, or nanos.
+        let nanos = d.nanos.abs();
+        if nanos == 0 {
+            write!(f, "s")
+        } else if nanos % 1_000_000 == 0 {
+            write!(f, ".{:03}s", nanos / 1_000_000)
+        } else if nanos % 1_000 == 0 {
+            write!(f, ".{:06}s", nanos / 1_000)
+        } else {
+            write!(f, ".{:09}s", nanos)
+        }
+    }
+}
+
+/// A duration handling error.
+#[derive(Debug, PartialEq)]
+#[non_exhaustive]
+pub enum DurationError {
+    /// Indicates failure to parse a [`Duration`] from a string.
+    ///
+    /// The [`Duration`] string format is specified in the [Protobuf JSON mapping specification][1].
+    ///
+    /// [1]: https://developers.google.com/protocol-buffers/docs/proto3#json
+    ParseFailure,
+
+    /// Indicates failure to convert a `prost_types::Duration` to a `std::time::Duration` because
+    /// the duration is negative. The included `std::time::Duration` matches the magnitude of the
+    /// original negative `prost_types::Duration`.
+    NegativeDuration(time::Duration),
+
+    /// Indicates failure to convert a `std::time::Duration` to a `prost_types::Duration`.
+    ///
+    /// Converting a `std::time::Duration` to a `prost_types::Duration` fails if the magnitude
+    /// exceeds that representable by `prost_types::Duration`.
+    OutOfRange,
+}
+
+impl fmt::Display for DurationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            DurationError::ParseFailure => write!(f, "failed to parse duration"),
+            DurationError::NegativeDuration(duration) => {
+                write!(f, "failed to convert negative duration: {:?}", duration)
+            }
+            DurationError::OutOfRange => {
+                write!(f, "failed to convert duration out of range")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for DurationError {}
+
+impl FromStr for Duration {
+    type Err = DurationError;
+
+    fn from_str(s: &str) -> Result<Duration, DurationError> {
+        datetime::parse_duration(s).ok_or(DurationError::ParseFailure)
     }
 }
 
@@ -333,7 +396,7 @@ impl fmt::Display for Timestamp {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::{self, SystemTime, UNIX_EPOCH};
 
     use proptest::prelude::*;
 
@@ -359,6 +422,31 @@ mod tests {
                 prop_assert_eq!(Timestamp::from(system_time), timestamp);
             }
         }
+
+        #[test]
+        fn check_duration_roundtrip(
+            std_duration in time::Duration::arbitrary(),
+        ) {
+            let prost_duration = match Duration::try_from(std_duration) {
+                Ok(duration) => duration,
+                Err(_) => return Err(TestCaseError::reject("duration out of range")),
+            };
+            prop_assert_eq!(time::Duration::try_from(prost_duration.clone()).unwrap(), std_duration);
+
+            if std_duration != time::Duration::default() {
+                let neg_prost_duration = Duration {
+                    seconds: -prost_duration.seconds,
+                    nanos: -prost_duration.nanos,
+                };
+
+                prop_assert!(
+                    matches!(
+                        time::Duration::try_from(neg_prost_duration),
+                        Err(DurationError::NegativeDuration(d)) if d == std_duration,
+                    )
+                )
+            }
+        }
     }
 
     #[cfg(feature = "std")]
@@ -374,28 +462,28 @@ mod tests {
         // character of the behaviour being tested, but ensures that the tests are
         // valid for both POSIX (1 ns precision) and Windows (100 ns precision).
         assert_eq!(
-            Timestamp::from(UNIX_EPOCH - Duration::new(1_001, 0)),
+            Timestamp::from(UNIX_EPOCH - time::Duration::new(1_001, 0)),
             Timestamp {
                 seconds: -1_001,
                 nanos: 0
             }
         );
         assert_eq!(
-            Timestamp::from(UNIX_EPOCH - Duration::new(0, 999_999_900)),
+            Timestamp::from(UNIX_EPOCH - time::Duration::new(0, 999_999_900)),
             Timestamp {
                 seconds: -1,
                 nanos: 100
             }
         );
         assert_eq!(
-            Timestamp::from(UNIX_EPOCH - Duration::new(2_001_234, 12_300)),
+            Timestamp::from(UNIX_EPOCH - time::Duration::new(2_001_234, 12_300)),
             Timestamp {
                 seconds: -2_001_235,
                 nanos: 999_987_700
             }
         );
         assert_eq!(
-            Timestamp::from(UNIX_EPOCH - Duration::new(768, 65_432_100)),
+            Timestamp::from(UNIX_EPOCH - time::Duration::new(768, 65_432_100)),
             Timestamp {
                 seconds: -769,
                 nanos: 934_567_900
@@ -408,21 +496,21 @@ mod tests {
     fn check_timestamp_negative_seconds_1ns() {
         // UNIX-only test cases with 1 ns precision
         assert_eq!(
-            Timestamp::from(UNIX_EPOCH - Duration::new(0, 999_999_999)),
+            Timestamp::from(UNIX_EPOCH - time::Duration::new(0, 999_999_999)),
             Timestamp {
                 seconds: -1,
                 nanos: 1
             }
         );
         assert_eq!(
-            Timestamp::from(UNIX_EPOCH - Duration::new(1_234_567, 123)),
+            Timestamp::from(UNIX_EPOCH - time::Duration::new(1_234_567, 123)),
             Timestamp {
                 seconds: -1_234_568,
                 nanos: 999_999_877
             }
         );
         assert_eq!(
-            Timestamp::from(UNIX_EPOCH - Duration::new(890, 987_654_321)),
+            Timestamp::from(UNIX_EPOCH - time::Duration::new(890, 987_654_321)),
             Timestamp {
                 seconds: -891,
                 nanos: 12_345_679
@@ -487,7 +575,7 @@ mod tests {
         ];
 
         for case in cases.iter() {
-            let mut test_duration = crate::Duration {
+            let mut test_duration = Duration {
                 seconds: case.1,
                 nanos: case.2,
             };
@@ -495,7 +583,7 @@ mod tests {
 
             assert_eq!(
                 test_duration,
-                crate::Duration {
+                Duration {
                     seconds: case.3,
                     nanos: case.4,
                 },


### PR DESCRIPTION
This PR implements to and from string methods for
`prost_types::Duration` following the duration format defined by the
[Protobuf JSON mapping spec][1].

This is a followup to #615 and re-uses a lot of the same parser helpers.
Additionally I did the same error type unification with a new
`DurationError` type. This is a breaking change for `prost-types` since
public APIs are changed slightly.

[1]: https://developers.google.com/protocol-buffers/docs/proto3#json