### PR TITLE
fix: correct change in visibility of compiler module

### DIFF
--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -12,7 +12,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
 #[rustfmt::skip]
-mod compiler;
+pub mod compiler;
 mod datetime;
 #[rustfmt::skip]
 mod protobuf;


### PR DESCRIPTION
Introduced in #801
Closes #823