### PR TITLE
Correct codeblocks to not break `cargo test --doc`

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -80,7 +80,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - 1.51.0
+          - 1.53.0
         os:
           - ubuntu-latest
           - macos-latest

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -15,6 +15,8 @@ edition = "2018"
 [features]
 default = []
 vendored = []
+# When MSRV moves to 1.60, these can change to dep:
+cleanup-markdown = ["pulldown-cmark", "pulldown-cmark-to-cmark"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }
@@ -29,8 +31,8 @@ tempfile = "3"
 lazy_static = "1.4.0"
 regex = { version = "1.5.5", default-features = false, features = ["std", "unicode-bool"] }
 # These two must be kept in sync
-pulldown-cmark = "0.9"
-pulldown-cmark-to-cmark = "10.0"
+pulldown-cmark = { version = "0.9", optional = true, default-features = false }
+pulldown-cmark-to-cmark = { version = "10.0", optional = true }
 
 [build-dependencies]
 which = { version = "4", default-features = false }

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -28,6 +28,9 @@ prost-types = { version = "0.10.0", path = "../prost-types", default-features = 
 tempfile = "3"
 lazy_static = "1.4.0"
 regex = { version = "1.5.5", default-features = false, features = ["std", "unicode-bool"] }
+# These two must be kept in sync
+pulldown-cmark = "0.9"
+pulldown-cmark-to-cmark = "10.0"
 
 [build-dependencies]
 which = { version = "4", default-features = false }

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -31,8 +31,8 @@ tempfile = "3"
 lazy_static = "1.4.0"
 regex = { version = "1.5.5", default-features = false, features = ["std", "unicode-bool"] }
 # These two must be kept in sync
-pulldown-cmark = { version = "0.9", optional = true, default-features = false }
-pulldown-cmark-to-cmark = { version = "10.0", optional = true }
+pulldown-cmark = { version = "0.9.1", optional = true, default-features = false }
+pulldown-cmark-to-cmark = { version = "10.0.1", optional = true }
 
 [build-dependencies]
 which = { version = "4", default-features = false }

--- a/prost-build/src/ast.rs
+++ b/prost-build/src/ast.rs
@@ -1,5 +1,6 @@
 use lazy_static::lazy_static;
 use prost_types::source_code_info::Location;
+use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag};
 use regex::Regex;
 
 /// Comments on a Protobuf item.
@@ -21,7 +22,44 @@ impl Comments {
         where
             S: AsRef<str>,
         {
-            comments.as_ref().lines().map(str::to_owned).collect()
+            let comments = comments.as_ref();
+            let mut buffer = String::with_capacity(comments.len() + 256);
+            let opts = pulldown_cmark_to_cmark::Options {
+                code_block_token_count: 3,
+                ..Default::default()
+            };
+            match pulldown_cmark_to_cmark::cmark_with_options(
+                Parser::new_ext(comments, Options::all() - Options::ENABLE_SMART_PUNCTUATION).map(
+                    |event| {
+                        fn map_codeblock(kind: CodeBlockKind) -> CodeBlockKind {
+                            match kind {
+                                CodeBlockKind::Fenced(s) => {
+                                    if &*s == "rust" {
+                                        CodeBlockKind::Fenced("compile_fail".into())
+                                    } else {
+                                        CodeBlockKind::Fenced(format!("text,{}", s).into())
+                                    }
+                                }
+                                CodeBlockKind::Indented => CodeBlockKind::Fenced("text".into()),
+                            }
+                        }
+                        match event {
+                            Event::Start(Tag::CodeBlock(kind)) => {
+                                Event::Start(Tag::CodeBlock(map_codeblock(kind)))
+                            }
+                            Event::End(Tag::CodeBlock(kind)) => {
+                                Event::End(Tag::CodeBlock(map_codeblock(kind)))
+                            }
+                            e => e,
+                        }
+                    },
+                ),
+                &mut buffer,
+                opts,
+            ) {
+                Ok(_) => buffer.lines().map(str::to_owned).collect(),
+                Err(_) => comments.lines().map(str::to_owned).collect(),
+            }
         }
 
         let leading_detached = location

--- a/prost-build/src/ast.rs
+++ b/prost-build/src/ast.rs
@@ -289,4 +289,48 @@ mod tests {
             assert_eq!(t.expected, actual, "failed {}", t.name);
         }
     }
+
+    #[test]
+    fn test_codeblocks() {
+        struct TestCase {
+            name: &'static str,
+            input: &'static str,
+            #[allow(unused)]
+            cleanedup_expected: Vec<&'static str>,
+        }
+
+        let tests = vec![
+            TestCase {
+                name: "unlabelled_block",
+                input: "    thingy\n",
+                cleanedup_expected: vec!["", "```text", "thingy", "```"],
+            },
+            TestCase {
+                name: "rust_block",
+                input: "```rust\nfoo.bar()\n```\n",
+                cleanedup_expected: vec!["", "```compile_fail", "foo.bar()", "```"],
+            },
+            TestCase {
+                name: "js_block",
+                input: "```javascript\nfoo.bar()\n```\n",
+                cleanedup_expected: vec!["", "```text,javascript", "foo.bar()", "```"],
+            },
+        ];
+
+        for t in tests {
+            let loc = Location {
+                path: vec![],
+                span: vec![],
+                leading_comments: Some(t.input.into()),
+                trailing_comments: None,
+                leading_detached_comments: vec![],
+            };
+            let comments = Comments::from_location(&loc);
+            #[cfg(feature = "cleanup-markdown")]
+            let expected = t.cleanedup_expected;
+            #[cfg(not(feature = "cleanup-markdown"))]
+            let expected: Vec<&str> = t.input.lines().collect();
+            assert_eq!(expected, comments.leading, "failed {}", t.name);
+        }
+    }
 }

--- a/prost-build/src/ast.rs
+++ b/prost-build/src/ast.rs
@@ -139,6 +139,9 @@ impl Comments {
 
         let mut s = RULE_URL.replace_all(line, r"<$0>").to_string();
         s = RULE_BRACKETS.replace_all(&s, r"\$1$2\$3").to_string();
+        if !s.is_empty() {
+            s.insert(0, ' ');
+        }
         s
     }
 }
@@ -201,22 +204,22 @@ mod tests {
             TestCases {
                 name: "valid_http",
                 input: "See https://www.rust-lang.org/".to_string(),
-                expected: "///See <https://www.rust-lang.org/>\n".to_string(),
+                expected: "/// See <https://www.rust-lang.org/>\n".to_string(),
             },
             TestCases {
                 name: "valid_https",
                 input: "See https://www.rust-lang.org/".to_string(),
-                expected: "///See <https://www.rust-lang.org/>\n".to_string(),
+                expected: "/// See <https://www.rust-lang.org/>\n".to_string(),
             },
             TestCases {
                 name: "valid_https_parenthesis",
                 input: "See (https://www.rust-lang.org/)".to_string(),
-                expected: "///See (<https://www.rust-lang.org/>)\n".to_string(),
+                expected: "/// See (<https://www.rust-lang.org/>)\n".to_string(),
             },
             TestCases {
                 name: "invalid",
                 input: "See note://abc".to_string(),
-                expected: "///See note://abc\n".to_string(),
+                expected: "/// See note://abc\n".to_string(),
             },
         ];
         for t in tests {
@@ -245,22 +248,22 @@ mod tests {
             TestCases {
                 name: "valid_brackets",
                 input: "foo [bar] baz".to_string(),
-                expected: "///foo \\[bar\\] baz\n".to_string(),
+                expected: "/// foo \\[bar\\] baz\n".to_string(),
             },
             TestCases {
                 name: "invalid_start_bracket",
                 input: "foo [= baz".to_string(),
-                expected: "///foo [= baz\n".to_string(),
+                expected: "/// foo [= baz\n".to_string(),
             },
             TestCases {
                 name: "invalid_end_bracket",
                 input: "foo =] baz".to_string(),
-                expected: "///foo =] baz\n".to_string(),
+                expected: "/// foo =] baz\n".to_string(),
             },
             TestCases {
                 name: "invalid_bracket_combination",
                 input: "[0, 9)".to_string(),
-                expected: "///[0, 9)\n".to_string(),
+                expected: "/// [0, 9)\n".to_string(),
             },
         ];
         for t in tests {

--- a/prost-build/src/ast.rs
+++ b/prost-build/src/ast.rs
@@ -1,5 +1,6 @@
 use lazy_static::lazy_static;
 use prost_types::source_code_info::Location;
+#[cfg(feature = "cleanup-markdown")]
 use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag};
 use regex::Regex;
 
@@ -18,6 +19,15 @@ pub struct Comments {
 
 impl Comments {
     pub(crate) fn from_location(location: &Location) -> Comments {
+        #[cfg(not(feature = "cleanup-markdown"))]
+        fn get_lines<S>(comments: S) -> Vec<String>
+        where
+            S: AsRef<str>,
+        {
+            comments.as_ref().lines().map(str::to_owned).collect()
+        }
+
+        #[cfg(feature = "cleanup-markdown")]
         fn get_lines<S>(comments: S) -> Vec<String>
         where
             S: AsRef<str>,

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -77,6 +77,18 @@
 //! That's it! Run `cargo doc` to see documentation for the generated code. The full
 //! example project can be found on [GitHub](https://github.com/danburkert/snazzy).
 //!
+//! ### Cleaning up Markdown in code docs
+//!
+//! If you are using protobuf files from third parties, where the author of the protobuf
+//! is not treating comments as Markdown, or is, but has codeblocks in their docs,
+//! then you may need to clean up the documentation in order that `cargo test --doc`
+//! will not fail spuriously, and that `cargo doc` doesn't attempt to render the
+//! codeblocks as Rust code.
+//!
+//! To do this, in your `Cargo.toml`, add `features = ["cleanup-markdown"]` to the inclusion
+//! of the `prost-build` crate and when your code is generated, the code docs will automatically
+//! be cleaned up a bit.
+//!
 //! ## Sourcing `protoc`
 //!
 //! `prost-build` depends on the Protocol Buffers compiler, `protoc`, to parse `.proto` files into

--- a/prost-types/src/compiler.rs
+++ b/prost-types/src/compiler.rs
@@ -71,7 +71,7 @@ pub mod code_generator_response {
         /// The file name, relative to the output directory.  The name must not
         /// contain "." or ".." components and must be relative, not be absolute (so,
         /// the file cannot lie outside the output directory).  "/" must be used as
-        /// the path separator, not "\".
+        /// the path separator, not "".
         ///
         /// If the name is omitted, the content will be appended to the previous
         /// file.  This allows the generator to break large files into small chunks,
@@ -87,7 +87,7 @@ pub mod code_generator_response {
         /// produced by another code generator.  The original generator may provide
         /// insertion points by placing special annotations in the file that look
         /// like:
-        ///   @@protoc_insertion_point(NAME)
+        /// @@protoc_insertion_point(NAME)
         /// The annotation can have arbitrary text before and after it on the line,
         /// which allows it to be placed in a comment.  NAME should be replaced with
         /// an identifier naming the point -- this is what other generators will use
@@ -99,7 +99,7 @@ pub mod code_generator_response {
         ///
         /// For example, the C++ code generator places the following line in the
         /// .pb.h files that it generates:
-        ///   // @@protoc_insertion_point(namespace_scope)
+        /// // @@protoc_insertion_point(namespace_scope)
         /// This line appears within the scope of the file's package namespace, but
         /// outside of any particular class.  Another plugin can then specify the
         /// insertion_point "namespace_scope" to generate additional classes or

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -310,15 +310,16 @@ pub struct MethodDescriptorProto {
 // just annotations which may cause code to be generated slightly differently
 // or may contain hints for code that manipulates protocol messages.
 //
-// Clients may define custom options as extensions of the *Options messages.
+// Clients may define custom options as extensions of the \*Options messages.
 // These extensions may not yet be known at parsing time, so the parser cannot
-// store the values in them.  Instead it stores them in a field in the *Options
+// store the values in them.  Instead it stores them in a field in the \*Options
 // message called uninterpreted_option. This field must have the same name
-// across all *Options messages. We then use this field to populate the
+// across all \*Options messages. We then use this field to populate the
 // extensions when we build a descriptor, at which point all protos have been
 // parsed and so all extensions are known.
 //
 // Extension numbers for custom options may be chosen as follows:
+//
 // * For options which will only be used within a single application or
 //   organization, or for experimental options, use field numbers 50000
 //   through 99999.  It is up to you to ensure that you do not use the
@@ -374,9 +375,10 @@ pub struct FileOptions {
     pub optimize_for: ::core::option::Option<i32>,
     /// Sets the Go package where structs generated from this .proto will be
     /// placed. If omitted, the Go package will be derived from the following:
-    ///   - The basename of the package import path, if provided.
-    ///   - Otherwise, the package statement in the .proto file, if present.
-    ///   - Otherwise, the basename of the .proto file, without extension.
+    ///
+    /// * The basename of the package import path, if provided.
+    /// * Otherwise, the package statement in the .proto file, if present.
+    /// * Otherwise, the basename of the .proto file, without extension.
     #[prost(string, optional, tag="11")]
     pub go_package: ::core::option::Option<::prost::alloc::string::String>,
     /// Should generic services be generated in each language?  "Generic" services
@@ -468,10 +470,10 @@ pub struct MessageOptions {
     /// efficient, has fewer features, and is more complicated.
     ///
     /// The message must be defined exactly as follows:
-    ///   message Foo {
-    ///     option message_set_wire_format = true;
-    ///     extensions 4 to max;
-    ///   }
+    /// message Foo {
+    /// option message_set_wire_format = true;
+    /// extensions 4 to max;
+    /// }
     /// Note that the message cannot have any defined fields; MessageSets only
     /// have extensions.
     ///
@@ -497,14 +499,14 @@ pub struct MessageOptions {
     /// maps field.
     ///
     /// For maps fields:
-    ///     map<KeyType, ValueType> map_field = 1;
+    /// map\<KeyType, ValueType> map_field = 1;
     /// The parsed descriptor looks like:
-    ///     message MapFieldEntry {
-    ///         option map_entry = true;
-    ///         optional KeyType key = 1;
-    ///         optional ValueType value = 2;
-    ///     }
-    ///     repeated MapFieldEntry map_field = 1;
+    /// message MapFieldEntry {
+    /// option map_entry = true;
+    /// optional KeyType key = 1;
+    /// optional ValueType value = 2;
+    /// }
+    /// repeated MapFieldEntry map_field = 1;
     ///
     /// Implementations may choose not to generate the map_entry=true message, but
     /// use a native map in the target language to hold the keys and values.
@@ -564,7 +566,6 @@ pub struct FieldOptions {
     /// interface is not affected by this option; const methods remain safe to
     /// call from multiple threads concurrently, while non-const methods continue
     /// to require exclusive access.
-    ///
     ///
     /// Note that implementations may choose not to check required fields within
     /// a lazy sub-message.  That is, calling IsInitialized() on the outer message
@@ -649,9 +650,9 @@ pub struct EnumValueOptions {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceOptions {
     // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
-    //   framework.  We apologize for hoarding these numbers to ourselves, but
-    //   we were already using them long before we decided to release Protocol
-    //   Buffers.
+    // framework.  We apologize for hoarding these numbers to ourselves, but
+    // we were already using them long before we decided to release Protocol
+    // Buffers.
 
     /// Is this service deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
@@ -666,9 +667,9 @@ pub struct ServiceOptions {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MethodOptions {
     // Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
-    //   framework.  We apologize for hoarding these numbers to ourselves, but
-    //   we were already using them long before we decided to release Protocol
-    //   Buffers.
+    // framework.  We apologize for hoarding these numbers to ourselves, but
+    // we were already using them long before we decided to release Protocol
+    // Buffers.
 
     /// Is this method deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
@@ -727,7 +728,7 @@ pub mod uninterpreted_option {
     /// The name of the uninterpreted option.  Each string represents a segment in
     /// a dot-separated name.  is_extension is true iff a segment represents an
     /// extension (denoted with parentheses in options specs in .proto files).
-    /// E.g.,{ ["foo", false], ["bar.baz", true], ["qux", false] } represents
+    /// E.g.,{ \["foo", false\], \["bar.baz", true\], \["qux", false\] } represents
     /// "foo.(bar.baz).qux".
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NamePart {
@@ -750,41 +751,42 @@ pub struct SourceCodeInfo {
     /// tools.
     ///
     /// For example, say we have a file like:
-    ///   message Foo {
-    ///     optional string foo = 1;
-    ///   }
+    /// message Foo {
+    /// optional string foo = 1;
+    /// }
     /// Let's look at just the field definition:
-    ///   optional string foo = 1;
-    ///   ^       ^^     ^^  ^  ^^^
-    ///   a       bc     de  f  ghi
+    /// optional string foo = 1;
+    /// ^       ^^     ^^  ^  ^^^
+    /// a       bc     de  f  ghi
     /// We have the following locations:
-    ///   span   path               represents
-    ///   [a,i)  [ 4, 0, 2, 0 ]     The whole field definition.
-    ///   [a,b)  [ 4, 0, 2, 0, 4 ]  The label (optional).
-    ///   [c,d)  [ 4, 0, 2, 0, 5 ]  The type (string).
-    ///   [e,f)  [ 4, 0, 2, 0, 1 ]  The name (foo).
-    ///   [g,h)  [ 4, 0, 2, 0, 3 ]  The number (1).
+    /// span   path               represents
+    /// \[a,i)  \[ 4, 0, 2, 0 \]     The whole field definition.
+    /// \[a,b)  \[ 4, 0, 2, 0, 4 \]  The label (optional).
+    /// \[c,d)  \[ 4, 0, 2, 0, 5 \]  The type (string).
+    /// \[e,f)  \[ 4, 0, 2, 0, 1 \]  The name (foo).
+    /// \[g,h)  \[ 4, 0, 2, 0, 3 \]  The number (1).
     ///
     /// Notes:
-    /// - A location may refer to a repeated field itself (i.e. not to any
+    ///
+    /// * A location may refer to a repeated field itself (i.e. not to any
     ///   particular index within it).  This is used whenever a set of elements are
     ///   logically enclosed in a single code segment.  For example, an entire
     ///   extend block (possibly containing multiple extension definitions) will
     ///   have an outer location whose path refers to the "extensions" repeated
     ///   field without an index.
-    /// - Multiple locations may have the same path.  This happens when a single
+    /// * Multiple locations may have the same path.  This happens when a single
     ///   logical declaration is spread out across multiple places.  The most
     ///   obvious example is the "extend" block again -- there may be multiple
     ///   extend blocks in the same scope, each of which will have the same path.
-    /// - A location's span is not always a subset of its parent's span.  For
+    /// * A location's span is not always a subset of its parent's span.  For
     ///   example, the "extendee" of an extension declaration appears at the
     ///   beginning of the "extend" block and is shared by all extensions within
     ///   the block.
-    /// - Just because a location's span is a subset of some other location's span
+    /// * Just because a location's span is a subset of some other location's span
     ///   does not mean that it is a descendant.  For example, a "group" defines
     ///   both a type and a field in a single declaration.  Thus, the locations
     ///   corresponding to the type and field and their components will overlap.
-    /// - Code which tries to interpret locations should probably be designed to
+    /// * Code which tries to interpret locations should probably be designed to
     ///   ignore those that it doesn't understand, as more types of locations could
     ///   be recorded in the future.
     #[prost(message, repeated, tag="1")]
@@ -800,21 +802,21 @@ pub mod source_code_info {
         /// Each element is a field number or an index.  They form a path from
         /// the root FileDescriptorProto to the place where the definition.  For
         /// example, this path:
-        ///   [ 4, 3, 2, 7, 1 ]
+        /// \[ 4, 3, 2, 7, 1 \]
         /// refers to:
-        ///   file.message_type(3)  // 4, 3
-        ///       .field(7)         // 2, 7
-        ///       .name()           // 1
+        /// file.message_type(3)  // 4, 3
+        /// .field(7)         // 2, 7
+        /// .name()           // 1
         /// This is because FileDescriptorProto.message_type has field number 4:
-        ///   repeated DescriptorProto message_type = 4;
+        /// repeated DescriptorProto message_type = 4;
         /// and DescriptorProto.field has field number 2:
-        ///   repeated FieldDescriptorProto field = 2;
+        /// repeated FieldDescriptorProto field = 2;
         /// and FieldDescriptorProto.name has field number 1:
-        ///   optional string name = 1;
+        /// optional string name = 1;
         ///
         /// Thus, the above path gives the location of a field name.  If we removed
         /// the last element:
-        ///   [ 4, 3, 2, 7 ]
+        /// \[ 4, 3, 2, 7 \]
         /// this path refers to the whole field declaration (from the beginning
         /// of the label to the terminating semicolon).
         #[prost(int32, repeated, tag="1")]
@@ -845,34 +847,34 @@ pub mod source_code_info {
         ///
         /// Examples:
         ///
-        ///   optional int32 foo = 1;  // Comment attached to foo.
-        ///   // Comment attached to bar.
-        ///   optional int32 bar = 2;
+        /// optional int32 foo = 1;  // Comment attached to foo.
+        /// // Comment attached to bar.
+        /// optional int32 bar = 2;
         ///
-        ///   optional string baz = 3;
-        ///   // Comment attached to baz.
-        ///   // Another line attached to baz.
+        /// optional string baz = 3;
+        /// // Comment attached to baz.
+        /// // Another line attached to baz.
         ///
-        ///   // Comment attached to qux.
-        ///   //
-        ///   // Another line attached to qux.
-        ///   optional double qux = 4;
+        /// // Comment attached to qux.
+        /// //
+        /// // Another line attached to qux.
+        /// optional double qux = 4;
         ///
-        ///   // Detached comment for corge. This is not leading or trailing comments
-        ///   // to qux or corge because there are blank lines separating it from
-        ///   // both.
+        /// // Detached comment for corge. This is not leading or trailing comments
+        /// // to qux or corge because there are blank lines separating it from
+        /// // both.
         ///
-        ///   // Detached comment for corge paragraph 2.
+        /// // Detached comment for corge paragraph 2.
         ///
-        ///   optional string corge = 5;
-        ///   /* Block comment attached
-        ///    * to corge.  Leading asterisks
-        ///    * will be removed. */
-        ///   /* Block comment attached to
-        ///    * grault. */
-        ///   optional int32 grault = 6;
+        /// optional string corge = 5;
+        /// /\* Block comment attached
+        /// \* to corge.  Leading asterisks
+        /// \* will be removed. */
+        /// /* Block comment attached to
+        /// \* grault. \*/
+        /// optional int32 grault = 6;
         ///
-        ///   // ignored detached comments.
+        /// // ignored detached comments.
         #[prost(string, optional, tag="3")]
         pub leading_comments: ::core::option::Option<::prost::alloc::string::String>,
         #[prost(string, optional, tag="4")]
@@ -921,45 +923,53 @@ pub mod generated_code_info {
 ///
 /// Example 1: Pack and unpack a message in C++.
 ///
-///     Foo foo = ...;
-///     Any any;
-///     any.PackFrom(foo);
-///     ...
-///     if (any.UnpackTo(&foo)) {
-///       ...
-///     }
+/// ```text
+///  Foo foo = ...;
+///  Any any;
+///  any.PackFrom(foo);
+///  ...
+///  if (any.UnpackTo(&foo)) {
+///    ...
+///  }
+/// ```
 ///
 /// Example 2: Pack and unpack a message in Java.
 ///
-///     Foo foo = ...;
-///     Any any = Any.pack(foo);
+/// ```text
+///  Foo foo = ...;
+///  Any any = Any.pack(foo);
+///  ...
+///  if (any.is(Foo.class)) {
+///    foo = any.unpack(Foo.class);
+///  }
+/// ```
+///
+/// Example 3: Pack and unpack a message in Python.
+///
+/// ```text
+///  foo = Foo(...)
+///  any = Any()
+///  any.Pack(foo)
+///  ...
+///  if any.Is(Foo.DESCRIPTOR):
+///    any.Unpack(foo)
+///    ...
+/// ```
+///
+/// Example 4: Pack and unpack a message in Go
+///
+/// ```text
+///   foo := &pb.Foo{...}
+///   any, err := anypb.New(foo)
+///   if err != nil {
 ///     ...
-///     if (any.is(Foo.class)) {
-///       foo = any.unpack(Foo.class);
-///     }
-///
-///  Example 3: Pack and unpack a message in Python.
-///
-///     foo = Foo(...)
-///     any = Any()
-///     any.Pack(foo)
+///   }
+///   ...
+///   foo := &pb.Foo{}
+///   if err := any.UnmarshalTo(foo); err != nil {
 ///     ...
-///     if any.Is(Foo.DESCRIPTOR):
-///       any.Unpack(foo)
-///       ...
-///
-///  Example 4: Pack and unpack a message in Go
-///
-///      foo := &pb.Foo{...}
-///      any, err := anypb.New(foo)
-///      if err != nil {
-///        ...
-///      }
-///      ...
-///      foo := &pb.Foo{}
-///      if err := any.UnmarshalTo(foo); err != nil {
-///        ...
-///      }
+///   }
+/// ```
 ///
 /// The pack methods provided by protobuf library will by default use
 /// 'type.googleapis.com/full.type.name' as the type URL and the unpack
@@ -967,35 +977,37 @@ pub mod generated_code_info {
 /// in the type URL, for example "foo.bar.com/x/y.z" will yield type
 /// name "y.z".
 ///
+/// # JSON
 ///
-/// JSON
-/// ====
 /// The JSON representation of an `Any` value uses the regular
 /// representation of the deserialized, embedded message, with an
 /// additional field `@type` which contains the type URL. Example:
 ///
-///     package google.profile;
-///     message Person {
-///       string first_name = 1;
-///       string last_name = 2;
-///     }
+/// ```text
+///  package google.profile;
+///  message Person {
+///    string first_name = 1;
+///    string last_name = 2;
+///  }
 ///
-///     {
-///       "@type": "type.googleapis.com/google.profile.Person",
-///       "firstName": <string>,
-///       "lastName": <string>
-///     }
+///  {
+///    "@type": "type.googleapis.com/google.profile.Person",
+///    "firstName": <string>,
+///    "lastName": <string>
+///  }
+/// ```
 ///
 /// If the embedded message type is well-known and has a custom JSON
 /// representation, that representation will be embedded adding a field
 /// `value` which holds the custom JSON in addition to the `@type`
-/// field. Example (for message \[google.protobuf.Duration][\]):
+/// field. Example (for message \\[google.protobuf.Duration\]\[\\]):
 ///
-///     {
-///       "@type": "type.googleapis.com/google.protobuf.Duration",
-///       "value": "1.212s"
-///     }
-///
+/// ```text
+///  {
+///    "@type": "type.googleapis.com/google.protobuf.Duration",
+///    "value": "1.212s"
+///  }
+/// ```
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Any {
     /// A URL/resource name that uniquely identifies the type of the serialized
@@ -1011,7 +1023,7 @@ pub struct Any {
     /// server that maps type URLs to message definitions as follows:
     ///
     /// * If no scheme is provided, `https` is assumed.
-    /// * An HTTP GET on the URL must yield a \[google.protobuf.Type][\]
+    /// * An HTTP GET on the URL must yield a \\[google.protobuf.Type\]\[\\]
     ///   value in binary format, or produce an error.
     /// * Applications are allowed to cache lookup results based on the
     ///   URL, or have them precompiled into a binary to avoid any
@@ -1025,7 +1037,6 @@ pub struct Any {
     ///
     /// Schemes other than `http`, `https` (or the empty scheme) might be
     /// used with implementation specific semantics.
-    ///
     #[prost(string, tag="1")]
     pub type_url: ::prost::alloc::string::String,
     /// Must be a valid serialized protocol buffer of the above specified type.
@@ -1256,15 +1267,13 @@ pub struct Api {
     /// `google.feature.v1`. For major versions 0 and 1, the suffix can
     /// be omitted. Zero major versions must only be used for
     /// experimental, non-GA interfaces.
-    ///
-    ///
     #[prost(string, tag="4")]
     pub version: ::prost::alloc::string::String,
     /// Source context for the protocol buffer service represented by this
     /// message.
     #[prost(message, optional, tag="5")]
     pub source_context: ::core::option::Option<SourceContext>,
-    /// Included interfaces. See \[Mixin][\].
+    /// Included interfaces. See \\[Mixin\]\[\\].
     #[prost(message, repeated, tag="6")]
     pub mixins: ::prost::alloc::vec::Vec<Mixin>,
     /// The source syntax of the service.
@@ -1300,45 +1309,49 @@ pub struct Method {
 /// interface must redeclare all the methods from the included interface, but
 /// documentation and options are inherited as follows:
 ///
-/// - If after comment and whitespace stripping, the documentation
+/// * If after comment and whitespace stripping, the documentation
 ///   string of the redeclared method is empty, it will be inherited
 ///   from the original method.
 ///
-/// - Each annotation belonging to the service config (http,
+/// * Each annotation belonging to the service config (http,
 ///   visibility) which is not set in the redeclared method will be
 ///   inherited.
 ///
-/// - If an http annotation is inherited, the path pattern will be
+/// * If an http annotation is inherited, the path pattern will be
 ///   modified as follows. Any version prefix will be replaced by the
-///   version of the including interface plus the \[root][\] path if
+///   version of the including interface plus the \\[root\]\[\\] path if
 ///   specified.
 ///
 /// Example of a simple mixin:
 ///
-///     package google.acl.v1;
-///     service AccessControl {
-///       // Get the underlying ACL object.
-///       rpc GetAcl(GetAclRequest) returns (Acl) {
-///         option (google.api.http).get = "/v1/{resource=**}:getAcl";
-///       }
-///     }
+/// ```text
+///  package google.acl.v1;
+///  service AccessControl {
+///    // Get the underlying ACL object.
+///    rpc GetAcl(GetAclRequest) returns (Acl) {
+///      option (google.api.http).get = "/v1/{resource=**}:getAcl";
+///    }
+///  }
 ///
-///     package google.storage.v2;
-///     service Storage {
-///       rpc GetAcl(GetAclRequest) returns (Acl);
+///  package google.storage.v2;
+///  service Storage {
+///    rpc GetAcl(GetAclRequest) returns (Acl);
 ///
-///       // Get a data record.
-///       rpc GetData(GetDataRequest) returns (Data) {
-///         option (google.api.http).get = "/v2/{resource=**}";
-///       }
-///     }
+///    // Get a data record.
+///    rpc GetData(GetDataRequest) returns (Data) {
+///      option (google.api.http).get = "/v2/{resource=**}";
+///    }
+///  }
+/// ```
 ///
 /// Example of a mixin configuration:
 ///
-///     apis:
-///     - name: google.storage.v2.Storage
-///       mixins:
-///       - name: google.acl.v1.AccessControl
+/// ```text
+///  apis:
+///  - name: google.storage.v2.Storage
+///    mixins:
+///    - name: google.acl.v1.AccessControl
+/// ```
 ///
 /// The mixin construct implies that all methods in `AccessControl` are
 /// also declared with same name and request/response types in
@@ -1346,34 +1359,40 @@ pub struct Method {
 /// see the effective `Storage.GetAcl` method after inheriting
 /// documentation and annotations as follows:
 ///
-///     service Storage {
-///       // Get the underlying ACL object.
-///       rpc GetAcl(GetAclRequest) returns (Acl) {
-///         option (google.api.http).get = "/v2/{resource=**}:getAcl";
-///       }
-///       ...
-///     }
+/// ```text
+///  service Storage {
+///    // Get the underlying ACL object.
+///    rpc GetAcl(GetAclRequest) returns (Acl) {
+///      option (google.api.http).get = "/v2/{resource=**}:getAcl";
+///    }
+///    ...
+///  }
+/// ```
 ///
 /// Note how the version in the path pattern changed from `v1` to `v2`.
 ///
 /// If the `root` field in the mixin is specified, it should be a
 /// relative path under which inherited HTTP paths are placed. Example:
 ///
-///     apis:
-///     - name: google.storage.v2.Storage
-///       mixins:
-///       - name: google.acl.v1.AccessControl
-///         root: acls
+/// ```text
+///  apis:
+///  - name: google.storage.v2.Storage
+///    mixins:
+///    - name: google.acl.v1.AccessControl
+///      root: acls
+/// ```
 ///
 /// This implies the following inherited HTTP annotation:
 ///
-///     service Storage {
-///       // Get the underlying ACL object.
-///       rpc GetAcl(GetAclRequest) returns (Acl) {
-///         option (google.api.http).get = "/v2/acls/{resource=**}:getAcl";
-///       }
-///       ...
-///     }
+/// ```text
+///  service Storage {
+///    // Get the underlying ACL object.
+///    rpc GetAcl(GetAclRequest) returns (Acl) {
+///      option (google.api.http).get = "/v2/acls/{resource=**}:getAcl";
+///    }
+///    ...
+///  }
+/// ```
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Mixin {
     /// The fully qualified name of the interface which is included.
@@ -1395,43 +1414,49 @@ pub struct Mixin {
 ///
 /// Example 1: Compute Duration from two Timestamps in pseudo code.
 ///
-///     Timestamp start = ...;
-///     Timestamp end = ...;
-///     Duration duration = ...;
+/// ```text
+///  Timestamp start = ...;
+///  Timestamp end = ...;
+///  Duration duration = ...;
 ///
-///     duration.seconds = end.seconds - start.seconds;
-///     duration.nanos = end.nanos - start.nanos;
+///  duration.seconds = end.seconds - start.seconds;
+///  duration.nanos = end.nanos - start.nanos;
 ///
-///     if (duration.seconds < 0 && duration.nanos > 0) {
-///       duration.seconds += 1;
-///       duration.nanos -= 1000000000;
-///     } else if (duration.seconds > 0 && duration.nanos < 0) {
-///       duration.seconds -= 1;
-///       duration.nanos += 1000000000;
-///     }
+///  if (duration.seconds < 0 && duration.nanos > 0) {
+///    duration.seconds += 1;
+///    duration.nanos -= 1000000000;
+///  } else if (duration.seconds > 0 && duration.nanos < 0) {
+///    duration.seconds -= 1;
+///    duration.nanos += 1000000000;
+///  }
+/// ```
 ///
 /// Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
 ///
-///     Timestamp start = ...;
-///     Duration duration = ...;
-///     Timestamp end = ...;
+/// ```text
+///  Timestamp start = ...;
+///  Duration duration = ...;
+///  Timestamp end = ...;
 ///
-///     end.seconds = start.seconds + duration.seconds;
-///     end.nanos = start.nanos + duration.nanos;
+///  end.seconds = start.seconds + duration.seconds;
+///  end.nanos = start.nanos + duration.nanos;
 ///
-///     if (end.nanos < 0) {
-///       end.seconds -= 1;
-///       end.nanos += 1000000000;
-///     } else if (end.nanos >= 1000000000) {
-///       end.seconds += 1;
-///       end.nanos -= 1000000000;
-///     }
+///  if (end.nanos < 0) {
+///    end.seconds -= 1;
+///    end.nanos += 1000000000;
+///  } else if (end.nanos >= 1000000000) {
+///    end.seconds += 1;
+///    end.nanos -= 1000000000;
+///  }
+/// ```
 ///
 /// Example 3: Compute Duration from datetime.timedelta in Python.
 ///
-///     td = datetime.timedelta(days=3, minutes=10)
-///     duration = Duration()
-///     duration.FromTimedelta(td)
+/// ```text
+///  td = datetime.timedelta(days=3, minutes=10)
+///  duration = Duration()
+///  duration.FromTimedelta(td)
+/// ```
 ///
 /// # JSON Mapping
 ///
@@ -1442,8 +1467,6 @@ pub struct Mixin {
 /// encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
 /// be expressed in JSON format as "3.000000001s", and 3 seconds and 1
 /// microsecond should be expressed in JSON format as "3.000001s".
-///
-///
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Duration {
     /// Signed seconds of the span of time. Must be from -315,576,000,000
@@ -1462,8 +1485,10 @@ pub struct Duration {
 }
 /// `FieldMask` represents a set of symbolic field paths, for example:
 ///
-///     paths: "f.a"
-///     paths: "f.b.d"
+/// ```text
+///  paths: "f.a"
+///  paths: "f.b.d"
+/// ```
 ///
 /// Here `f` represents a field in some root message, `a` and `b`
 /// fields in the message found in `f`, and `d` a field found in the
@@ -1480,27 +1505,30 @@ pub struct Duration {
 /// specified in the mask. For example, if the mask in the previous
 /// example is applied to a response message as follows:
 ///
-///     f {
-///       a : 22
-///       b {
-///         d : 1
-///         x : 2
-///       }
-///       y : 13
-///     }
-///     z: 8
+/// ```text
+///  f {
+///    a : 22
+///    b {
+///      d : 1
+///      x : 2
+///    }
+///    y : 13
+///  }
+///  z: 8
+/// ```
 ///
 /// The result will not contain specific values for fields x,y and z
 /// (their value will be set to the default, and omitted in proto text
 /// output):
 ///
-///
-///     f {
-///       a : 22
-///       b {
-///         d : 1
-///       }
-///     }
+/// ```text
+///  f {
+///    a : 22
+///    b {
+///      d : 1
+///    }
+///  }
+/// ```
 ///
 /// A repeated field is not allowed except at the last position of a
 /// paths string.
@@ -1538,36 +1566,42 @@ pub struct Duration {
 ///
 /// For example, given the target message:
 ///
-///     f {
-///       b {
-///         d: 1
-///         x: 2
-///       }
-///       c: \[1\]
-///     }
+/// ```text
+///  f {
+///    b {
+///      d: 1
+///      x: 2
+///    }
+///    c: \[1\]
+///  }
+/// ```
 ///
 /// And an update message:
 ///
-///     f {
-///       b {
-///         d: 10
-///       }
-///       c: \[2\]
-///     }
+/// ```text
+///  f {
+///    b {
+///      d: 10
+///    }
+///    c: \[2\]
+///  }
+/// ```
 ///
 /// then if the field mask is:
 ///
-///  paths: ["f.b", "f.c"]
+/// paths: \["f.b", "f.c"\]
 ///
 /// then the result will be:
 ///
-///     f {
-///       b {
-///         d: 10
-///         x: 2
-///       }
-///       c: [1, 2]
-///     }
+/// ```text
+///  f {
+///    b {
+///      d: 10
+///      x: 2
+///    }
+///    c: [1, 2]
+///  }
+/// ```
 ///
 /// An implementation may provide options to override this default behavior for
 /// repeated and message fields.
@@ -1605,51 +1639,63 @@ pub struct Duration {
 ///
 /// As an example, consider the following message declarations:
 ///
-///     message Profile {
-///       User user = 1;
-///       Photo photo = 2;
-///     }
-///     message User {
-///       string display_name = 1;
-///       string address = 2;
-///     }
+/// ```text
+///  message Profile {
+///    User user = 1;
+///    Photo photo = 2;
+///  }
+///  message User {
+///    string display_name = 1;
+///    string address = 2;
+///  }
+/// ```
 ///
 /// In proto a field mask for `Profile` may look as such:
 ///
-///     mask {
-///       paths: "user.display_name"
-///       paths: "photo"
-///     }
+/// ```text
+///  mask {
+///    paths: "user.display_name"
+///    paths: "photo"
+///  }
+/// ```
 ///
 /// In JSON, the same mask is represented as below:
 ///
-///     {
-///       mask: "user.displayName,photo"
-///     }
+/// ```text
+///  {
+///    mask: "user.displayName,photo"
+///  }
+/// ```
 ///
 /// # Field Masks and Oneof Fields
 ///
 /// Field masks treat fields in oneofs just as regular fields. Consider the
 /// following message:
 ///
-///     message SampleMessage {
-///       oneof test_oneof {
-///         string name = 4;
-///         SubMessage sub_message = 9;
-///       }
-///     }
+/// ```text
+///  message SampleMessage {
+///    oneof test_oneof {
+///      string name = 4;
+///      SubMessage sub_message = 9;
+///    }
+///  }
+/// ```
 ///
 /// The field mask can be:
 ///
-///     mask {
-///       paths: "name"
-///     }
+/// ```text
+///  mask {
+///    paths: "name"
+///  }
+/// ```
 ///
 /// Or:
 ///
-///     mask {
-///       paths: "sub_message"
-///     }
+/// ```text
+///  mask {
+///    paths: "sub_message"
+///  }
+/// ```
 ///
 /// Note that oneof type names ("test_oneof" in this case) cannot be used in
 /// paths.
@@ -1728,7 +1774,7 @@ pub struct ListValue {
 /// `NullValue` is a singleton enumeration to represent the null value for the
 /// `Value` type union.
 ///
-///  The JSON representation for `NullValue` is JSON `null`.
+/// The JSON representation for `NullValue` is JSON `null`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum NullValue {
@@ -1753,58 +1799,68 @@ pub enum NullValue {
 ///
 /// Example 1: Compute Timestamp from POSIX `time()`.
 ///
-///     Timestamp timestamp;
-///     timestamp.set_seconds(time(NULL));
-///     timestamp.set_nanos(0);
+/// ```text
+///  Timestamp timestamp;
+///  timestamp.set_seconds(time(NULL));
+///  timestamp.set_nanos(0);
+/// ```
 ///
 /// Example 2: Compute Timestamp from POSIX `gettimeofday()`.
 ///
-///     struct timeval tv;
-///     gettimeofday(&tv, NULL);
+/// ```text
+///  struct timeval tv;
+///  gettimeofday(&tv, NULL);
 ///
-///     Timestamp timestamp;
-///     timestamp.set_seconds(tv.tv_sec);
-///     timestamp.set_nanos(tv.tv_usec * 1000);
+///  Timestamp timestamp;
+///  timestamp.set_seconds(tv.tv_sec);
+///  timestamp.set_nanos(tv.tv_usec * 1000);
+/// ```
 ///
 /// Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
 ///
-///     FILETIME ft;
-///     GetSystemTimeAsFileTime(&ft);
-///     UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+/// ```text
+///  FILETIME ft;
+///  GetSystemTimeAsFileTime(&ft);
+///  UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
 ///
-///     // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
-///     // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
-///     Timestamp timestamp;
-///     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
-///     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+///  // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+///  // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+///  Timestamp timestamp;
+///  timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+///  timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+/// ```
 ///
 /// Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
 ///
-///     long millis = System.currentTimeMillis();
+/// ```text
+///  long millis = System.currentTimeMillis();
 ///
-///     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
-///         .setNanos((int) ((millis % 1000) * 1000000)).build();
-///
+///  Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+///      .setNanos((int) ((millis % 1000) * 1000000)).build();
+/// ```
 ///
 /// Example 5: Compute Timestamp from Java `Instant.now()`.
 ///
-///     Instant now = Instant.now();
+/// ```text
+///  Instant now = Instant.now();
 ///
-///     Timestamp timestamp =
-///         Timestamp.newBuilder().setSeconds(now.getEpochSecond())
-///             .setNanos(now.getNano()).build();
-///
+///  Timestamp timestamp =
+///      Timestamp.newBuilder().setSeconds(now.getEpochSecond())
+///          .setNanos(now.getNano()).build();
+/// ```
 ///
 /// Example 6: Compute Timestamp from current time in Python.
 ///
-///     timestamp = Timestamp()
-///     timestamp.GetCurrentTime()
+/// ```text
+///  timestamp = Timestamp()
+///  timestamp.GetCurrentTime()
+/// ```
 ///
 /// # JSON Mapping
 ///
 /// In JSON format, the Timestamp type is encoded as a string in the
 /// [RFC 3339](<https://www.ietf.org/rfc/rfc3339.txt>) format. That is, the
-/// format is "{year}-{month}-{day}T{hour}:{min}:{sec}\[.{frac_sec}\]Z"
+/// format is "{year}-{month}-{day}T{hour}:{min}:{sec}\\[.{frac_sec}\\]Z"
 /// where {year} is always expressed using four digits while {month}, {day},
 /// {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
 /// seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
@@ -1823,11 +1879,7 @@ pub enum NullValue {
 /// to this format using
 /// \[`strftime`\](<https://docs.python.org/2/library/time.html#time.strftime>) with
 /// the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
-/// the Joda Time's \[`ISODateTimeFormat.dateTime()`\](
-/// <http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime%2D%2D>
-/// ) to obtain a formatter capable of generating timestamps in this format.
-///
-///
+/// the Joda Time's \[`ISODateTimeFormat.dateTime()`\](<http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime%2D%2D>) to obtain a formatter capable of generating timestamps in this format.
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Timestamp {
     /// Represents seconds of UTC time since Unix epoch

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -24,7 +24,7 @@ protobuf = { path = "../protobuf" }
 
 [dev-dependencies]
 diff = "0.1"
-prost-build = { path = "../prost-build" }
+prost-build = { path = "../prost-build", features = ["cleanup-markdown"] }
 tempfile = "3"
 
 [build-dependencies]


### PR DESCRIPTION
I have been working with protocol buffers whose documentation includes code blocks, often things like example service descriptions and the like (consider https://github.com/googleapis/googleapis/blob/master/google/api/http.proto#L67-L81 )

As such, it's important that by the time prost-build has run, the code blocks in those comments have been transformed into something safe from `rustdoc`'s test extractor.

This PR is split into three commits.  The first adds the code-block processing support.  The second fixes up ensuring there's leading spaces in the comments to retain the pleasant-ish human look, and the third updates the generated code files for `prost-types` so that things are consistent.