### PR TITLE
Update to `syn@2` & `prettyplease@0.2`

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -34,8 +34,8 @@ lazy_static = "1.4.0"
 regex = { version = "1.5.5", default-features = false, features = ["std", "unicode-bool"] }
 which = "4"
 
-prettyplease = { version = "0.1", optional = true }
-syn = { version = "1", features = ["full"], optional = true }
+prettyplease = { version = "0.2", optional = true }
+syn = { version = "2", features = ["full"], optional = true }
 
 # These two must be kept in sync, used for `cleanup-markdown` feature.
 pulldown-cmark = { version = "0.9.1", optional = true, default-features = false }


### PR DESCRIPTION
They both have the same MSRV: 1.56.0

https://github.com/dtolnay/syn/blob/master/Cargo.toml#L21
https://github.com/dtolnay/prettyplease/blob/master/Cargo.toml#L15