### PR TITLE
feat: `TypeUrl` trait + `Any` encoding support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub use bytes;
 
 mod error;
 mod message;
+mod type_url;
 mod types;
 
 #[doc(hidden)]
@@ -18,6 +19,7 @@ pub mod encoding;
 
 pub use crate::error::{DecodeError, EncodeError};
 pub use crate::message::Message;
+pub use crate::type_url::TypeUrl;
 
 use bytes::{Buf, BufMut};
 

--- a/src/type_url.rs
+++ b/src/type_url.rs
@@ -1,0 +1,19 @@
+//! Support for associating a type URL with a [`Message`].
+
+use crate::Message;
+
+/// Associate a type URL with the given [`Message]`.
+pub trait TypeUrl: Message {
+    /// Type URL for this [`Message`]. They take the form:
+    ///
+    /// ```text
+    /// /<package>.<TypeName>
+    /// ```
+    ///
+    /// For example:
+    ///
+    /// ```text
+    /// /foo.bar.baz.MyTypeName
+    /// ```
+    const TYPE_URL: &'static str;
+}


### PR DESCRIPTION
As discussed in #299, adds a `TypeUrl` trait which associates a type URL constant with a `Message` type.

This enables adding methods to `Any` for decoding/encoding messages:

- `Any::from_message`: encodes a given `Message`, returning `Any`.
- `Any::to_message`: decodes `Any::value` as the given `Message`, first validating the message type has the expected type URL.