### PR TITLE
Allow generated `Message` derive path to be changed

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -35,6 +35,7 @@ pub struct CodeGenerator<'a> {
     extern_paths: &'a ExternPaths,
     depth: u8,
     path: Vec<i32>,
+    default_derive: String,
     buf: &'a mut String,
 }
 
@@ -68,6 +69,10 @@ impl<'a> CodeGenerator<'a> {
             Some(s) => panic!("unknown syntax: {}", s),
         };
 
+        let default_derive = format!(
+            "#[derive(Clone, PartialEq, {}::Message)]\n",
+            config.prost_path.as_deref().unwrap_or("::prost")
+        );
         let mut code_gen = CodeGenerator {
             config,
             package: file.package.unwrap_or_default(),
@@ -77,6 +82,7 @@ impl<'a> CodeGenerator<'a> {
             extern_paths,
             depth: 0,
             path: Vec::new(),
+            default_derive,
             buf,
         };
 
@@ -183,8 +189,7 @@ impl<'a> CodeGenerator<'a> {
         self.append_doc(&fq_message_name, None);
         self.append_type_attributes(&fq_message_name);
         self.push_indent();
-        self.buf
-            .push_str("#[derive(Clone, PartialEq, ::prost::Message)]\n");
+        self.buf.push_str(&self.default_derive);
         self.push_indent();
         self.buf.push_str("pub struct ");
         self.buf.push_str(&to_upper_camel(&message_name));

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -252,6 +252,7 @@ pub struct Config {
     disable_comments: PathMap<()>,
     skip_protoc_run: bool,
     include_file: Option<PathBuf>,
+    prost_path: Option<String>,
 }
 
 impl Config {
@@ -706,6 +707,17 @@ impl Config {
         self
     }
 
+    /// Configures the path that's used for deriving `Message` for generated messages.
+    /// This is mainly useful for generating crates that wish to re-export prost.
+    /// Defaults to `::prost::Message` if not specified.
+    pub fn prost_path<S>(&mut self, path: S) -> &mut Self
+    where
+        S: Into<String>,
+    {
+        self.prost_path = Some(path.into());
+        self
+    }
+
     /// Add an argument to the `protoc` protobuf compilation invocation.
     ///
     /// # Example `build.rs`
@@ -1062,6 +1074,7 @@ impl default::Default for Config {
             disable_comments: PathMap::default(),
             skip_protoc_run: false,
             include_file: None,
+            prost_path: None,
         }
     }
 }
@@ -1082,6 +1095,7 @@ impl fmt::Debug for Config {
             .field("default_package_filename", &self.default_package_filename)
             .field("protoc_args", &self.protoc_args)
             .field("disable_comments", &self.disable_comments)
+            .field("prost_path", &self.prost_path)
             .finish()
     }
 }


### PR DESCRIPTION
I have a use case where I'm building a wrapper around `prost-build` in combination with `prost-reflect` to extract protobuf custom options and do some magic.
However, since this wrapper, let's call it `my-build`, will be used from a large number of different crates it would be ideal to have the `my-core` crate re-export `prost` to simplify upgrades down the line.

In order to facilitate this use case I've added a simple configuration option which would allow me to change the default `#[derive(::prost::Message)]` to `#[derive(::my_crate::prost::Message)]`.

Hopefully, it's a simple enough change that it won't be too controversial 😄 

Please let me know if there's anything you'd like me to change.