### PR TITLE
chore: Add cargo-machete to detect unused dependencies

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -70,6 +70,12 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
             toolchain: ${{ matrix.toolchain }}
+      - name: Install cargo-machete
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-machete
+      - name: Check unused dependencies
+        run: cargo machete
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:

--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -50,6 +50,22 @@ jobs:
 #           args: --workspace --all-targets
 #           toolchain: stable
 
+  machete:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+      - name: install toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-machete
+        uses: baptiste0928/cargo-install@v1
+        with:
+          crate: cargo-machete
+      - name: Check unused dependencies
+        run: cargo machete
+
   test:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -70,12 +86,6 @@ jobs:
         uses: dtolnay/rust-toolchain@master
         with:
             toolchain: ${{ matrix.toolchain }}
-      - name: Install cargo-machete
-        uses: baptiste0928/cargo-install@v1
-        with:
-          crate: cargo-machete
-      - name: Check unused dependencies
-        run: cargo machete
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
         with:

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 [dependencies]
 bytes = "1"
 env_logger = { version = "0.8", default-features = false }
-log = "0.4"
 prost = { path = ".." }
 protobuf = { path = "../protobuf" }
 tests = { path = "../tests" }

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -22,7 +22,6 @@ default = ["std"]
 std = ["prost/std"]
 
 [dependencies]
-bytes = { version = "1", default-features = false }
 prost = { version = "0.11.6", path = "..", default-features = false, features = ["prost-derive"] }
 
 [dev-dependencies]

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytes = { version = "1", default-features = false }
 prost = { path = ".." }
 prost-types = { path = "../prost-types" }
 
@@ -39,3 +38,6 @@ bench = false
 [[bench]]
 name = "dataset"
 harness = false
+
+[package.metadata.cargo-machete]
+ignored = ["prost-types"]


### PR DESCRIPTION
Adds cargo-machete to detect unused dependencies in order to keep manifests not to depend on unused crates, and removes detected crates.