### PR TITLE
Revert "build: Skip empty protobuf files (#605)"

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -880,10 +880,6 @@ impl Config {
 
         let modules = self.generate(requests)?;
         for (module, content) in &modules {
-            if content.is_empty() {
-                continue;
-            }
-
             let file_name = file_names
                 .get(module)
                 .expect("every module should have a filename");

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -109,6 +109,18 @@ fn main() {
         .compile_protos(&[src.join("well_known_types.proto")], includes)
         .unwrap();
 
+    let out = std::env::var("OUT_DIR").unwrap();
+    let out_path = PathBuf::from(out).join("wellknown_include");
+
+    std::fs::create_dir_all(&out_path).unwrap();
+
+    prost_build::Config::new()
+        .bytes(&["."])
+        .out_dir(out_path)
+        .include_file("wellknown_include.rs")
+        .compile_protos(&[src.join("well_known_types.proto")], includes)
+        .unwrap();
+
     config
         .compile_protos(
             &[src.join("packages/widget_factory.proto")],

--- a/tests/src/well_known_types.rs
+++ b/tests/src/well_known_types.rs
@@ -62,6 +62,7 @@ fn test_timestamp() {
     );
 }
 
+#[cfg(feature = "std")]
 mod include {
     include!(concat!(
         env!("OUT_DIR"),

--- a/tests/src/well_known_types.rs
+++ b/tests/src/well_known_types.rs
@@ -61,3 +61,10 @@ fn test_timestamp() {
         "hash for normalized should match and not inserted"
     );
 }
+
+mod include {
+    include!(concat!(
+        env!("OUT_DIR"),
+        "/wellknown_include/wellknown_include.rs"
+    ));
+}


### PR DESCRIPTION
This reverts commit c577d3f.

Fixes https://github.com/hyperium/tonic/issues/964