### PR TITLE
add clone to Service type

### DIFF
--- a/prost-build/src/ast.rs
+++ b/prost-build/src/ast.rs
@@ -5,7 +5,7 @@ use pulldown_cmark::{CodeBlockKind, Event, Options, Parser, Tag};
 use regex::Regex;
 
 /// Comments on a Protobuf item.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Comments {
     /// Leading detached blocks of comments.
     pub leading_detached: Vec<Vec<String>>,
@@ -178,7 +178,7 @@ impl Comments {
 }
 
 /// A service descriptor.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Service {
     /// The service name in Rust style.
     pub name: String,
@@ -195,7 +195,7 @@ pub struct Service {
 }
 
 /// A service method descriptor.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Method {
     /// The name of the method in Rust style.
     pub name: String,


### PR DESCRIPTION
I'm trying to make prost_build run several generators, because I want to make http and grpc servers. So I've written this code, but it fails to compile because `Service` doesn't implement `Clone`, so I've added the derive.
```rust
//<...>
impl ServiceGenerator for GeneratorList {
    fn generate(&mut self, service: Service, buf: &mut String) {
        for gen in self.generators.iter_mut() {
            gen.generate(service.clone(), buf); // Error: clone not found
        }
    }
    // <...>
}
```