### PR TITLE
Remove usage of the flag experimental_allow_proto3_optional

### DIFF
--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -91,7 +91,6 @@ fn main() {
         .unwrap();
 
     prost_build::Config::new()
-        .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(&[src.join("proto3_presence.proto")], includes)
         .unwrap();
 


### PR DESCRIPTION
Optional fields in the proto3 syntax are now stabilised. This flag has been removed in newer version of protoc and now causes issues building tests.