### PR TITLE
Fix invalid `fq_message_name` when appending nested message in empty package

### DIFF
--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -95,6 +95,10 @@ fn main() {
         .compile_protos(&[src.join("custom_debug.proto")], includes)
         .unwrap();
 
+    config
+        .compile_protos(&[src.join("issue_843.proto")], includes)
+        .unwrap();
+
     prost_build::Config::new()
         .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(&[src.join("proto3_presence.proto")], includes)

--- a/tests/src/issue_843.proto
+++ b/tests/src/issue_843.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+message M {
+  message SubMessage {
+    map<string, string> item = 1;
+  }
+  SubMessage reply = 2;
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -120,6 +120,10 @@ pub mod default_string_escape {
     include!(concat!(env!("OUT_DIR"), "/default_string_escape.rs"));
 }
 
+pub mod issue_843 {
+    include!(concat!(env!("OUT_DIR"), "/_.rs"));
+}
+
 use alloc::vec::Vec;
 
 use anyhow::anyhow;
@@ -622,6 +626,11 @@ mod tests {
     fn test_default_string_escape() {
         let msg = default_string_escape::Person::default();
         assert_eq!(msg.name, r#"["unknown"]"#);
+    }
+
+    #[test]
+    fn test_issue_843() {
+        let _msg = issue_843::M::default();
     }
 
     #[test]


### PR DESCRIPTION
On appending nested message, if package is empty, wrong `fq_message_name` is generated(e.g. `..M.SubMessage` in this case), which leads to codegen failure. Making `CodeGenerator::package` vec and removing the string hacks solve this issue.

fixes #843 