### PR TITLE
chore: fix new clippy lint in generated code

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -184,7 +184,7 @@ impl<'a> CodeGenerator<'a> {
         self.append_type_attributes(&fq_message_name);
         self.push_indent();
         self.buf
-            .push_str("#[derive(Clone, PartialEq, ::prost::Message)]\n");
+            .push_str("#[derive(Clone, Eq, PartialEq, ::prost::Message)]\n");
         self.push_indent();
         self.buf.push_str("pub struct ");
         self.buf.push_str(&to_upper_camel(&message_name));
@@ -499,7 +499,7 @@ impl<'a> CodeGenerator<'a> {
         self.append_type_attributes(&oneof_name);
         self.push_indent();
         self.buf
-            .push_str("#[derive(Clone, PartialEq, ::prost::Oneof)]\n");
+            .push_str("#[derive(Clone, Eq, PartialEq, ::prost::Oneof)]\n");
         self.push_indent();
         self.buf.push_str("pub enum ");
         self.buf.push_str(&to_upper_camel(oneof.name()));


### PR DESCRIPTION
With rust version 1.62.0, the clippy lint [derive_partial_eq_without_eq](https://rust-lang.github.io/rust-clippy/master/index.html#derive_partial_eq_without_eq) was introduced. It makes the code generated by `prost-build` to fail clippy checks as it derives `PartialEq` but not `Eq`. This PR adds the `Eq` derive.
A patch release including this would be greatly appreciated as CI checks are failing for a lot of projects 🙏🏻 