### PR TITLE
Permit overflow with wrapping.

### DIFF
--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -369,7 +369,11 @@ impl TryFrom<Timestamp> for std::time::SystemTime {
             std::time::UNIX_EPOCH.checked_add(time::Duration::from_secs(timestamp.seconds as u64))
         } else {
             std::time::UNIX_EPOCH.checked_sub(time::Duration::from_secs(
-                (-std::num::Wrapping(timestamp.seconds)).0 as u64,
+                timestamp
+                    .seconds
+                    .checked_neg()
+                    .ok_or(TimestampError::OutOfSystemRange(timestamp.clone()))?
+                    as u64,
             ))
         };
 

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -369,7 +369,7 @@ impl TryFrom<Timestamp> for std::time::SystemTime {
             std::time::UNIX_EPOCH.checked_add(time::Duration::from_secs(timestamp.seconds as u64))
         } else {
             std::time::UNIX_EPOCH
-                .checked_sub(time::Duration::from_secs((-timestamp.seconds) as u64))
+                .checked_sub(time::Duration::from_secs((-std::num::Wrapping(timestamp.seconds)).0 as u64))
         };
 
         let system_time = system_time.and_then(|system_time| {

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -368,8 +368,9 @@ impl TryFrom<Timestamp> for std::time::SystemTime {
         let system_time = if timestamp.seconds >= 0 {
             std::time::UNIX_EPOCH.checked_add(time::Duration::from_secs(timestamp.seconds as u64))
         } else {
-            std::time::UNIX_EPOCH
-                .checked_sub(time::Duration::from_secs((-std::num::Wrapping(timestamp.seconds)).0 as u64))
+            std::time::UNIX_EPOCH.checked_sub(time::Duration::from_secs(
+                (-std::num::Wrapping(timestamp.seconds)).0 as u64,
+            ))
         };
 
         let system_time = system_time.and_then(|system_time| {


### PR DESCRIPTION
Fixes #682 by allowing i64 wrapping during negation. 

This allows `seconds = i64::MIN` to pass with debug checks enabled.