### PR TITLE
chore(types): Remove including generated code

### DIFF
--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -11,6 +11,10 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+mod compiler;
+mod datetime;
+mod protobuf;
+
 use core::convert::TryFrom;
 use core::fmt;
 use core::i32;
@@ -18,12 +22,7 @@ use core::i64;
 use core::str::FromStr;
 use core::time;
 
-include!("protobuf.rs");
-pub mod compiler {
-    include!("compiler.rs");
-}
-
-mod datetime;
+pub use protobuf::*;
 
 // The Protobuf `Duration` and `Timestamp` types can't delegate to the standard library equivalents
 // because the Protobuf versions are signed. To make them easier to work with, `From` conversions

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -11,8 +11,10 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[rustfmt::skip]
 mod compiler;
 mod datetime;
+#[rustfmt::skip]
 mod protobuf;
 
 use core::convert::TryFrom;


### PR DESCRIPTION
Removes including generated codes from prost-types. This wil improve our development experience allowing rust-analyzer to jump to the actual generated codes instead of the include sentence.