### PR TITLE
Clarify `default_package_filename` documentation.

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -794,6 +794,7 @@ impl Config {
     }
 
     /// Configures what filename protobufs with no package definition are written to.
+    /// The filename will be appended with the `.rs` extension.
     pub fn default_package_filename<S>(&mut self, filename: S) -> &mut Self
     where
         S: Into<String>,


### PR DESCRIPTION
Added a line clarifying that `default_package_filename` receives a base-name and adds an extension itself.

Issue:
 - https://github.com/tokio-rs/prost/issues/807