### PR TITLE
Use &mut Buf in decode_length_delimited and merge_length_delimited

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ bench = false
 [features]
 default = ["prost-derive", "std"]
 no-recursion-limit = []
-std = []
+std = ["bytes/std"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }

--- a/src/message.rs
+++ b/src/message.rs
@@ -117,7 +117,7 @@ pub trait Message: Debug + Send + Sync {
     }
 
     /// Decodes a length-delimited instance of the message from the buffer.
-    fn decode_length_delimited<B>(buf: B) -> Result<Self, DecodeError>
+    fn decode_length_delimited<B>(buf: &mut B) -> Result<Self, DecodeError>
     where
         B: Buf,
         Self: Default,
@@ -145,7 +145,7 @@ pub trait Message: Debug + Send + Sync {
 
     /// Decodes a length-delimited instance of the message from buffer, and
     /// merges it into `self`.
-    fn merge_length_delimited<B>(&mut self, mut buf: B) -> Result<(), DecodeError>
+    fn merge_length_delimited<B>(&mut self, buf: &mut B) -> Result<(), DecodeError>
     where
         B: Buf,
         Self: Sized,
@@ -153,7 +153,7 @@ pub trait Message: Debug + Send + Sync {
         message::merge(
             WireType::LengthDelimited,
             self,
-            &mut buf,
+            buf,
             DecodeContext::default(),
         )
     }


### PR DESCRIPTION
See https://github.com/tokio-rs/prost/issues/862

This PR:
- Changes the function signatures of `merge_length_delimited` and `decode_length_delimited` to take a `&mut B where B: Buf` instead of `B` by ownership
- Adds the `std` feature of the `bytes` crate when `std` is set in this crate (allows to use `Buf` implementation of `Cursor`)