### PR TITLE
Replace prints with logging

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -994,11 +994,11 @@ fn unescape_c_escape_string(s: &str) -> Vec<u8> {
                     p += 1;
                 }
                 b'0'..=b'7' => {
-                    eprintln!("another octal: {}, offset: {}", s, &s[p..]);
+                    debug!("another octal: {}, offset: {}", s, &s[p..]);
                     let mut octal = 0;
                     for _ in 0..3 {
                         if p < len && src[p] >= b'0' && src[p] <= b'7' {
-                            eprintln!("\toctal: {}", octal);
+                            debug!("\toctal: {}", octal);
                             octal = octal * 8 + (src[p] - b'0');
                             p += 1;
                         } else {

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -138,6 +138,7 @@ use std::ops::RangeToInclusive;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use log::debug;
 use log::trace;
 
 use prost::Message;
@@ -857,7 +858,7 @@ impl Config {
                 if include.as_ref().exists() {
                     cmd.arg("-I").arg(include.as_ref());
                 } else {
-                    println!(
+                    debug!(
                         "ignoring {} since it does not exist.",
                         include.as_ref().display()
                     )
@@ -878,7 +879,7 @@ impl Config {
                 cmd.arg(proto.as_ref());
             }
 
-            println!("Running: {:?}", cmd);
+            debug!("Running: {:?}", cmd);
 
             let output = cmd.output().map_err(|error| {
                 Error::new(


### PR DESCRIPTION
Simply removes prints in favor of logging. This makes prost-build less noisy when used outside a build.rs.