### PR TITLE
chore(build): Ignore clippy warning derive_partial_eq_without_eq

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -183,6 +183,8 @@ impl<'a> CodeGenerator<'a> {
         self.append_doc(&fq_message_name, None);
         self.append_type_attributes(&fq_message_name);
         self.push_indent();
+        self.buf
+            .push_str("#[allow(clippy::derive_partial_eq_without_eq)]\n");
         self.buf.push_str(&format!(
             "#[derive(Clone, PartialEq, {}::Message)]\n",
             self.config.prost_path.as_deref().unwrap_or("::prost")
@@ -505,6 +507,8 @@ impl<'a> CodeGenerator<'a> {
         let oneof_name = format!("{}.{}", fq_message_name, oneof.name());
         self.append_type_attributes(&oneof_name);
         self.push_indent();
+        self.buf
+            .push_str("#[allow(clippy::derive_partial_eq_without_eq)]\n");
         self.buf.push_str(&format!(
             "#[derive(Clone, PartialEq, {}::Oneof)]\n",
             self.config.prost_path.as_deref().unwrap_or("::prost")

--- a/tests/single-include/src/outdir/outdir.rs
+++ b/tests/single-include/src/outdir/outdir.rs
@@ -1,3 +1,4 @@
+#[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OutdirRequest {
     #[prost(string, tag = "1")]


### PR DESCRIPTION
Ignores clippy warning [derive_partial_eq_without_eq](https://rust-lang.github.io/rust-clippy/stable/#derive_partial_eq_without_eq) in generated codes to solve clippy warning easily in projects using prost-build.