### PR TITLE
chore: Update msrv to 1.60

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "A Protocol Buffers implementation for the Rust Language."
 keywords = ["protobuf", "serialization"]
 categories = ["encoding"]
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [workspace]
 members = [

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/prost-build"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [features]
 default = ["format"]
@@ -43,4 +43,3 @@ pulldown-cmark-to-cmark = { version = "10.0.1", optional = true }
 
 [dev-dependencies]
 env_logger = { version = "0.8", default-features = false }
-

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/prost-derive"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [lib]
 proc_macro = true

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/prost-types"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
 edition = "2021"
-rust-version = "1.56"
+rust-version = "1.60"
 
 [lib]
 doctest = false


### PR DESCRIPTION
Updates rust-version field in manifests to follow to #814.