### PR TITLE
chore: Prepare 0.11 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "prost"
-version = "0.10.1"
+version = "0.11.0"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
+    "Lucio Franco <luciofranco14@gmail.com",
     "Tokio Contributors <team@tokio.rs>",
 ]
 license = "Apache-2.0"
@@ -47,7 +48,7 @@ std = []
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-prost-derive = { version = "0.10.0", path = "prost-derive", optional = true }
+prost-derive = { version = "0.11.0", path = "prost-derive", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "prost-build"
-version = "0.10.1"
+version = "0.11.0"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
+    "Lucio Franco <luciofranco14@gmail.com>",
     "Tokio Contributors <team@tokio.rs>",
 ]
 license = "Apache-2.0"
@@ -25,8 +26,8 @@ itertools = "0.10"
 log = "0.4"
 multimap = { version = "0.8", default-features = false }
 petgraph = { version = "0.6", default-features = false }
-prost = { version = "0.10.0", path = "..", default-features = false }
-prost-types = { version = "0.10.0", path = "../prost-types", default-features = false }
+prost = { version = "0.11.0", path = "..", default-features = false }
+prost-types = { version = "0.11.0", path = "../prost-types", default-features = false }
 tempfile = "3"
 lazy_static = "1.4.0"
 regex = { version = "1.5.5", default-features = false, features = ["std", "unicode-bool"] }

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-build/0.10.1")]
+#![doc(html_root_url = "https://docs.rs/prost-build/0.11.0")]
 #![allow(clippy::option_as_ref_deref, clippy::format_push_string)]
 
 //! `prost-build` compiles `.proto` files into Rust.

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "prost-derive"
-version = "0.10.1"
+version = "0.11.0"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
+    "Lucio Franco <luciofranco14@gmail.com>",
     "Tokio Contributors <team@tokio.rs>",
 ]
 license = "Apache-2.0"

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "prost-types"
-version = "0.10.1"
+version = "0.11.0"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
+    "Lucio Franco <luciofranco14@gmail.com",
     "Tokio Contributors <team@tokio.rs>",
 ]
 license = "Apache-2.0"
@@ -22,7 +23,7 @@ std = ["prost/std"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-prost = { version = "0.10.0", path = "..", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.11", path = "..", default-features = false, features = ["prost-derive"] }
 
 [dev-dependencies]
 proptest = "1"

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-types/0.10.1")]
+#![doc(html_root_url = "https://docs.rs/prost-types/0.11.0")]
 
 //! Protocol Buffers well-known types.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost/0.10.1")]
+#![doc(html_root_url = "https://docs.rs/prost/0.11")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![doc = include_str!("../README.md")]
 


### PR DESCRIPTION
 _PROST!_ is a [Protocol Buffers](https://developers.google.com/protocol-buffers/) implementation for the
[Rust Language](https://www.rust-lang.org/). `prost` generates simple, idiomatic Rust code from `proto2` and
`proto3` files.

Relase 0.11 brings a few breaking changes and changes to how prost
sources protoc.

- `prost-build` now requires `protoc` to be available in the path or set
  via the `PROTOC` env var.
- `prost-types` now contains new `Timestamp`/`Duration` `FromStr` implementations.
- MSRV bump to `1.56` and all crates have been moved to edition 2021

Notible changes that are not breaking:

- `prost-build` now has a `cleanup-markdown` feature for cleaining up
  code blocks from protobuf files so that they work under rustdoc tests.
- `prost-build` now generates `as_str_name` for message types.