### PR TITLE
docs: Fix typo in PROTOC_NO_VENDOR environment variable doc

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -103,7 +103,7 @@
 //! source.
 //!
 //! If you would not like `prost-build` to not compile `protoc` from source ever then
-//! ensure you have set `PROTO_NO_VENDOR` environment variable as this will disable
+//! ensure you have set `PROTOC_NO_VENDOR` environment variable as this will disable
 //! compiling from source even if the `vendored` feature flag is enabled.
 //!
 //! If you would like to always compile from source then setting the `vendored` feature


### PR DESCRIPTION
The variable should be named `PROTOC_NO_VENDOR` but has a typo in the prost-build lib documentation.