### PR TITLE
fix(build): do not unwrap modules unconditionally

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1066,8 +1066,9 @@ impl Config {
 
         if let Some(ref mut service_generator) = self.service_generator {
             for (module, package) in packages {
-                let buf = modules.get_mut(&module).unwrap();
-                service_generator.finalize_package(&package, buf);
+                if let Some(buf) = modules.get_mut(&module) {
+                    service_generator.finalize_package(&package, buf);
+                }
             }
         }
 


### PR DESCRIPTION
This happens for protos referencing a different package from their name, i.e. something like foo/v1/bar.proto where bar.proto defines `package foo.v1`.

Fixes #747