### PR TITLE
Disable building protobuf tests when building vendored protoc

### DIFF
--- a/prost-build/build.rs
+++ b/prost-build/build.rs
@@ -79,7 +79,9 @@ fn compile() -> Option<PathBuf> {
 
     println!("cargo:rerun-if-changed={}", protobuf_src.display());
 
-    let dst = cmake::Config::new(protobuf_src).build();
+    let dst = cmake::Config::new(protobuf_src)
+        .define("protobuf_BUILD_TESTS", "OFF")
+        .build();
 
     Some(dst.join("bin").join("protoc"))
 }


### PR DESCRIPTION
Pending the outcome of https://github.com/tokio-rs/prost/pull/620, can we at least disable running the protocol buffer tests when building protoc, this speeds up the build quite considerably.