### PR TITLE
Fix build in directory not named `prost`

### DIFF
--- a/tests/single-include/Cargo.toml
+++ b/tests/single-include/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 license = "MIT"
 
 [dependencies]
-prost = { path = "../../../prost" }
+prost = { path = "../.." }
 
 [build-dependencies]
 prost-build = { path = "../../prost-build" }


### PR DESCRIPTION
This library will fail to build with the following error when checked out into a directory not named exactly `prost`:

```
error: failed to load manifest for workspace member `/home/alex/src/prost-rs/tests/single-include`

Caused by:
  failed to load manifest for dependency `prost`

Caused by:
  failed to read `/home/alex/src/prost/Cargo.toml`

Caused by:
  No such file or directory (os error 2)
```

This is because the `single-include` test depends on `prost` with the path `../../../prost`. This patch fixes the issue by correcting the path to `../..`.