### PR TITLE
Only require cmake if using "vendored" feature

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [features]
 default = []
-vendored = []
+vendored = ["dep:cmake"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }
@@ -32,7 +32,7 @@ regex = { version = "1.5.5", default-features = false, features = ["std", "unico
 [build-dependencies]
 which = { version = "4", default-features = false }
 cfg-if = "1"
-cmake = "0.1"
+cmake = { version = "0.1", optional = true }
 
 [dev-dependencies]
 env_logger = { version = "0.8", default-features = false }

--- a/prost-build/build.rs
+++ b/prost-build/build.rs
@@ -62,18 +62,8 @@ fn path_protoc() -> Option<PathBuf> {
         .or_else(|| which("protoc").ok())
 }
 
-/// Returns true if the vendored flag is enabled.
-fn vendored() -> bool {
-    cfg_if! {
-        if #[cfg(feature = "vendored")] {
-            true
-        } else {
-            false
-        }
-    }
-}
-
 /// Compile `protoc` via `cmake`.
+#[cfg(feature = "vendored")]
 fn compile() -> Option<PathBuf> {
     let protobuf_src = bundle_path().join("protobuf").join("cmake");
 
@@ -89,11 +79,15 @@ fn compile() -> Option<PathBuf> {
 /// Check module docs for more info.
 fn protoc() -> Option<PathBuf> {
     if env::var_os("PROTOC_NO_VENDOR").is_some() {
-        path_protoc()
-    } else if vendored() {
-        compile()
-    } else {
-        path_protoc().or_else(compile)
+        return path_protoc();
+    }
+
+    cfg_if! {
+        if #[cfg(feature = "vendored")] {
+            path_protoc().or_else(compile)
+        } else {
+            path_protoc()
+        }
     }
 }
 


### PR DESCRIPTION
Only require cmake dependency for `prost-build` if using `vendored` feature. 

Issue #646 

CI seems to fail since it uses a older rust version. The `dep` syntax is only stable since 1.60