### PR TITLE
Support custom recursion limits at runtime

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -199,7 +199,7 @@ pub struct DecodeContext {
     /// customized. The recursion limit can be ignored by building the Prost
     /// crate with the `no-recursion-limit` feature.
     #[cfg(not(feature = "no-recursion-limit"))]
-    recurse_count: u32,
+    pub recurse_count: u32,
 }
 
 #[cfg(not(feature = "no-recursion-limit"))]


### PR DESCRIPTION
We decode protobuf from both trusted and untrusted sources, so the `no-recursion-limit` feature wasn't a good fit for our workload.

As a followup to #186, this PR introduces a `decode_with_context` function that allows users to customize the `DecodeContext`. I chose a generic approach (instead of `decode_with_recursion_limit`) in case there are additional decode settings that might be added in the future.

Thoughts on the best place to document this, and whether any additional tests are required?

Todo:
- [ ] update the inline docs on `DecodeContext`