### PR TITLE
Replace `.to_str_name()` with `.as_str_name()`

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -662,7 +662,7 @@ impl<'a> CodeGenerator<'a> {
         );
         self.push_indent();
         self.buf
-            .push_str("pub fn to_str_name(&self) -> &'static str {\n");
+            .push_str("pub fn as_str_name(&self) -> &'static str {\n");
         self.depth += 1;
 
         self.push_indent();
@@ -685,7 +685,7 @@ impl<'a> CodeGenerator<'a> {
 
         self.depth -= 1;
         self.push_indent();
-        self.buf.push_str("}\n"); // End of to_str_name()
+        self.buf.push_str("}\n"); // End of as_str_name()
 
         self.path.pop();
         self.depth -= 1;

--- a/prost-types/src/compiler.rs
+++ b/prost-types/src/compiler.rs
@@ -141,7 +141,7 @@ pub mod code_generator_response {
         ///
         /// The values are not transformed in any way and thus are considered stable
         /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn to_str_name(&self) -> &'static str {
+        pub fn as_str_name(&self) -> &'static str {
             match self {
                 Feature::None => "FEATURE_NONE",
                 Feature::Proto3Optional => "FEATURE_PROTO3_OPTIONAL",

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -214,7 +214,7 @@ pub mod field_descriptor_proto {
         ///
         /// The values are not transformed in any way and thus are considered stable
         /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn to_str_name(&self) -> &'static str {
+        pub fn as_str_name(&self) -> &'static str {
             match self {
                 Type::Double => "TYPE_DOUBLE",
                 Type::Float => "TYPE_FLOAT",
@@ -250,7 +250,7 @@ pub mod field_descriptor_proto {
         ///
         /// The values are not transformed in any way and thus are considered stable
         /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn to_str_name(&self) -> &'static str {
+        pub fn as_str_name(&self) -> &'static str {
             match self {
                 Label::Optional => "LABEL_OPTIONAL",
                 Label::Required => "LABEL_REQUIRED",
@@ -507,7 +507,7 @@ pub mod file_options {
         ///
         /// The values are not transformed in any way and thus are considered stable
         /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn to_str_name(&self) -> &'static str {
+        pub fn as_str_name(&self) -> &'static str {
             match self {
                 OptimizeMode::Speed => "SPEED",
                 OptimizeMode::CodeSize => "CODE_SIZE",
@@ -661,7 +661,7 @@ pub mod field_options {
         ///
         /// The values are not transformed in any way and thus are considered stable
         /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn to_str_name(&self) -> &'static str {
+        pub fn as_str_name(&self) -> &'static str {
             match self {
                 CType::String => "STRING",
                 CType::Cord => "CORD",
@@ -684,7 +684,7 @@ pub mod field_options {
         ///
         /// The values are not transformed in any way and thus are considered stable
         /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn to_str_name(&self) -> &'static str {
+        pub fn as_str_name(&self) -> &'static str {
             match self {
                 JsType::JsNormal => "JS_NORMAL",
                 JsType::JsString => "JS_STRING",
@@ -782,7 +782,7 @@ pub mod method_options {
         ///
         /// The values are not transformed in any way and thus are considered stable
         /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn to_str_name(&self) -> &'static str {
+        pub fn as_str_name(&self) -> &'static str {
             match self {
                 IdempotencyLevel::IdempotencyUnknown => "IDEMPOTENCY_UNKNOWN",
                 IdempotencyLevel::NoSideEffects => "NO_SIDE_EFFECTS",
@@ -1253,7 +1253,7 @@ pub mod field {
         ///
         /// The values are not transformed in any way and thus are considered stable
         /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn to_str_name(&self) -> &'static str {
+        pub fn as_str_name(&self) -> &'static str {
             match self {
                 Kind::TypeUnknown => "TYPE_UNKNOWN",
                 Kind::TypeDouble => "TYPE_DOUBLE",
@@ -1295,7 +1295,7 @@ pub mod field {
         ///
         /// The values are not transformed in any way and thus are considered stable
         /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-        pub fn to_str_name(&self) -> &'static str {
+        pub fn as_str_name(&self) -> &'static str {
             match self {
                 Cardinality::Unknown => "CARDINALITY_UNKNOWN",
                 Cardinality::Optional => "CARDINALITY_OPTIONAL",
@@ -1368,7 +1368,7 @@ impl Syntax {
     ///
     /// The values are not transformed in any way and thus are considered stable
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-    pub fn to_str_name(&self) -> &'static str {
+    pub fn as_str_name(&self) -> &'static str {
         match self {
             Syntax::Proto2 => "SYNTAX_PROTO2",
             Syntax::Proto3 => "SYNTAX_PROTO3",
@@ -1934,7 +1934,7 @@ impl NullValue {
     ///
     /// The values are not transformed in any way and thus are considered stable
     /// (if the ProtoBuf definition does not change) and safe for programmatic use.
-    pub fn to_str_name(&self) -> &'static str {
+    pub fn as_str_name(&self) -> &'static str {
         match self {
             NullValue::NullValue => "NULL_VALUE",
         }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -533,19 +533,19 @@ mod tests {
     fn test_enum_to_string() {
         use default_enum_value::{ERemoteClientBroadcastMsg, PrivacyLevel};
 
-        assert_eq!(PrivacyLevel::One.to_str_name(), "PRIVACY_LEVEL_ONE");
-        assert_eq!(PrivacyLevel::Two.to_str_name(), "PRIVACY_LEVEL_TWO");
+        assert_eq!(PrivacyLevel::One.as_str_name(), "PRIVACY_LEVEL_ONE");
+        assert_eq!(PrivacyLevel::Two.as_str_name(), "PRIVACY_LEVEL_TWO");
         assert_eq!(
-            PrivacyLevel::PrivacyLevelThree.to_str_name(),
+            PrivacyLevel::PrivacyLevelThree.as_str_name(),
             "PRIVACY_LEVEL_PRIVACY_LEVEL_THREE"
         );
         assert_eq!(
-            PrivacyLevel::PrivacyLevelprivacyLevelFour.to_str_name(),
+            PrivacyLevel::PrivacyLevelprivacyLevelFour.as_str_name(),
             "PRIVACY_LEVELPRIVACY_LEVEL_FOUR"
         );
 
         assert_eq!(
-            ERemoteClientBroadcastMsg::KERemoteClientBroadcastMsgDiscovery.to_str_name(),
+            ERemoteClientBroadcastMsg::KERemoteClientBroadcastMsgDiscovery.as_str_name(),
             "k_ERemoteClientBroadcastMsgDiscovery"
         );
     }


### PR DESCRIPTION
To be more convention compliant.