### PR TITLE
Add Kani to CI.

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -96,6 +96,27 @@ jobs:
           command: test
           args: --no-default-features
 
+  kani:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: Verify with Kani
+        uses: model-checking/kani-github-action@v0.19
+        with:
+          enable-propproof: true
+          args: |
+            --tests -p prost-types --default-unwind 3 \
+            --harness "tests::check_timestamp_roundtrip_via_system_time"
+        # --default-unwind N roughly corresponds to how much effort
+        # Kani will spend trying to prove correctness of the
+        # program. Higher the number, more programs can be proven
+        # correct. However, Kani will require more time and memory. If
+        # Kani fails with "Failed Checks: unwinding assertion," this
+        # number may need to be raised for Kani to succeed.
+
   no-std:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds Kani to the CI as previously discussed with @LucioFranco.

- This PR adds Kani verification to only the `tests::check_timestamp_roundtrip_via_system_time` proptest harness. We focused on this harness because it was involved in bug #682
- Remaining harnesses within `prost-types` are blocked by [Kani issue 274](https://github.com/model-checking/kani/issues/274). We are working to implement the required features to resolve 274 and we will submit a second PR to enable these harnesses once Kani implements the feature.
- Harnesses outside of `prost-types` will be difficult to support within GitHub Actions due to Kani's large memory consumption when running these harnesses.