### PR TITLE
add `Message` support for heapless::{Vec,String}

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,14 @@ bench = false
 
 [features]
 default = ["prost-derive", "std"]
+heapless = ["dep:heapless"]
 no-recursion-limit = []
 std = []
 
 [dependencies]
 bytes = { version = "1", default-features = false }
 prost-derive = { version = "0.11.0", path = "prost-derive", optional = true }
+heapless = { version = "0.7.16", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/src/types.rs
+++ b/src/types.rs
@@ -322,8 +322,86 @@ impl Message for String {
     }
 }
 
+/// `google.protobuf.StringValue`
+#[cfg(feature = "heapless")]
+impl <const N: usize> Message for heapless::String<N> {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        if !self.is_empty() {
+            string::encode_heapless(1, self, buf)
+        }
+    }
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        if tag == 1 {
+            string::merge_heapless(wire_type, self, buf, ctx)
+        } else {
+            skip_field(wire_type, tag, buf, ctx)
+        }
+    }
+    fn encoded_len(&self) -> usize {
+        if !self.is_empty() {
+            crate::encoding::key_len(1) + crate::encoded_len_varint(self.len() as u64) + self.len()
+        } else {
+            0
+        }
+    }
+    fn clear(&mut self) {
+        self.clear();
+    }
+}
+
 /// `google.protobuf.BytesValue`
 impl Message for Vec<u8> {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        if !self.is_empty() {
+            bytes::encode(1, self, buf)
+        }
+    }
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        if tag == 1 {
+            bytes::merge(wire_type, self, buf, ctx)
+        } else {
+            skip_field(wire_type, tag, buf, ctx)
+        }
+    }
+    fn encoded_len(&self) -> usize {
+        if !self.is_empty() {
+            bytes::encoded_len(1, self)
+        } else {
+            0
+        }
+    }
+    fn clear(&mut self) {
+        self.clear();
+    }
+}
+
+#[cfg(feature = "heapless")]
+/// `google.protobuf.BytesValue`
+impl <const N: usize> Message for heapless::Vec<u8, N> {
     fn encode_raw<B>(&self, buf: &mut B)
     where
         B: BufMut,

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,6 +12,7 @@ build = "src/build.rs"
 
 [features]
 default = ["std"]
+heapless = [ "dep:heapless", "prost/heapless" ]
 std = []
 
 [dependencies]
@@ -21,6 +22,7 @@ cfg-if = "1"
 prost = { path = ".." }
 prost-types = { path = "../prost-types" }
 protobuf = { path = "../protobuf" }
+heapless = { version = "0.7.16", optional = true }
 
 [dev-dependencies]
 diff = "0.1"

--- a/tests/src/derive_heapless.rs
+++ b/tests/src/derive_heapless.rs
@@ -1,0 +1,39 @@
+
+use core::fmt::Debug;
+use prost::Message;
+use heapless::{Vec, String};
+
+
+// Helper for encode/decode tests
+fn encode_decode<T: Debug + PartialEq + Default + Message>(a: T) {
+
+    let buff = a.encode_to_vec();
+
+    let b = T::decode(&*buff).unwrap();
+
+    assert_eq!(a, b);
+}
+
+/// [`heapless::String`] container
+#[derive(Clone, PartialEq, Message)]
+pub struct TestString {
+    #[prost(message, required, tag = "1")]
+    pub s: String<32>,
+}
+
+#[test]
+fn encode_decode_string() {
+    encode_decode(TestString{ s: String::from("abc1234") });
+}
+
+/// [`heapless::Vec`] container
+#[derive(Clone, PartialEq, Message)]
+pub struct TestVec {
+    #[prost(message, required, tag = "1")]
+    pub s: Vec<u8, 32>,
+}
+
+#[test]
+fn encode_decode_bytes() {
+    encode_decode(TestVec{ s: Vec::from_slice(&[0xaa, 0xbb, 0xcc]).unwrap() });
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -45,6 +45,9 @@ mod no_unused_results;
 #[cfg(test)]
 mod well_known_types;
 
+#[cfg(all(test, feature = "heapless"))]
+mod derive_heapless;
+
 pub mod foo {
     pub mod bar_baz {
         include!(concat!(env!("OUT_DIR"), "/foo.bar_baz.rs"));


### PR DESCRIPTION
hey there,

this PR adds preliminary support for `heapless::String` and `heapless::Vec` behind the `heapless` feature, for those of us running prost without an allocator ^_^

the logic is basically a clone of the existing `alloc::string::String` and `alloc::vec::Vec` implementations because i couldn't see an easy way of genericising across these.