### PR TITLE
chore: Prepare `0.11.2` release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost"
-version = "0.11.0"
+version = "0.11.2"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Lucio Franco <luciofranco14@gmail.com",

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost-build"
-version = "0.11.1"
+version = "0.11.2"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Lucio Franco <luciofranco14@gmail.com>",

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-build/0.11.1")]
+#![doc(html_root_url = "https://docs.rs/prost-build/0.11.2")]
 #![allow(clippy::option_as_ref_deref, clippy::format_push_string)]
 
 //! `prost-build` compiles `.proto` files into Rust.

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost-derive"
-version = "0.11.0"
+version = "0.11.2"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Lucio Franco <luciofranco14@gmail.com>",

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-derive/0.10.1")]
+#![doc(html_root_url = "https://docs.rs/prost-derive/0.10.2")]
 // The `quote!` macro requires deep recursion.
 #![recursion_limit = "4096"]
 

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost-types"
-version = "0.11.1"
+version = "0.11.2"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Lucio Franco <luciofranco14@gmail.com",

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-types/0.11.1")]
+#![doc(html_root_url = "https://docs.rs/prost-types/0.11.2")]
 
 //! Protocol Buffers well-known types.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost/0.11")]
+#![doc(html_root_url = "https://docs.rs/prost/0.11.2")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![doc = include_str!("../README.md")]
 


### PR DESCRIPTION
_PROST!_ is a [Protocol Buffers](https://developers.google.com/protocol-buffers/) implementation for the [Rust Language](https://www.rust-lang.org/). `prost` generates simple, idiomatic Rust code from `proto2` and `proto3` files.

This patch updates brings a few new features and fixes:
- build: Improve `protoc` sourcing instructions in error messages.
- build: Add `Clone` to `Service` types.
- build: Sort modules to produce deterministic include files.
- core: Tuple struct support.
- build: Allow generated code derive path's to be changed.
- build: Allow changing prost crate path.
- build: Add code formatting support.