### PR TITLE
Add snazzy module to example

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -62,9 +62,14 @@
 //!
 //! ```rust,ignore
 //! // Include the `items` module, which is generated from items.proto.
-//! pub mod items {
-//!     include!(concat!(env!("OUT_DIR"), "/snazzy.items.rs"));
+//! // It is important to maintain the same structure as in the proto.
+//! pub mod snazzy {
+//!     pub mod items {
+//!         include!(concat!(env!("OUT_DIR"), "/snazzy.items.rs"));
+//!     }
 //! }
+//!
+//! use snazzy::items;
 //!
 //! pub fn create_large_shirt(color: String) -> items::Shirt {
 //!     let mut shirt = items::Shirt::default();


### PR DESCRIPTION
Modify the example code for prost-build so that it uses the right module structure.

Otherwise this might cause issues if the proto imports other protos.

-----

However, it would be better if the example used directly the Config::include_file method, to make it easier to discover :). I can also change that if needed.