### PR TITLE
chore: Bump msrv to 1.63

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yaml
+++ b/.github/workflows/continuous-integration-workflow.yaml
@@ -72,7 +72,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - "1.60"
+          - "1.63"
         os:
           - ubuntu-latest
           - macos-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "A Protocol Buffers implementation for the Rust Language."
 keywords = ["protobuf", "serialization"]
 categories = ["encoding"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ start-to-finish example.
 
 ### MSRV
 
-`prost` follows the `tokio-rs` projects MSRV model and supports 1.60. For more
+`prost` follows the `tokio-rs` projects MSRV model and supports 1.63. For more
 information on the tokio msrv policy you can check it out [here][tokio msrv]
 
 [tokio msrv]: https://github.com/tokio-rs/tokio/#supported-rust-versions

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/prost-build"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 
 [features]
 default = ["format"]

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/prost-derive"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 
 [lib]
 proc_macro = true

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/prost-types"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 
 [lib]
 doctest = false


### PR DESCRIPTION
[`tempfile` 3.7.0](https://github.com/Stebalien/tempfile/blob/v3.7.0/CHANGELOG.md?plain=1#L10) requires Rust 1.63.