### PR TITLE
Add optional support for simdutf8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,12 @@ bench = false
 default = ["prost-derive", "std"]
 no-recursion-limit = []
 std = []
+simdutf8 = ["dep:simdutf8"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }
 prost-derive = { version = "0.11.8", path = "prost-derive", optional = true }
+simdutf8 = { version = "0.1.4", optional = true, features = ["aarch64_neon"] }
 
 [dev-dependencies]
 criterion = { version = "0.4", default-features = false }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -11,9 +11,14 @@ use alloc::vec::Vec;
 use core::cmp::min;
 use core::convert::TryFrom;
 use core::mem;
-use core::str;
 use core::u32;
 use core::usize;
+
+#[cfg(feature = "simdutf8")]
+use simdutf8::basic::from_utf8;
+
+#[cfg(not(feature = "simdutf8"))]
+use core::str::from_utf8;
 
 use ::bytes::{Buf, BufMut, Bytes};
 
@@ -835,7 +840,7 @@ pub mod string {
 
             let drop_guard = DropGuard(value.as_mut_vec());
             bytes::merge_one_copy(wire_type, drop_guard.0, buf, ctx)?;
-            match str::from_utf8(drop_guard.0) {
+            match from_utf8(drop_guard.0) {
                 Ok(_) => {
                     // Success; do not clear the bytes.
                     mem::forget(drop_guard);


### PR DESCRIPTION
[simdutf8](https://github.com/rusticstuff/simdutf8) is faster variant of `from_utf8` method than from `core`. 