### PR TITLE
no_std/sgx: deps: fix itertools features

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -23,7 +23,7 @@ cleanup-markdown = ["pulldown-cmark", "pulldown-cmark-to-cmark"]
 [dependencies]
 bytes = { version = "1", default-features = false }
 heck = "0.4"
-itertools = "0.10"
+itertools = { version = "0.10", default-features = false, features = ["use_alloc"] }
 log = "0.4"
 multimap = { version = "0.8", default-features = false }
 petgraph = { version = "0.6", default-features = false }

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -19,7 +19,7 @@ proc_macro = true
 
 [dependencies]
 anyhow = "1.0.1"
-itertools = "0.10"
+itertools = { version = "0.10", default-features = false, features = ["use_alloc"] }
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "1.0.3", features = [ "extra-traits" ] }


### PR DESCRIPTION
This allows prost(or rather `prost-derive`) to be built in SGX environment.

Without this the dependencies are:
```
either v1.8.0
└── itertools v0.10.5
    └── prost-derive v0.11.2 (proc-macro)
        └── prost v0.11.3
            └── XXX v0.1.0 (/XXX) (*)
```
And "either" fails to build under no_std:
`cargo no-std-check --manifest-path Cargo.toml`:

```
error[E0463]: can't find crate for `std`
  --> /home/pratn/.cargo/registry/src/github.com-1ecc6299db9ec823/either-1.8.0/src/lib.rs:19:1
   |
19 | extern crate std;
   | ^^^^^^^^^^^^^^^^^ can't find crate
[...]
```

I also used the same features for `prost-build` for consistency, but this is not really required I guess?