### PR TITLE
fix case on type attribute in prost-build documentation

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -445,9 +445,9 @@ impl Config {
     /// config.type_attribute(".", "#[derive(Eq)]");
     /// // Some messages want to be serializable with serde as well.
     /// config.type_attribute("my_messages.MyMessageType",
-    ///                       "#[derive(Serialize)] #[serde(rename-all = \"snake_case\")]");
+    ///                       "#[derive(Serialize)] #[serde(rename_all = \"snake_case\")]");
     /// config.type_attribute("my_messages.MyMessageType.MyNestedMessageType",
-    ///                       "#[derive(Serialize)] #[serde(rename-all = \"snake_case\")]");
+    ///                       "#[derive(Serialize)] #[serde(rename_all = \"snake_case\")]");
     /// ```
     ///
     /// # Oneof fields


### PR DESCRIPTION
This fixes a small error in the `prost-build` documentation where an example for a `serde` attribute used `kabob-case` instad of `snake_case`. Correct syntax confirmed in their docs [here](https://serde.rs/container-attrs.html#rename_all)