### PR TITLE
prost-types: fix tests without default features

### DIFF
--- a/prost-types/src/datetime.rs
+++ b/prost-types/src/datetime.rs
@@ -587,8 +587,6 @@ impl From<DateTime> for Timestamp {
 #[cfg(test)]
 mod tests {
 
-    use std::convert::TryFrom;
-
     use proptest::prelude::*;
 
     use super::*;
@@ -612,6 +610,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "std")]
     fn test_datetime_from_timestamp() {
         let case = |expected: &str, secs: i64, nanos: i32| {
             let timestamp = Timestamp {
@@ -850,6 +849,7 @@ mod tests {
             )
         }
 
+        #[cfg(feature = "std")]
         #[test]
         fn check_duration_parse_to_string_roundtrip(
             duration in core::time::Duration::arbitrary(),

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -421,6 +421,7 @@ impl fmt::Display for Timestamp {
     }
 }
 
+#[cfg(feature = "std")]
 #[cfg(test)]
 mod tests {
     use std::time::{self, SystemTime, UNIX_EPOCH};
@@ -429,7 +430,6 @@ mod tests {
 
     use super::*;
 
-    #[cfg(feature = "std")]
     proptest! {
         #[test]
         fn check_system_time_roundtrip(


### PR DESCRIPTION
Only include tests using std if the feature is available. When running cargo test with --no-default-features there are a few failures due to the fact that std is missing.