### PR TITLE
Add `serde` feature for prost-types protobuf types

### DIFF
--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -19,10 +19,12 @@ doctest = false
 
 [features]
 default = ["std"]
-std = ["prost/std"]
+std = ["prost/std", "serde/std"]
+serde = []
 
 [dependencies]
 prost = { version = "0.11.8", path = "..", default-features = false, features = ["prost-derive"] }
+serde = { version = "1", default-features = false, features = ["derive"], optional = true}
 
 [dev-dependencies]
 proptest = "1"

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -2,6 +2,7 @@
 /// files it parses.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FileDescriptorSet {
     #[prost(message, repeated, tag = "1")]
     pub file: ::prost::alloc::vec::Vec<FileDescriptorProto>,
@@ -9,6 +10,7 @@ pub struct FileDescriptorSet {
 /// Describes a complete .proto file.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FileDescriptorProto {
     /// file name, relative to root of source tree
     #[prost(string, optional, tag = "1")]
@@ -51,6 +53,7 @@ pub struct FileDescriptorProto {
 /// Describes a message type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct DescriptorProto {
     #[prost(string, optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -79,7 +82,8 @@ pub struct DescriptorProto {
 pub mod descriptor_proto {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct ExtensionRange {
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct ExtensionRange {
         /// Inclusive.
         #[prost(int32, optional, tag = "1")]
         pub start: ::core::option::Option<i32>,
@@ -94,7 +98,8 @@ pub mod descriptor_proto {
     /// not overlap.
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct ReservedRange {
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct ReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag = "1")]
         pub start: ::core::option::Option<i32>,
@@ -105,6 +110,7 @@ pub mod descriptor_proto {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ExtensionRangeOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag = "999")]
@@ -113,6 +119,7 @@ pub struct ExtensionRangeOptions {
 /// Describes a field within a message.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FieldDescriptorProto {
     #[prost(string, optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -192,7 +199,8 @@ pub mod field_descriptor_proto {
         ::prost::Enumeration
     )]
     #[repr(i32)]
-    pub enum Type {
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum Type {
         /// 0 is reserved for errors.
         /// Order is weird for historical reasons.
         Double = 1,
@@ -290,7 +298,8 @@ pub mod field_descriptor_proto {
         ::prost::Enumeration
     )]
     #[repr(i32)]
-    pub enum Label {
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum Label {
         /// 0 is reserved for errors
         Optional = 1,
         Required = 2,
@@ -322,6 +331,7 @@ pub mod field_descriptor_proto {
 /// Describes a oneof.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct OneofDescriptorProto {
     #[prost(string, optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -331,6 +341,7 @@ pub struct OneofDescriptorProto {
 /// Describes an enum type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct EnumDescriptorProto {
     #[prost(string, optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -360,7 +371,8 @@ pub mod enum_descriptor_proto {
     /// domain.
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct EnumReservedRange {
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct EnumReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag = "1")]
         pub start: ::core::option::Option<i32>,
@@ -372,6 +384,7 @@ pub mod enum_descriptor_proto {
 /// Describes a value within an enum.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct EnumValueDescriptorProto {
     #[prost(string, optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -383,6 +396,7 @@ pub struct EnumValueDescriptorProto {
 /// Describes a service.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ServiceDescriptorProto {
     #[prost(string, optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -394,6 +408,7 @@ pub struct ServiceDescriptorProto {
 /// Describes a method of a service.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct MethodDescriptorProto {
     #[prost(string, optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
@@ -443,6 +458,7 @@ pub struct MethodDescriptorProto {
 ///   to automatically assign option numbers.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FileOptions {
     /// Sets the Java package where classes generated from this .proto will be
     /// placed.  By default, the proto package is used, but this is often
@@ -572,7 +588,8 @@ pub mod file_options {
         ::prost::Enumeration
     )]
     #[repr(i32)]
-    pub enum OptimizeMode {
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum OptimizeMode {
         /// Generate complete code for parsing, serialization,
         Speed = 1,
         /// etc.
@@ -607,6 +624,7 @@ pub mod file_options {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct MessageOptions {
     /// Set true to use the old proto1 MessageSet wire format for extensions.
     /// This is provided for backwards-compatibility with the MessageSet wire
@@ -668,6 +686,7 @@ pub struct MessageOptions {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FieldOptions {
     /// The ctype option instructs the C++ code generator to use a different
     /// representation of the field than it normally would.  See the specific
@@ -761,7 +780,8 @@ pub mod field_options {
         ::prost::Enumeration
     )]
     #[repr(i32)]
-    pub enum CType {
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum CType {
         /// Default mode.
         String = 0,
         Cord = 1,
@@ -801,7 +821,8 @@ pub mod field_options {
         ::prost::Enumeration
     )]
     #[repr(i32)]
-    pub enum JsType {
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum JsType {
         /// Use the default type.
         JsNormal = 0,
         /// Use JavaScript strings.
@@ -834,6 +855,7 @@ pub mod field_options {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct OneofOptions {
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag = "999")]
@@ -841,6 +863,7 @@ pub struct OneofOptions {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct EnumOptions {
     /// Set this option to true to allow mapping different tag names to the same
     /// value.
@@ -858,6 +881,7 @@ pub struct EnumOptions {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct EnumValueOptions {
     /// Is this enum value deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
@@ -871,6 +895,7 @@ pub struct EnumValueOptions {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ServiceOptions {
     /// Is this service deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
@@ -884,6 +909,7 @@ pub struct ServiceOptions {
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct MethodOptions {
     /// Is this method deprecated?
     /// Depending on the target platform, this can emit Deprecated annotations
@@ -919,7 +945,8 @@ pub mod method_options {
         ::prost::Enumeration
     )]
     #[repr(i32)]
-    pub enum IdempotencyLevel {
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum IdempotencyLevel {
         IdempotencyUnknown = 0,
         /// implies idempotent
         NoSideEffects = 1,
@@ -957,6 +984,7 @@ pub mod method_options {
 /// in them.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct UninterpretedOption {
     #[prost(message, repeated, tag = "2")]
     pub name: ::prost::alloc::vec::Vec<uninterpreted_option::NamePart>,
@@ -984,7 +1012,8 @@ pub mod uninterpreted_option {
     /// "foo.(bar.baz).qux".
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct NamePart {
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct NamePart {
         #[prost(string, required, tag = "1")]
         pub name_part: ::prost::alloc::string::String,
         #[prost(bool, required, tag = "2")]
@@ -995,6 +1024,7 @@ pub mod uninterpreted_option {
 /// FileDescriptorProto was generated.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct SourceCodeInfo {
     /// A Location identifies a piece of source code in a .proto file which
     /// corresponds to a particular definition.  This information is intended
@@ -1047,7 +1077,8 @@ pub struct SourceCodeInfo {
 pub mod source_code_info {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct Location {
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct Location {
         /// Identifies which part of the FileDescriptorProto was defined at this
         /// location.
         ///
@@ -1142,6 +1173,7 @@ pub mod source_code_info {
 /// source file, but may contain references to different source .proto files.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct GeneratedCodeInfo {
     /// An Annotation connects some span of text in generated code to an element
     /// of its generating .proto file.
@@ -1152,7 +1184,8 @@ pub struct GeneratedCodeInfo {
 pub mod generated_code_info {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct Annotation {
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub struct Annotation {
         /// Identifies the element in the original source .proto file. This field
         /// is formatted the same as SourceCodeInfo.Location.path.
         #[prost(int32, repeated, tag = "1")]
@@ -1266,6 +1299,7 @@ pub mod generated_code_info {
 /// ```
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Any {
     /// A URL/resource name that uniquely identifies the type of the serialized
     /// protocol buffer message. This string must contain at least
@@ -1304,6 +1338,7 @@ pub struct Any {
 /// protobuf element, like the file in which it is defined.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct SourceContext {
     /// The path-qualified name of the .proto file that contained the associated
     /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
@@ -1313,6 +1348,7 @@ pub struct SourceContext {
 /// A protocol buffer message type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Type {
     /// The fully qualified message name.
     #[prost(string, tag = "1")]
@@ -1336,6 +1372,7 @@ pub struct Type {
 /// A single field of a message type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Field {
     /// The field type.
     #[prost(enumeration = "field::Kind", tag = "1")]
@@ -1385,7 +1422,8 @@ pub mod field {
         ::prost::Enumeration
     )]
     #[repr(i32)]
-    pub enum Kind {
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum Kind {
         /// Field type unknown.
         TypeUnknown = 0,
         /// Field type double.
@@ -1492,7 +1530,8 @@ pub mod field {
         ::prost::Enumeration
     )]
     #[repr(i32)]
-    pub enum Cardinality {
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum Cardinality {
         /// For fields with unknown cardinality.
         Unknown = 0,
         /// For optional fields.
@@ -1530,6 +1569,7 @@ pub mod field {
 /// Enum type definition.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Enum {
     /// Enum type name.
     #[prost(string, tag = "1")]
@@ -1550,6 +1590,7 @@ pub struct Enum {
 /// Enum value definition.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct EnumValue {
     /// Enum value name.
     #[prost(string, tag = "1")]
@@ -1565,6 +1606,7 @@ pub struct EnumValue {
 /// enumeration, etc.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Option {
     /// The option's name. For protobuf built-in options (options defined in
     /// descriptor.proto), this is the short name. For example, `"map_entry"`.
@@ -1582,6 +1624,7 @@ pub struct Option {
 /// The syntax in which a protocol buffer element is defined.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum Syntax {
     /// Syntax `proto2`.
     Proto2 = 0,
@@ -1619,6 +1662,7 @@ impl Syntax {
 /// detailed terminology.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Api {
     /// The fully qualified name of this interface, including package name
     /// followed by the interface's simple name.
@@ -1665,6 +1709,7 @@ pub struct Api {
 /// Method represents a method of an API interface.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Method {
     /// The simple name of this method.
     #[prost(string, tag = "1")]
@@ -1778,6 +1823,7 @@ pub struct Method {
 /// ```
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Mixin {
     /// The fully qualified name of the interface which is included.
     #[prost(string, tag = "1")]
@@ -1853,6 +1899,7 @@ pub struct Mixin {
 /// microsecond should be expressed in JSON format as "3.000001s".
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Duration {
     /// Signed seconds of the span of time. Must be from -315,576,000,000
     /// to +315,576,000,000 inclusive. Note: these bounds are computed from:
@@ -2092,6 +2139,7 @@ pub struct Duration {
 /// `INVALID_ARGUMENT` error if any path is unmappable.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct FieldMask {
     /// The set of field mask paths.
     #[prost(string, repeated, tag = "1")]
@@ -2107,6 +2155,7 @@ pub struct FieldMask {
 /// The JSON representation for `Struct` is JSON object.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Struct {
     /// Unordered map of dynamically typed values.
     #[prost(btree_map = "string, message", tag = "1")]
@@ -2123,6 +2172,7 @@ pub struct Struct {
 /// The JSON representation for `Value` is JSON value.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Value {
     /// The kind of value.
     #[prost(oneof = "value::Kind", tags = "1, 2, 3, 4, 5, 6")]
@@ -2133,7 +2183,8 @@ pub mod value {
     /// The kind of value.
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Oneof)]
-    pub enum Kind {
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+pub enum Kind {
         /// Represents a null value.
         #[prost(enumeration = "super::NullValue", tag = "1")]
         NullValue(i32),
@@ -2159,6 +2210,7 @@ pub mod value {
 /// The JSON representation for `ListValue` is JSON array.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct ListValue {
     /// Repeated field of dynamically typed values.
     #[prost(message, repeated, tag = "1")]
@@ -2170,6 +2222,7 @@ pub struct ListValue {
 /// The JSON representation for `NullValue` is JSON `null`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub enum NullValue {
     /// Null value.
     NullValue = 0,
@@ -2293,6 +2346,7 @@ impl NullValue {
 /// the Joda Time's \[`ISODateTimeFormat.dateTime()`\](<http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime%2D%2D>) to obtain a formatter capable of generating timestamps in this format.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
+#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
 pub struct Timestamp {
     /// Represents seconds of UTC time since Unix epoch
     /// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to


### PR DESCRIPTION
This is useful when you want to re-use prost-build generated types with non-protobuf serializations