### PR TITLE
Fix issue with negative nanos in Duration::try_from(), and add tests

### DIFF
--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -496,7 +496,7 @@ mod tests {
         };
 
         assert!(matches!(
-           dbg!(time::Duration::try_from(neg_prost_duration)),
+           time::Duration::try_from(neg_prost_duration),
            Err(DurationError::NegativeDuration(d)) if d == std_duration,
         ))
     }


### PR DESCRIPTION
If `seconds` are `0`, but `nanos` are negative, `Duration::try_from` incorrectly treats the duration as positive.  The negative `nanos` are unconditionally cast to `u32`, leading to an invalid positive `Duration`.  

1. Fixes the check.
2. Adds a regression test for the reproducer.
3. Adds a proptest to detect any cases where this might occur.

This issue was found using [Kani Rust Verifier](https://github.com/model-checking/kani)