### PR TITLE
Move edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
 keywords = ["protobuf", "serialization"]
 categories = ["encoding"]
-edition = "2018"
+edition = "2021"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ description = "A Protocol Buffers implementation for the Rust Language."
 keywords = ["protobuf", "serialization"]
 categories = ["encoding"]
 edition = "2021"
+rust-version = "1.56"
 
 [workspace]
 members = [


### PR DESCRIPTION
Looks like since I've last looked at the repo the update to
[MSRV 1.56 happened](https://github.com/tokio-rs/prost/pull/669) and we don't have any clippy errors on the 2021
edition. Therefore, I _think_ we can just up the edition now. 
If there's a good reason not to do so let me know and I can close this. 

I've also set the MSRV explicitly in the Cargo.toml so that users that happen to have an older rust version set (like I did when I was testing 1.51 at some point) get an error telling them they're on the wrong version instead of abstruse compiler errors. 

Closes #553, also closes #595 since 1.51 will no longer be supported.