### PR TITLE
chore: Prepare 0.11.3 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost"
-version = "0.11.2"
+version = "0.11.3"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Lucio Franco <luciofranco14@gmail.com",

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost-build"
-version = "0.11.2"
+version = "0.11.3"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Lucio Franco <luciofranco14@gmail.com>",

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-build/0.11.2")]
+#![doc(html_root_url = "https://docs.rs/prost-build/0.11.3")]
 #![allow(clippy::option_as_ref_deref, clippy::format_push_string)]
 
 //! `prost-build` compiles `.proto` files into Rust.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost/0.11.2")]
+#![doc(html_root_url = "https://docs.rs/prost/0.11.3")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![doc = include_str!("../README.md")]
 


### PR DESCRIPTION
_PROST!_ is a [Protocol Buffers](https://developers.google.com/protocol-buffers/) implementation for the [Rust Language](https://www.rust-lang.org/). `prost` generates simple, idiomatic Rust code from `proto2` and `proto3` files.

This patch updates brings a few new features and fixes:
- build: Use `log` to print error logs.
- build: Remove accidentally included prints.
- build: Improve debian error message hint.
