### PR TITLE
Allow using `Box<[u8]>`/`Box<str>` for `bytes`/`string` fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,12 +329,12 @@ and the generated Rust code (`tutorial.rs`):
 ```rust,ignore
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Person {
-    #[prost(string, tag="1")]
+    #[prost(string = "string", tag="1")]
     pub name: ::prost::alloc::string::String,
     /// Unique ID number for this person.
     #[prost(int32, tag="2")]
     pub id: i32,
-    #[prost(string, tag="3")]
+    #[prost(string = "string", tag="3")]
     pub email: ::prost::alloc::string::String,
     #[prost(message, repeated, tag="4")]
     pub phones: ::prost::alloc::vec::Vec<person::PhoneNumber>,
@@ -343,7 +343,7 @@ pub struct Person {
 pub mod person {
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct PhoneNumber {
-        #[prost(string, tag="1")]
+        #[prost(string = "string", tag="1")]
         pub number: ::prost::alloc::string::String,
         #[prost(enumeration="PhoneType", tag="2")]
         pub r#type: i32,
@@ -422,15 +422,15 @@ use prost::{Enumeration, Message};
 
 #[derive(Clone, PartialEq, Message)]
 struct Person {
-    #[prost(string, tag = "1")]
+    #[prost(string = "string", tag = "1")]
     pub id: String, // tag=1
     // NOTE: Old "name" field has been removed
     // pub name: String, // tag=2 (Removed)
-    #[prost(string, tag = "6")]
+    #[prost(string = "string", tag = "6")]
     pub given_name: String, // tag=6
-    #[prost(string)]
+    #[prost(string = "string")]
     pub family_name: String, // tag=7
-    #[prost(string)]
+    #[prost(string = "string")]
     pub formatted_name: String, // tag=8
     #[prost(uint32, tag = "3")]
     pub age: u32, // tag=3
@@ -439,11 +439,11 @@ struct Person {
     #[prost(enumeration = "Gender")]
     pub gender: i32, // tag=5
     // NOTE: Skip to less commonly occurring fields
-    #[prost(string, tag = "16")]
+    #[prost(string = "string", tag = "16")]
     pub name_prefix: String, // tag=16  (eg. mr/mrs/ms)
-    #[prost(string)]
+    #[prost(string = "string")]
     pub name_suffix: String, // tag=17  (eg. jr/esq)
-    #[prost(string)]
+    #[prost(string = "string")]
     pub maiden_name: String, // tag=18
 }
 

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -555,7 +555,7 @@ impl<'a> CodeGenerator<'a> {
             self.path.pop();
 
             self.push_indent();
-            let ty_tag = self.field_type_tag(&field);
+            let ty_tag = self.field_type_tag_detailed(fq_message_name, &field);
             self.buf.push_str(&format!(
                 "#[prost({}, tag=\"{}\")]\n",
                 ty_tag,

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -1222,6 +1222,7 @@ impl BytesType {
         match self {
             BytesType::Vec => "vec",
             BytesType::Bytes => "bytes",
+            BytesType::BoxedSlice => "boxed_slice",
         }
     }
 
@@ -1230,6 +1231,7 @@ impl BytesType {
         match self {
             BytesType::Vec => "::prost::alloc::vec::Vec<u8>",
             BytesType::Bytes => "::prost::bytes::Bytes",
+            BytesType::BoxedSlice => "::prost::alloc::boxed::Box<[u8]>",
         }
     }
 }

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -18,7 +18,7 @@ use crate::ast::{Comments, Method, Service};
 use crate::extern_paths::ExternPaths;
 use crate::ident::{to_snake, to_upper_camel};
 use crate::message_graph::MessageGraph;
-use crate::{BytesType, Config, MapType};
+use crate::{BytesType, Config, MapType, StringType};
 
 #[derive(PartialEq)]
 enum Syntax {
@@ -884,8 +884,6 @@ impl<'a> CodeGenerator<'a> {
     }
 
     fn resolve_type(&self, field: &FieldDescriptorProto, fq_message_name: &str) -> String {
-        let prost_path = self.config.prost_path.as_deref().unwrap_or("::prost");
-
         match field.r#type() {
             Type::Float => String::from("f32"),
             Type::Double => String::from("f64"),
@@ -894,7 +892,14 @@ impl<'a> CodeGenerator<'a> {
             Type::Int32 | Type::Sfixed32 | Type::Sint32 | Type::Enum => String::from("i32"),
             Type::Int64 | Type::Sfixed64 | Type::Sint64 => String::from("i64"),
             Type::Bool => String::from("bool"),
-            Type::String => format!("{}::alloc::string::String", prost_path),
+            Type::String => self
+                .config
+                .string_type
+                .get_first_field(fq_message_name, field.name())
+                .copied()
+                .unwrap_or_default()
+                .rust_type()
+                .to_owned(),
             Type::Bytes => self
                 .config
                 .bytes_type
@@ -1232,6 +1237,22 @@ impl BytesType {
             BytesType::Vec => "::prost::alloc::vec::Vec<u8>",
             BytesType::Bytes => "::prost::bytes::Bytes",
             BytesType::BoxedSlice => "::prost::alloc::boxed::Box<[u8]>",
+        }
+    }
+}
+
+impl StringType {
+    /// The `prost-derive` annotation type corresponding to the string type.
+    fn annotation(&self) -> &'static str {
+        match self {
+            Self::String => "string",
+        }
+    }
+
+    /// The fully-qualified Rust type corresponding to the string type.
+    fn rust_type(&self) -> &'static str {
+        match self {
+            Self::String => "::prost::alloc::string::String",
         }
     }
 }

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -1271,6 +1271,7 @@ impl StringType {
     fn annotation(&self) -> &'static str {
         match self {
             Self::String => "string",
+            Self::BoxedStr => "boxed_str",
         }
     }
 
@@ -1278,6 +1279,7 @@ impl StringType {
     fn rust_type(&self) -> &'static str {
         match self {
             Self::String => "::prost::alloc::string::String",
+            Self::BoxedStr => "::prost::alloc::boxed::Box<str>",
         }
     }
 }

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -364,6 +364,17 @@ impl<'a> CodeGenerator<'a> {
                 .push_str(&format!("={:?}", bytes_type.annotation()));
         }
 
+        if type_ == Type::String {
+            let string_type = self
+                .config
+                .string_type
+                .get_first_field(fq_message_name, field.name())
+                .copied()
+                .unwrap_or_default();
+            self.buf
+                .push_str(&format!("={:?}", string_type.annotation()));
+        }
+
         match field.label() {
             Label::Optional => {
                 if optional {

--- a/prost-build/src/fixtures/field_attributes/_expected_field_attributes.rs
+++ b/prost-build/src/fixtures/field_attributes/_expected_field_attributes.rs
@@ -18,7 +18,7 @@ pub mod container {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Foo {
-    #[prost(string, tag="1")]
+    #[prost(string="string", tag="1")]
     pub foo: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/prost-build/src/fixtures/field_attributes/_expected_field_attributes_formatted.rs
+++ b/prost-build/src/fixtures/field_attributes/_expected_field_attributes_formatted.rs
@@ -18,7 +18,7 @@ pub mod container {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Foo {
-    #[prost(string, tag = "1")]
+    #[prost(string = "string", tag = "1")]
     pub foo: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]

--- a/prost-build/src/fixtures/helloworld/_expected_helloworld.rs
+++ b/prost-build/src/fixtures/helloworld/_expected_helloworld.rs
@@ -2,14 +2,14 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Message {
-    #[prost(string, tag="1")]
+    #[prost(string="string", tag="1")]
     pub say: ::prost::alloc::string::String,
 }
 #[derive(derive_builder::Builder)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Response {
-    #[prost(string, tag="1")]
+    #[prost(string="string", tag="1")]
     pub say: ::prost::alloc::string::String,
 }
 #[some_enum_attr(u8)]

--- a/prost-build/src/fixtures/helloworld/_expected_helloworld_formatted.rs
+++ b/prost-build/src/fixtures/helloworld/_expected_helloworld_formatted.rs
@@ -2,14 +2,14 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Message {
-    #[prost(string, tag = "1")]
+    #[prost(string = "string", tag = "1")]
     pub say: ::prost::alloc::string::String,
 }
 #[derive(derive_builder::Builder)]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Response {
-    #[prost(string, tag = "1")]
+    #[prost(string = "string", tag = "1")]
     pub say: ::prost::alloc::string::String,
 }
 #[some_enum_attr(u8)]

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1781,4 +1781,35 @@ mod tests {
         f.read_to_string(&mut content).unwrap();
         content
     }
+
+    #[test]
+    fn bytes_and_boxed_slice() {
+        let mut cfg = Config::new();
+
+        assert_eq!(&cfg.bytes_type.matchers, &[]);
+
+        let a = ".a.A.a1";
+        let b = "B.b2";
+        let c = "3";
+
+        cfg.bytes([a, b, c]);
+
+        assert_eq!(
+            &cfg.bytes_type.matchers,
+            &[
+                (a.to_string(), BytesType::Bytes),
+                (b.to_string(), BytesType::Bytes),
+                (c.to_string(), BytesType::Bytes),
+            ]
+        );
+
+        cfg.bytes([a]);
+
+        assert_eq!(
+            &cfg.bytes_type.matchers,
+            &[
+                (a.to_string(), BytesType::Bytes),
+            ]
+        );
+    }
 }

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -237,6 +237,20 @@ impl Default for BytesType {
     }
 }
 
+/// The string type to output for Protobuf `string` fields.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum StringType {
+    /// The [`alloc::string::String`] type.
+    String,
+}
+
+impl Default for StringType {
+    fn default() -> StringType {
+        StringType::String
+    }
+}
+
 /// Configuration options for Protobuf code generation.
 ///
 /// This configuration builder can be used to set non-default code generation options.
@@ -245,6 +259,7 @@ pub struct Config {
     service_generator: Option<Box<dyn ServiceGenerator>>,
     map_type: PathMap<MapType>,
     bytes_type: PathMap<BytesType>,
+    string_type: PathMap<StringType>,
     type_attributes: PathMap<String>,
     message_attributes: PathMap<String>,
     enum_attributes: PathMap<String>,
@@ -1345,6 +1360,7 @@ impl default::Default for Config {
             service_generator: None,
             map_type: PathMap::default(),
             bytes_type: PathMap::default(),
+            string_type: PathMap::default(),
             type_attributes: PathMap::default(),
             message_attributes: PathMap::default(),
             enum_attributes: PathMap::default(),
@@ -1373,6 +1389,7 @@ impl fmt::Debug for Config {
             .field("service_generator", &self.service_generator.is_some())
             .field("map_type", &self.map_type)
             .field("bytes_type", &self.bytes_type)
+            .field("string_type", &self.string_type)
             .field("type_attributes", &self.type_attributes)
             .field("field_attributes", &self.field_attributes)
             .field("prost_types", &self.prost_types)

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -367,7 +367,7 @@ fn key_ty_from_str(s: &str) -> Result<scalar::Ty, Error> {
         | scalar::Ty::Sfixed32
         | scalar::Ty::Sfixed64
         | scalar::Ty::Bool
-        | scalar::Ty::String => Ok(ty),
+        | scalar::Ty::String(_) => Ok(ty),
         _ => bail!("invalid map key type: {}", s),
     }
 }

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -815,7 +815,7 @@ impl DefaultValue {
     pub fn owned(&self) -> TokenStream {
         match *self {
             DefaultValue::String(ref value) if value.is_empty() => {
-                quote!(::prost::alloc::string::String::new())
+                quote!(::core::default::Default::default())
             }
             DefaultValue::String(ref value) => quote!(#value.into()),
             DefaultValue::Bytes(ref value) if value.is_empty() => {

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -494,7 +494,11 @@ impl Ty {
             }) if path.is_ident("string") => Ty::String(StringTy::try_from_str(&l.value())?),
             Meta::NameValue(MetaNameValue {
                 ref path,
-                lit: Lit::Str(ref l),
+                value:
+                    syn::Expr::Lit(ExprLit {
+                        lit: Lit::Str(ref l),
+                        ..
+                    }),
                 ..
             }) if path.is_ident("bytes") => Ty::Bytes(BytesTy::try_from_str(&l.value())?),
             Meta::NameValue(MetaNameValue {

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -204,7 +204,7 @@ impl Field {
             Kind::Plain(ref default) | Kind::Required(ref default) => {
                 let default = default.typed();
                 match self.ty {
-                    Ty::String | Ty::Bytes(..) => quote!(#ident.clear()),
+                    Ty::String(..) | Ty::Bytes(..) => quote!(#ident.clear()),
                     _ => quote!(#ident = #default),
                 }
             }
@@ -407,7 +407,7 @@ pub enum Ty {
     Sfixed32,
     Sfixed64,
     Bool,
-    String,
+    String(StringTy),
     Bytes(BytesTy),
     Enumeration(Path),
 }
@@ -417,6 +417,11 @@ pub enum BytesTy {
     Vec,
     Bytes,
     BoxedSlice,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StringTy {
+    String,
 }
 
 impl BytesTy {
@@ -438,6 +443,21 @@ impl BytesTy {
     }
 }
 
+impl StringTy {
+    fn try_from_str(s: &str) -> Result<Self, Error> {
+        match s {
+            "string" => Ok(StringTy::String),
+            _ => bail!("Invalid string type: {}", s),
+        }
+    }
+
+    fn rust_type(&self) -> TokenStream {
+        match self {
+            StringTy::String => quote! { ::prost::alloc::string::String },
+        }
+    }
+}
+
 impl Ty {
     pub fn from_attr(attr: &Meta) -> Result<Option<Ty>, Error> {
         let ty = match *attr {
@@ -454,7 +474,7 @@ impl Ty {
             Meta::Path(ref name) if name.is_ident("sfixed32") => Ty::Sfixed32,
             Meta::Path(ref name) if name.is_ident("sfixed64") => Ty::Sfixed64,
             Meta::Path(ref name) if name.is_ident("bool") => Ty::Bool,
-            Meta::Path(ref name) if name.is_ident("string") => Ty::String,
+            Meta::Path(ref name) if name.is_ident("string") => Ty::String(StringTy::String),
             Meta::Path(ref name) if name.is_ident("bytes") => Ty::Bytes(BytesTy::Vec),
             Meta::NameValue(MetaNameValue {
                 ref path,
@@ -463,6 +483,11 @@ impl Ty {
                         lit: Lit::Str(ref l),
                         ..
                     }),
+                ..
+            }) if path.is_ident("string") => Ty::String(StringTy::try_from_str(&l.value())?),
+            Meta::NameValue(MetaNameValue {
+                ref path,
+                lit: Lit::Str(ref l),
                 ..
             }) if path.is_ident("bytes") => Ty::Bytes(BytesTy::try_from_str(&l.value())?),
             Meta::NameValue(MetaNameValue {
@@ -499,7 +524,7 @@ impl Ty {
             "sfixed32" => Ty::Sfixed32,
             "sfixed64" => Ty::Sfixed64,
             "bool" => Ty::Bool,
-            "string" => Ty::String,
+            "string" => Ty::String(StringTy::String),
             "bytes" => Ty::Bytes(BytesTy::Vec),
             s if s.len() > enumeration_len && &s[..enumeration_len] == "enumeration" => {
                 let s = &s[enumeration_len..].trim();
@@ -535,7 +560,7 @@ impl Ty {
             Ty::Sfixed32 => "sfixed32",
             Ty::Sfixed64 => "sfixed64",
             Ty::Bool => "bool",
-            Ty::String => "string",
+            Ty::String(..) => "string",
             Ty::Bytes(..) => "bytes",
             Ty::Enumeration(..) => "enum",
         }
@@ -544,7 +569,7 @@ impl Ty {
     // TODO: rename to 'owned_type'.
     pub fn rust_type(&self) -> TokenStream {
         match self {
-            Ty::String => quote!(::prost::alloc::string::String),
+            Ty::String(ty) => ty.rust_type(),
             Ty::Bytes(ty) => ty.rust_type(),
             _ => self.rust_ref_type(),
         }
@@ -566,7 +591,7 @@ impl Ty {
             Ty::Sfixed32 => quote!(i32),
             Ty::Sfixed64 => quote!(i64),
             Ty::Bool => quote!(bool),
-            Ty::String => quote!(&str),
+            Ty::String(..) => quote!(&str),
             Ty::Bytes(..) => quote!(&[u8]),
             Ty::Enumeration(..) => quote!(i32),
         }
@@ -581,7 +606,7 @@ impl Ty {
 
     /// Returns false if the scalar type is length delimited (i.e., `string` or `bytes`).
     pub fn is_numeric(&self) -> bool {
-        !matches!(self, Ty::String | Ty::Bytes(..))
+        !matches!(self, Ty::String(..) | Ty::Bytes(..))
     }
 }
 
@@ -677,7 +702,7 @@ impl DefaultValue {
             Lit::Int(ref lit) if *ty == Ty::Double => DefaultValue::F64(lit.base10_parse()?),
 
             Lit::Bool(ref lit) if *ty == Ty::Bool => DefaultValue::Bool(lit.value),
-            Lit::Str(ref lit) if *ty == Ty::String => DefaultValue::String(lit.value()),
+            Lit::Str(ref lit) if matches!(ty, Ty::String(_)) => DefaultValue::String(lit.value()),
             Lit::ByteStr(ref lit) if matches!(ty, Ty::Bytes(_)) => DefaultValue::Bytes(lit.value()),
             Lit::Str(ref lit) => {
                 let value = lit.value();
@@ -781,7 +806,7 @@ impl DefaultValue {
             Ty::Uint64 | Ty::Fixed64 => DefaultValue::U64(0),
 
             Ty::Bool => DefaultValue::Bool(false),
-            Ty::String => DefaultValue::String(String::new()),
+            Ty::String(..) => DefaultValue::String(String::new()),
             Ty::Bytes(..) => DefaultValue::Bytes(Vec::new()),
             Ty::Enumeration(ref path) => DefaultValue::Enumeration(quote!(#path::default())),
         }

--- a/prost-types/src/compiler.rs
+++ b/prost-types/src/compiler.rs
@@ -10,7 +10,7 @@ pub struct Version {
     pub patch: ::core::option::Option<i32>,
     /// A suffix for alpha, beta or rc release, e.g., "alpha-1", "rc2". It should
     /// be empty for mainline stable releases.
-    #[prost(string, optional, tag = "4")]
+    #[prost(string = "string", optional, tag = "4")]
     pub suffix: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// An encoded CodeGeneratorRequest is written to the plugin's stdin.
@@ -20,10 +20,10 @@ pub struct CodeGeneratorRequest {
     /// The .proto files that were explicitly listed on the command-line.  The
     /// code generator should generate code only for these files.  Each file's
     /// descriptor will be included in proto_file, below.
-    #[prost(string, repeated, tag = "1")]
+    #[prost(string = "string", repeated, tag = "1")]
     pub file_to_generate: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// The generator parameter passed on the command-line.
-    #[prost(string, optional, tag = "2")]
+    #[prost(string = "string", optional, tag = "2")]
     pub parameter: ::core::option::Option<::prost::alloc::string::String>,
     /// FileDescriptorProtos for all files in files_to_generate and everything
     /// they import.  The files will appear in topological order, so each file
@@ -57,7 +57,7 @@ pub struct CodeGeneratorResponse {
     /// problem in protoc itself -- such as the input CodeGeneratorRequest being
     /// unparseable -- should be reported by writing a message to stderr and
     /// exiting with a non-zero status code.
-    #[prost(string, optional, tag = "1")]
+    #[prost(string = "string", optional, tag = "1")]
     pub error: ::core::option::Option<::prost::alloc::string::String>,
     /// A bitmask of supported features that the code generator supports.
     /// This is a bitwise "or" of values from the Feature enum.
@@ -83,7 +83,7 @@ pub mod code_generator_response {
         /// files need not reside completely in memory at one time.  Note that as of
         /// this writing protoc does not optimize for this -- it will read the entire
         /// CodeGeneratorResponse before writing files to disk.
-        #[prost(string, optional, tag = "1")]
+        #[prost(string = "string", optional, tag = "1")]
         pub name: ::core::option::Option<::prost::alloc::string::String>,
         /// If non-empty, indicates that the named file should already exist, and the
         /// content here is to be inserted into that file at a defined insertion
@@ -122,10 +122,10 @@ pub mod code_generator_response {
         /// command line.
         ///
         /// If |insertion_point| is present, |name| must also be present.
-        #[prost(string, optional, tag = "2")]
+        #[prost(string = "string", optional, tag = "2")]
         pub insertion_point: ::core::option::Option<::prost::alloc::string::String>,
         /// The file contents.
-        #[prost(string, optional, tag = "15")]
+        #[prost(string = "string", optional, tag = "15")]
         pub content: ::core::option::Option<::prost::alloc::string::String>,
         /// Information describing the file content being inserted. If an insertion
         /// point is used, this information will be appropriately offset and inserted

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -11,13 +11,13 @@ pub struct FileDescriptorSet {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileDescriptorProto {
     /// file name, relative to root of source tree
-    #[prost(string, optional, tag = "1")]
+    #[prost(string = "string", optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
     /// e.g. "foo", "foo.bar", etc.
-    #[prost(string, optional, tag = "2")]
+    #[prost(string = "string", optional, tag = "2")]
     pub package: ::core::option::Option<::prost::alloc::string::String>,
     /// Names of files imported by this file.
-    #[prost(string, repeated, tag = "3")]
+    #[prost(string = "string", repeated, tag = "3")]
     pub dependency: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// Indexes of the public imported files in the dependency list above.
     #[prost(int32, repeated, packed = "false", tag = "10")]
@@ -45,14 +45,14 @@ pub struct FileDescriptorProto {
     pub source_code_info: ::core::option::Option<SourceCodeInfo>,
     /// The syntax of the proto file.
     /// The supported values are "proto2" and "proto3".
-    #[prost(string, optional, tag = "12")]
+    #[prost(string = "string", optional, tag = "12")]
     pub syntax: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// Describes a message type.
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DescriptorProto {
-    #[prost(string, optional, tag = "1")]
+    #[prost(string = "string", optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, repeated, tag = "2")]
     pub field: ::prost::alloc::vec::Vec<FieldDescriptorProto>,
@@ -72,7 +72,7 @@ pub struct DescriptorProto {
     pub reserved_range: ::prost::alloc::vec::Vec<descriptor_proto::ReservedRange>,
     /// Reserved field names, which may not be used by fields in the same message.
     /// A given name may only be reserved once.
-    #[prost(string, repeated, tag = "10")]
+    #[prost(string = "string", repeated, tag = "10")]
     pub reserved_name: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Nested message and enum types in `DescriptorProto`.
@@ -114,7 +114,7 @@ pub struct ExtensionRangeOptions {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldDescriptorProto {
-    #[prost(string, optional, tag = "1")]
+    #[prost(string = "string", optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(int32, optional, tag = "3")]
     pub number: ::core::option::Option<i32>,
@@ -129,18 +129,18 @@ pub struct FieldDescriptorProto {
     /// rules are used to find the type (i.e. first the nested types within this
     /// message are searched, then within the parent, on up to the root
     /// namespace).
-    #[prost(string, optional, tag = "6")]
+    #[prost(string = "string", optional, tag = "6")]
     pub type_name: ::core::option::Option<::prost::alloc::string::String>,
     /// For extensions, this is the name of the type being extended.  It is
     /// resolved in the same manner as type_name.
-    #[prost(string, optional, tag = "2")]
+    #[prost(string = "string", optional, tag = "2")]
     pub extendee: ::core::option::Option<::prost::alloc::string::String>,
     /// For numeric types, contains the original text representation of the value.
     /// For booleans, "true" or "false".
     /// For strings, contains the default text contents (not escaped in any way).
     /// For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
     /// TODO(kenton):  Base-64 encode?
-    #[prost(string, optional, tag = "7")]
+    #[prost(string = "string", optional, tag = "7")]
     pub default_value: ::core::option::Option<::prost::alloc::string::String>,
     /// If set, gives the index of a oneof in the containing type's oneof_decl
     /// list.  This field is a member of that oneof.
@@ -150,7 +150,7 @@ pub struct FieldDescriptorProto {
     /// user has set a "json_name" option on this field, that option's value
     /// will be used. Otherwise, it's deduced from the field's name by converting
     /// it to camelCase.
-    #[prost(string, optional, tag = "10")]
+    #[prost(string = "string", optional, tag = "10")]
     pub json_name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, optional, tag = "8")]
     pub options: ::core::option::Option<FieldOptions>,
@@ -323,7 +323,7 @@ pub mod field_descriptor_proto {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OneofDescriptorProto {
-    #[prost(string, optional, tag = "1")]
+    #[prost(string = "string", optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, optional, tag = "2")]
     pub options: ::core::option::Option<OneofOptions>,
@@ -332,7 +332,7 @@ pub struct OneofDescriptorProto {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumDescriptorProto {
-    #[prost(string, optional, tag = "1")]
+    #[prost(string = "string", optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, repeated, tag = "2")]
     pub value: ::prost::alloc::vec::Vec<EnumValueDescriptorProto>,
@@ -347,7 +347,7 @@ pub struct EnumDescriptorProto {
     >,
     /// Reserved enum value names, which may not be reused. A given name may only
     /// be reserved once.
-    #[prost(string, repeated, tag = "5")]
+    #[prost(string = "string", repeated, tag = "5")]
     pub reserved_name: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// Nested message and enum types in `EnumDescriptorProto`.
@@ -373,7 +373,7 @@ pub mod enum_descriptor_proto {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumValueDescriptorProto {
-    #[prost(string, optional, tag = "1")]
+    #[prost(string = "string", optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(int32, optional, tag = "2")]
     pub number: ::core::option::Option<i32>,
@@ -384,7 +384,7 @@ pub struct EnumValueDescriptorProto {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ServiceDescriptorProto {
-    #[prost(string, optional, tag = "1")]
+    #[prost(string = "string", optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, repeated, tag = "2")]
     pub method: ::prost::alloc::vec::Vec<MethodDescriptorProto>,
@@ -395,13 +395,13 @@ pub struct ServiceDescriptorProto {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MethodDescriptorProto {
-    #[prost(string, optional, tag = "1")]
+    #[prost(string = "string", optional, tag = "1")]
     pub name: ::core::option::Option<::prost::alloc::string::String>,
     /// Input and output type names.  These are resolved in the same way as
     /// FieldDescriptorProto.type_name, but must refer to a message type.
-    #[prost(string, optional, tag = "2")]
+    #[prost(string = "string", optional, tag = "2")]
     pub input_type: ::core::option::Option<::prost::alloc::string::String>,
-    #[prost(string, optional, tag = "3")]
+    #[prost(string = "string", optional, tag = "3")]
     pub output_type: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(message, optional, tag = "4")]
     pub options: ::core::option::Option<MethodOptions>,
@@ -448,14 +448,14 @@ pub struct FileOptions {
     /// placed.  By default, the proto package is used, but this is often
     /// inappropriate because proto packages do not normally start with backwards
     /// domain names.
-    #[prost(string, optional, tag = "1")]
+    #[prost(string = "string", optional, tag = "1")]
     pub java_package: ::core::option::Option<::prost::alloc::string::String>,
     /// Controls the name of the wrapper Java class generated for the .proto file.
     /// That class will always contain the .proto file's getDescriptor() method as
     /// well as any top-level extensions defined in the .proto file.
     /// If java_multiple_files is disabled, then all the other classes from the
     /// .proto file will be nested inside the single wrapper outer class.
-    #[prost(string, optional, tag = "8")]
+    #[prost(string = "string", optional, tag = "8")]
     pub java_outer_classname: ::core::option::Option<::prost::alloc::string::String>,
     /// If enabled, then the Java code generator will generate a separate .java
     /// file for each top-level message, enum, and service defined in the .proto
@@ -490,7 +490,7 @@ pub struct FileOptions {
     /// * The basename of the package import path, if provided.
     /// * Otherwise, the package statement in the .proto file, if present.
     /// * Otherwise, the basename of the .proto file, without extension.
-    #[prost(string, optional, tag = "11")]
+    #[prost(string = "string", optional, tag = "11")]
     pub go_package: ::core::option::Option<::prost::alloc::string::String>,
     /// Should generic services be generated in each language?  "Generic" services
     /// are not specific to any particular RPC system.  They are generated by the
@@ -522,35 +522,35 @@ pub struct FileOptions {
     pub cc_enable_arenas: ::core::option::Option<bool>,
     /// Sets the objective c class prefix which is prepended to all objective c
     /// generated classes from this .proto. There is no default.
-    #[prost(string, optional, tag = "36")]
+    #[prost(string = "string", optional, tag = "36")]
     pub objc_class_prefix: ::core::option::Option<::prost::alloc::string::String>,
     /// Namespace for generated classes; defaults to the package.
-    #[prost(string, optional, tag = "37")]
+    #[prost(string = "string", optional, tag = "37")]
     pub csharp_namespace: ::core::option::Option<::prost::alloc::string::String>,
     /// By default Swift generators will take the proto package and CamelCase it
     /// replacing '.' with underscore and use that to prefix the types/symbols
     /// defined. When this options is provided, they will use this value instead
     /// to prefix the types/symbols defined.
-    #[prost(string, optional, tag = "39")]
+    #[prost(string = "string", optional, tag = "39")]
     pub swift_prefix: ::core::option::Option<::prost::alloc::string::String>,
     /// Sets the php class prefix which is prepended to all php generated classes
     /// from this .proto. Default is empty.
-    #[prost(string, optional, tag = "40")]
+    #[prost(string = "string", optional, tag = "40")]
     pub php_class_prefix: ::core::option::Option<::prost::alloc::string::String>,
     /// Use this option to change the namespace of php generated classes. Default
     /// is empty. When this option is empty, the package name will be used for
     /// determining the namespace.
-    #[prost(string, optional, tag = "41")]
+    #[prost(string = "string", optional, tag = "41")]
     pub php_namespace: ::core::option::Option<::prost::alloc::string::String>,
     /// Use this option to change the namespace of php generated metadata classes.
     /// Default is empty. When this option is empty, the proto file name will be
     /// used for determining the namespace.
-    #[prost(string, optional, tag = "44")]
+    #[prost(string = "string", optional, tag = "44")]
     pub php_metadata_namespace: ::core::option::Option<::prost::alloc::string::String>,
     /// Use this option to change the package of ruby generated classes. Default
     /// is empty. When this option is not set, the package name will be used for
     /// determining the ruby package.
-    #[prost(string, optional, tag = "45")]
+    #[prost(string = "string", optional, tag = "45")]
     pub ruby_package: ::core::option::Option<::prost::alloc::string::String>,
     /// The parser stores options it doesn't recognize here.
     /// See the documentation for the "Options" section above.
@@ -962,7 +962,7 @@ pub struct UninterpretedOption {
     pub name: ::prost::alloc::vec::Vec<uninterpreted_option::NamePart>,
     /// The value of the uninterpreted option, in whatever type the tokenizer
     /// identified it as during parsing. Exactly one of these should be set.
-    #[prost(string, optional, tag = "3")]
+    #[prost(string = "string", optional, tag = "3")]
     pub identifier_value: ::core::option::Option<::prost::alloc::string::String>,
     #[prost(uint64, optional, tag = "4")]
     pub positive_int_value: ::core::option::Option<u64>,
@@ -972,7 +972,7 @@ pub struct UninterpretedOption {
     pub double_value: ::core::option::Option<f64>,
     #[prost(bytes = "vec", optional, tag = "7")]
     pub string_value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
-    #[prost(string, optional, tag = "8")]
+    #[prost(string = "string", optional, tag = "8")]
     pub aggregate_value: ::core::option::Option<::prost::alloc::string::String>,
 }
 /// Nested message and enum types in `UninterpretedOption`.
@@ -985,7 +985,7 @@ pub mod uninterpreted_option {
     #[allow(clippy::derive_partial_eq_without_eq)]
     #[derive(Clone, PartialEq, ::prost::Message)]
     pub struct NamePart {
-        #[prost(string, required, tag = "1")]
+        #[prost(string = "string", required, tag = "1")]
         pub name_part: ::prost::alloc::string::String,
         #[prost(bool, required, tag = "2")]
         pub is_extension: bool,
@@ -1127,11 +1127,11 @@ pub mod source_code_info {
         /// optional int32 grault = 6;
         ///
         /// // ignored detached comments.
-        #[prost(string, optional, tag = "3")]
+        #[prost(string = "string", optional, tag = "3")]
         pub leading_comments: ::core::option::Option<::prost::alloc::string::String>,
-        #[prost(string, optional, tag = "4")]
+        #[prost(string = "string", optional, tag = "4")]
         pub trailing_comments: ::core::option::Option<::prost::alloc::string::String>,
-        #[prost(string, repeated, tag = "6")]
+        #[prost(string = "string", repeated, tag = "6")]
         pub leading_detached_comments: ::prost::alloc::vec::Vec<
             ::prost::alloc::string::String,
         >,
@@ -1158,7 +1158,7 @@ pub mod generated_code_info {
         #[prost(int32, repeated, tag = "1")]
         pub path: ::prost::alloc::vec::Vec<i32>,
         /// Identifies the filesystem path to the original source .proto.
-        #[prost(string, optional, tag = "2")]
+        #[prost(string = "string", optional, tag = "2")]
         pub source_file: ::core::option::Option<::prost::alloc::string::String>,
         /// Identifies the starting offset in bytes in the generated code
         /// that relates to the identified object.
@@ -1294,7 +1294,7 @@ pub struct Any {
     ///
     /// Schemes other than `http`, `https` (or the empty scheme) might be
     /// used with implementation specific semantics.
-    #[prost(string, tag = "1")]
+    #[prost(string = "string", tag = "1")]
     pub type_url: ::prost::alloc::string::String,
     /// Must be a valid serialized protocol buffer of the above specified type.
     #[prost(bytes = "vec", tag = "2")]
@@ -1307,7 +1307,7 @@ pub struct Any {
 pub struct SourceContext {
     /// The path-qualified name of the .proto file that contained the associated
     /// protobuf element.  For example: `"google/protobuf/source_context.proto"`.
-    #[prost(string, tag = "1")]
+    #[prost(string = "string", tag = "1")]
     pub file_name: ::prost::alloc::string::String,
 }
 /// A protocol buffer message type.
@@ -1315,13 +1315,13 @@ pub struct SourceContext {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Type {
     /// The fully qualified message name.
-    #[prost(string, tag = "1")]
+    #[prost(string = "string", tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// The list of fields.
     #[prost(message, repeated, tag = "2")]
     pub fields: ::prost::alloc::vec::Vec<Field>,
     /// The list of types appearing in `oneof` definitions in this type.
-    #[prost(string, repeated, tag = "3")]
+    #[prost(string = "string", repeated, tag = "3")]
     pub oneofs: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
     /// The protocol buffer options.
     #[prost(message, repeated, tag = "4")]
@@ -1347,11 +1347,11 @@ pub struct Field {
     #[prost(int32, tag = "3")]
     pub number: i32,
     /// The field name.
-    #[prost(string, tag = "4")]
+    #[prost(string = "string", tag = "4")]
     pub name: ::prost::alloc::string::String,
     /// The field type URL, without the scheme, for message or enumeration
     /// types. Example: `"type.googleapis.com/google.protobuf.Timestamp"`.
-    #[prost(string, tag = "6")]
+    #[prost(string = "string", tag = "6")]
     pub type_url: ::prost::alloc::string::String,
     /// The index of the field type in `Type.oneofs`, for message or enumeration
     /// types. The first type has index 1; zero means the type is not in the list.
@@ -1364,10 +1364,10 @@ pub struct Field {
     #[prost(message, repeated, tag = "9")]
     pub options: ::prost::alloc::vec::Vec<Option>,
     /// The field JSON name.
-    #[prost(string, tag = "10")]
+    #[prost(string = "string", tag = "10")]
     pub json_name: ::prost::alloc::string::String,
     /// The string value of the default value of this field. Proto2 syntax only.
-    #[prost(string, tag = "11")]
+    #[prost(string = "string", tag = "11")]
     pub default_value: ::prost::alloc::string::String,
 }
 /// Nested message and enum types in `Field`.
@@ -1532,7 +1532,7 @@ pub mod field {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Enum {
     /// Enum type name.
-    #[prost(string, tag = "1")]
+    #[prost(string = "string", tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// Enum value definitions.
     #[prost(message, repeated, tag = "2")]
@@ -1552,7 +1552,7 @@ pub struct Enum {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EnumValue {
     /// Enum value name.
-    #[prost(string, tag = "1")]
+    #[prost(string = "string", tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// Enum value number.
     #[prost(int32, tag = "2")]
@@ -1570,7 +1570,7 @@ pub struct Option {
     /// descriptor.proto), this is the short name. For example, `"map_entry"`.
     /// For custom options, it should be the fully-qualified name. For example,
     /// `"google.api.http"`.
-    #[prost(string, tag = "1")]
+    #[prost(string = "string", tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// The option's value packed in an Any message. If the value is a primitive,
     /// the corresponding wrapper type defined in google/protobuf/wrappers.proto
@@ -1622,7 +1622,7 @@ impl Syntax {
 pub struct Api {
     /// The fully qualified name of this interface, including package name
     /// followed by the interface's simple name.
-    #[prost(string, tag = "1")]
+    #[prost(string = "string", tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// The methods of this interface, in unspecified order.
     #[prost(message, repeated, tag = "2")]
@@ -1649,7 +1649,7 @@ pub struct Api {
     /// `google.feature.v1`. For major versions 0 and 1, the suffix can
     /// be omitted. Zero major versions must only be used for
     /// experimental, non-GA interfaces.
-    #[prost(string, tag = "4")]
+    #[prost(string = "string", tag = "4")]
     pub version: ::prost::alloc::string::String,
     /// Source context for the protocol buffer service represented by this
     /// message.
@@ -1667,16 +1667,16 @@ pub struct Api {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Method {
     /// The simple name of this method.
-    #[prost(string, tag = "1")]
+    #[prost(string = "string", tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// A URL of the input message type.
-    #[prost(string, tag = "2")]
+    #[prost(string = "string", tag = "2")]
     pub request_type_url: ::prost::alloc::string::String,
     /// If true, the request is streamed.
     #[prost(bool, tag = "3")]
     pub request_streaming: bool,
     /// The URL of the output message type.
-    #[prost(string, tag = "4")]
+    #[prost(string = "string", tag = "4")]
     pub response_type_url: ::prost::alloc::string::String,
     /// If true, the response is streamed.
     #[prost(bool, tag = "5")]
@@ -1780,11 +1780,11 @@ pub struct Method {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Mixin {
     /// The fully qualified name of the interface which is included.
-    #[prost(string, tag = "1")]
+    #[prost(string = "string", tag = "1")]
     pub name: ::prost::alloc::string::String,
     /// If non-empty specifies a path under which inherited HTTP paths
     /// are rooted.
-    #[prost(string, tag = "2")]
+    #[prost(string = "string", tag = "2")]
     pub root: ::prost::alloc::string::String,
 }
 /// A Duration represents a signed, fixed-length span of time represented
@@ -2094,7 +2094,7 @@ pub struct Duration {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FieldMask {
     /// The set of field mask paths.
-    #[prost(string, repeated, tag = "1")]
+    #[prost(string = "string", repeated, tag = "1")]
     pub paths: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
 /// `Struct` represents a structured data value, consisting of fields
@@ -2141,7 +2141,7 @@ pub mod value {
         #[prost(double, tag = "2")]
         NumberValue(f64),
         /// Represents a string value.
-        #[prost(string, tag = "3")]
+        #[prost(string = "string", tag = "3")]
         StringValue(::prost::alloc::string::String),
         /// Represents a boolean value.
         #[prost(bool, tag = "4")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,6 +5,7 @@
 //! the `prost-types` crate in order to avoid a cyclic dependency between `prost` and
 //! `prost-build`.
 
+use alloc::boxed::Box;
 use alloc::string::String;
 use alloc::vec::Vec;
 
@@ -395,6 +396,43 @@ impl Message for Bytes {
     }
     fn clear(&mut self) {
         self.clear();
+    }
+}
+
+impl Message for Box<[u8]> {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        if !self.is_empty() {
+            bytes::encode(1, self, buf)
+        }
+    }
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        if tag == 1 {
+            bytes::merge(wire_type, self, buf, ctx)
+        } else {
+            skip_field(wire_type, tag, buf, ctx)
+        }
+    }
+    fn encoded_len(&self) -> usize {
+        if !self.is_empty() {
+            bytes::encoded_len(1, self)
+        } else {
+            0
+        }
+    }
+    fn clear(&mut self) {
+        *self = Self::default();
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -13,7 +13,7 @@ use ::bytes::{Buf, BufMut, Bytes};
 
 use crate::{
     encoding::{
-        bool, bytes, double, float, int32, int64, skip_field, string, uint32, uint64,
+        bool, boxed_str, bytes, double, float, int32, int64, skip_field, string, uint32, uint64,
         DecodeContext, WireType,
     },
     DecodeError, Message,
@@ -320,6 +320,44 @@ impl Message for String {
     }
     fn clear(&mut self) {
         self.clear();
+    }
+}
+
+/// `google.protobuf.StringValue`
+impl Message for Box<str> {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        if !self.is_empty() {
+            boxed_str::encode(1, self, buf)
+        }
+    }
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        if tag == 1 {
+            boxed_str::merge(wire_type, self, buf, ctx)
+        } else {
+            skip_field(wire_type, tag, buf, ctx)
+        }
+    }
+    fn encoded_len(&self) -> usize {
+        if !self.is_empty() {
+            boxed_str::encoded_len(1, self)
+        } else {
+            0
+        }
+    }
+    fn clear(&mut self) {
+        *self = Self::default();
     }
 }
 

--- a/tests/single-include/src/outdir/outdir.rs
+++ b/tests/single-include/src/outdir/outdir.rs
@@ -1,7 +1,7 @@
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OutdirRequest {
-    #[prost(string, tag = "1")]
+    #[prost(string = "string", tag = "1")]
     pub query: ::prost::alloc::string::String,
     #[prost(int32, tag = "2")]
     pub page_number: i32,

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -132,6 +132,7 @@ fn main() {
 
     config
         .bytes([".bytes_types.BytesTypes.is_bytes"])
+        .boxed_slice([".bytes_types.BytesTypes.is_boxed_slice"])
         .compile_protos(&[src.join("bytes_types.proto")], includes)
         .unwrap();
 

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -137,8 +137,10 @@ fn main() {
         .unwrap();
 
     config
+        .boxed_str([".string_types.StringTypes.is_boxed_str"])
         .compile_protos(&[src.join("string_types.proto")], includes)
         .unwrap();
+
     let out = std::env::var("OUT_DIR").unwrap();
     let out_path = PathBuf::from(out).join("wellknown_include");
 

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -130,6 +130,11 @@ fn main() {
         .compile_protos(&[src.join("well_known_types.proto")], includes)
         .unwrap();
 
+    config
+        .bytes([".bytes_types.BytesTypes.is_bytes"])
+        .compile_protos(&[src.join("bytes_types.proto")], includes)
+        .unwrap();
+
     let out = std::env::var("OUT_DIR").unwrap();
     let out_path = PathBuf::from(out).join("wellknown_include");
 

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -136,6 +136,9 @@ fn main() {
         .compile_protos(&[src.join("bytes_types.proto")], includes)
         .unwrap();
 
+    config
+        .compile_protos(&[src.join("string_types.proto")], includes)
+        .unwrap();
     let out = std::env::var("OUT_DIR").unwrap();
     let out_path = PathBuf::from(out).join("wellknown_include");
 

--- a/tests/src/bytes_types.proto
+++ b/tests/src/bytes_types.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+
+package bytes_types;
+
+message BytesTypes {
+    bytes is_vec = 1;
+    bytes is_bytes = 2;
+}

--- a/tests/src/bytes_types.proto
+++ b/tests/src/bytes_types.proto
@@ -5,4 +5,5 @@ package bytes_types;
 message BytesTypes {
     bytes is_vec = 1;
     bytes is_bytes = 2;
+    bytes is_boxed_slice = 3;
 }

--- a/tests/src/bytes_types.rs
+++ b/tests/src/bytes_types.rs
@@ -1,0 +1,10 @@
+include!(concat!(env!("OUT_DIR"), "/bytes_types.rs"));
+
+#[test]
+fn test_bytes_types() {
+    // Successful compilation means the types and generated code are correct
+    let _ = BytesTypes {
+        is_vec: ::prost::alloc::vec::Vec::<u8>::default(),
+        is_bytes: ::prost::bytes::Bytes::default(),
+    };
+}

--- a/tests/src/bytes_types.rs
+++ b/tests/src/bytes_types.rs
@@ -6,5 +6,6 @@ fn test_bytes_types() {
     let _ = BytesTypes {
         is_vec: ::prost::alloc::vec::Vec::<u8>::default(),
         is_bytes: ::prost::bytes::Bytes::default(),
+        is_boxed_slice: ::prost::alloc::boxed::Box::<[u8]>::default(),
     };
 }

--- a/tests/src/debug.rs
+++ b/tests/src/debug.rs
@@ -73,7 +73,7 @@ fn tuple_struct() {
 pub enum OneofWithEnum {
     #[prost(int32, tag = "8")]
     Int(i32),
-    #[prost(string, tag = "9")]
+    #[prost(string = "string", tag = "9")]
     String(String),
     #[prost(enumeration = "BasicEnumeration", tag = "10")]
     Enumeration(i32),

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -33,6 +33,8 @@ pub mod unittest;
 #[cfg(test)]
 mod bootstrap;
 #[cfg(test)]
+mod bytes_types;
+#[cfg(test)]
 mod debug;
 #[cfg(test)]
 mod deprecated_field;

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -47,6 +47,8 @@ mod no_unused_results;
 #[cfg(test)]
 #[cfg(feature = "std")]
 mod skip_debug;
+#[cfg(test)]
+mod string_types;
 
 mod test_enum_named_option_value {
     include!(concat!(env!("OUT_DIR"), "/myenum.optionn.rs"));

--- a/tests/src/message_encoding.rs
+++ b/tests/src/message_encoding.rs
@@ -61,7 +61,7 @@ pub struct ScalarTypes {
     pub double: f64,
     #[prost(bool, tag = "013")]
     pub _bool: bool,
-    #[prost(string, tag = "014")]
+    #[prost(string = "string", tag = "014")]
     pub string: String,
     #[prost(bytes = "vec", tag = "015")]
     pub bytes_vec: Vec<u8>,
@@ -94,7 +94,7 @@ pub struct ScalarTypes {
     pub required_double: f64,
     #[prost(bool, required, tag = "113")]
     pub required_bool: bool,
-    #[prost(string, required, tag = "114")]
+    #[prost(string = "string", required, tag = "114")]
     pub required_string: String,
     #[prost(bytes = "vec", required, tag = "115")]
     pub required_bytes_vec: Vec<u8>,
@@ -128,7 +128,7 @@ pub struct ScalarTypes {
     pub optional_double: Option<f64>,
     #[prost(bool, optional, tag = "213")]
     pub optional_bool: Option<bool>,
-    #[prost(string, optional, tag = "214")]
+    #[prost(string = "string", optional, tag = "214")]
     pub optional_string: Option<String>,
     #[prost(bytes = "vec", optional, tag = "215")]
     pub optional_bytes_vec: Option<Vec<u8>>,
@@ -161,7 +161,7 @@ pub struct ScalarTypes {
     pub repeated_double: Vec<f64>,
     #[prost(bool, repeated, packed = "false", tag = "313")]
     pub repeated_bool: Vec<bool>,
-    #[prost(string, repeated, packed = "false", tag = "315")]
+    #[prost(string = "string", repeated, packed = "false", tag = "315")]
     pub repeated_string: Vec<String>,
     #[prost(bytes = "vec", repeated, packed = "false", tag = "316")]
     pub repeated_bytes_vec: Vec<Vec<u8>>,
@@ -195,7 +195,7 @@ pub struct ScalarTypes {
     pub packed_double: Vec<f64>,
     #[prost(bool, repeated, tag = "413")]
     pub packed_bool: Vec<bool>,
-    #[prost(string, repeated, tag = "415")]
+    #[prost(string = "string", repeated, tag = "415")]
     pub packed_string: Vec<String>,
     #[prost(bytes = "vec", repeated, tag = "416")]
     pub packed_bytes_vec: Vec<Vec<u8>>,
@@ -289,7 +289,7 @@ pub struct DefaultValues {
     #[prost(int32, optional, tag = "2", default = "88")]
     pub optional_int32: Option<i32>,
 
-    #[prost(string, tag = "3", default = "forty two")]
+    #[prost(string = "string", tag = "3", default = "forty two")]
     pub string: String,
 
     #[prost(bytes = "vec", tag = "7", default = "b\"foo\\x00bar\"")]
@@ -341,10 +341,10 @@ pub struct Basic {
     #[prost(bool, repeated, packed = "false", tag = "2")]
     pub bools: Vec<bool>,
 
-    #[prost(string, tag = "3")]
+    #[prost(string = "string", tag = "3")]
     pub string: String,
 
-    #[prost(string, optional, tag = "4")]
+    #[prost(string = "string", optional, tag = "4")]
     pub optional_string: Option<String>,
 
     #[prost(enumeration = "BasicEnumeration", tag = "5")]
@@ -397,6 +397,6 @@ pub struct Compound {
 pub enum BasicOneof {
     #[prost(int32, tag = "8")]
     Int(i32),
-    #[prost(string, tag = "9")]
+    #[prost(string = "string", tag = "9")]
     String(String),
 }

--- a/tests/src/string_types.proto
+++ b/tests/src/string_types.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package string_types;
+
+message StringTypes {
+    string is_string = 1;
+}

--- a/tests/src/string_types.proto
+++ b/tests/src/string_types.proto
@@ -4,4 +4,5 @@ package string_types;
 
 message StringTypes {
     string is_string = 1;
+    string is_boxed_str = 2;
 }

--- a/tests/src/string_types.rs
+++ b/tests/src/string_types.rs
@@ -5,5 +5,6 @@ fn test_string_types() {
     // Successful compilation means the types and generated code are correct
     let _ = StringTypes {
         is_string: ::prost::alloc::string::String::default(),
+        is_boxed_str: ::prost::alloc::boxed::Box::<str>::default(),
     };
 }

--- a/tests/src/string_types.rs
+++ b/tests/src/string_types.rs
@@ -1,0 +1,9 @@
+include!(concat!(env!("OUT_DIR"), "/string_types.rs"));
+
+#[test]
+fn test_string_types() {
+    // Successful compilation means the types and generated code are correct
+    let _ = StringTypes {
+        is_string: ::prost::alloc::string::String::default(),
+    };
+}


### PR DESCRIPTION
This reduces the size of objects by one byte each time they're used, which can help quite a lot in some cases.

This is fully optional and the defaults have not changed.