### PR TITLE
feat: add TryFrom<i32> implementation to Enumeration

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,21 +163,22 @@ The `#[derive(::prost::Enumeration)]` annotation added to the generated
 ```rust,ignore
 impl PhoneType {
     pub fn is_valid(value: i32) -> bool { ... }
+    #[deprecated]
     pub fn from_i32(value: i32) -> Option<PhoneType> { ... }
 }
 ```
 
-so you can convert an `i32` to its corresponding `PhoneType` value by doing,
+It also adds an `impl TryFrom<i32> for PhoneType`, so you can convert an `i32` to its corresponding `PhoneType` value by doing,
 for example:
 
 ```rust,ignore
 let phone_type = 2i32;
 
-match PhoneType::from_i32(phone_type) {
-    Some(PhoneType::Mobile) => ...,
-    Some(PhoneType::Home) => ...,
-    Some(PhoneType::Work) => ...,
-    None => ...,
+match PhoneType::try_from(phone_type) {
+    Ok(PhoneType::Mobile) => ...,
+    Ok(PhoneType::Home) => ...,
+    Ok(PhoneType::Work) => ...,
+    Err(_) => ...,
 }
 ```
 

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -279,11 +279,17 @@ impl Field {
             Some(quote! {
                 #[doc=#get_doc]
                 pub fn #get(&self, key: #key_ref_ty) -> ::core::option::Option<#ty> {
-                    self.#ident.get(#take_ref key).cloned().and_then(#ty::from_i32)
+                    self.#ident.get(#take_ref key).cloned().and_then(|x| {
+                        let result: Result<#ty, _> = ::core::convert::TryFrom::try_from(x);
+                        result.ok()
+                    })
                 }
                 #[doc=#insert_doc]
                 pub fn #insert(&mut self, key: #key_ty, value: #ty) -> ::core::option::Option<#ty> {
-                    self.#ident.insert(key, value as i32).and_then(#ty::from_i32)
+                    self.#ident.insert(key, value as i32).and_then(|x| {
+                        let result: Result<#ty, _> = ::core::convert::TryFrom::try_from(x);
+                        result.ok()
+                    })
                 }
             })
         } else {

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -221,9 +221,10 @@ impl Field {
                 struct #wrap_name<'a>(&'a i32);
                 impl<'a> ::core::fmt::Debug for #wrap_name<'a> {
                     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                        match #ty::from_i32(*self.0) {
-                            None => ::core::fmt::Debug::fmt(&self.0, f),
-                            Some(en) => ::core::fmt::Debug::fmt(&en, f),
+                        let res: Result<#ty, _> = ::core::convert::TryFrom::try_from(*self.0);
+                        match res {
+                            Err(_) => ::core::fmt::Debug::fmt(&self.0, f),
+                            Ok(en) => ::core::fmt::Debug::fmt(&en, f),
                         }
                     }
                 }
@@ -297,7 +298,7 @@ impl Field {
                     quote! {
                         #[doc=#get_doc]
                         pub fn #get(&self) -> #ty {
-                            #ty::from_i32(self.#ident).unwrap_or(#default)
+                            ::core::convert::TryFrom::try_from(self.#ident).unwrap_or(#default)
                         }
 
                         #[doc=#set_doc]
@@ -315,7 +316,10 @@ impl Field {
                     quote! {
                         #[doc=#get_doc]
                         pub fn #get(&self) -> #ty {
-                            self.#ident.and_then(#ty::from_i32).unwrap_or(#default)
+                            self.#ident.and_then(|x| {
+                                let result: Result<#ty, _> = ::core::convert::TryFrom::try_from(x);
+                                result.ok()
+                            }).unwrap_or(#default)
                         }
 
                         #[doc=#set_doc]
@@ -337,7 +341,10 @@ impl Field {
                             ::core::iter::Cloned<::core::slice::Iter<i32>>,
                             fn(i32) -> ::core::option::Option<#ty>,
                         > {
-                            self.#ident.iter().cloned().filter_map(#ty::from_i32)
+                            self.#ident.iter().cloned().filter_map(|x| {
+                                let result: Result<#ty, _> = ::core::convert::TryFrom::try_from(x);
+                                result.ok()
+                            })
                         }
                         #[doc=#push_doc]
                         pub fn #push(&mut self, value: #ty) {

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -579,6 +579,32 @@ mod tests {
     }
 
     #[test]
+    fn test_enum_try_from_i32() {
+        use core::convert::TryFrom;
+        use default_enum_value::{ERemoteClientBroadcastMsg, PrivacyLevel};
+
+        assert_eq!(Ok(PrivacyLevel::One), PrivacyLevel::try_from(1));
+        assert_eq!(Ok(PrivacyLevel::Two), PrivacyLevel::try_from(2));
+        assert_eq!(
+            Ok(PrivacyLevel::PrivacyLevelThree),
+            PrivacyLevel::try_from(3)
+        );
+        assert_eq!(
+            Ok(PrivacyLevel::PrivacyLevelprivacyLevelFour),
+            PrivacyLevel::try_from(4)
+        );
+        assert_eq!(
+            Err(prost::DecodeError::new("invalid enumeration value")),
+            PrivacyLevel::try_from(5)
+        );
+
+        assert_eq!(
+            Ok(ERemoteClientBroadcastMsg::KERemoteClientBroadcastMsgDiscovery),
+            ERemoteClientBroadcastMsg::try_from(0)
+        );
+    }
+
+    #[test]
     fn test_default_string_escape() {
         let msg = default_string_escape::Person::default();
         assert_eq!(msg.name, r#"["unknown"]"#);


### PR DESCRIPTION
Related to #812.

This allows us to more easily have generic functions that deal with conversions between i32 and prost Enums.

I took the liberty of deprecating `from_i32` and updating the README.md to show how to use the TryFrom<i32> instead of `from_i32`. I also changed code that used `from_i32` so that it uses `try_from`. If this is not how things are usually done in this repo, please tell me so I can undo those changes and make it so the only change is the addition of the TryFrom<i32> implementation and the new test.

Also, one point that I am not sure about is the Error type of the TryFrom<i32> implementation. I used DecodeError, but if that is not suitable and I should create a new Error struct/enum, please tell me so I can fix it.