### PR TITLE
chore: Update github action

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -11,17 +11,11 @@ jobs:
         with:
           submodules: recursive
       - name: install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-            toolchain: stable
-            default: true
-            profile: minimal
             components: rustfmt
       - name: rustfmt
-        uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+        run: cargo fmt --all --check
 # Disabled because downstream crates don't check this as well
 #   minversions:
 #     runs-on: ubuntu-latest
@@ -73,28 +67,20 @@ jobs:
         with:
           submodules: recursive
       - name: install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
             toolchain: ${{ matrix.toolchain }}
-            default: true
-            profile: minimal
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: install ninja
         uses: seanmiddleditch/gha-setup-ninja@v3
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --workspace --all-targets
+        run: cargo test --workspace --all-targets
       - name: test no-default-features
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --no-default-features
+        run: cargo test --no-default-features
 
   kani:
     runs-on: ubuntu-latest
@@ -125,38 +111,24 @@ jobs:
         with:
           submodules: recursive
       - name: install toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-            toolchain: nightly
-            default: true
-            profile: minimal
+        uses: dtolnay/rust-toolchain@nightly
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: Swatinem/rust-cache@v1
+      - uses: Swatinem/rust-cache@v2
       - name: install cargo-no-std-check
-        uses: actions-rs/cargo@v1
+        uses: baptiste0928/cargo-install@v1
         with:
-          command: install
-          args: cargo-no-std-check
+          crate: cargo-no-std-check
       - name: prost cargo-no-std-check
-        uses: actions-rs/cargo@v1
-        with:
-          command: no-std-check
-          args: --manifest-path Cargo.toml --no-default-features
+        run: cargo no-std-check --manifest-path Cargo.toml --no-default-features
       - name: prost-types cargo-no-std-check
-        uses: actions-rs/cargo@v1
-        with:
-          command: no-std-check
-          args: --manifest-path prost-types/Cargo.toml --no-default-features
+        run: cargo no-std-check --manifest-path prost-types/Cargo.toml --no-default-features
       # prost-build depends on prost with --no-default-features, but when
       # prost-build is built through the workspace, prost typically has default
       # features enabled due to vagaries in Cargo workspace feature resolution.
       # This additional check ensures that prost-build does not rely on any of
       # prost's default features to compile.
       - name: prost-build check
-        uses: actions-rs/cargo@v1
-        with:
-          command: check
-          args: --manifest-path prost-build/Cargo.toml
+        run: cargo check --manifest-path prost-build/Cargo.toml


### PR DESCRIPTION
Updates github action configs.

- Switches to dtolnay/rust-toolchain from actions-rs/toolchain as it is outdated.
- Switches to use `run:` from actions-rs/cargo as it is outdated.
- Switches to baptiste0928/cargo-install from actions-rs/cargo when install a tool.
- Update Swatinem/rust-cache to v2 from v1.