### PR TITLE
Fix `non_snake_case` warning on generated identity functions

### DIFF
--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -230,6 +230,7 @@ impl Field {
             }
         } else {
             quote! {
+                #[allow(non_snake_case)]
                 fn #wrap_name<T>(v: T) -> T { v }
             }
         }


### PR DESCRIPTION
The `Message` derive macro currently generates `Debug` implementations that contain code that violates the `non_snake_case` linter rule[^1]. This PR changes the macro expansion to add an `#[allow(...)]` attribute for this rule.

**Note**: If there is consensus that the solution is OK, I'll fix any failing tests to make this PR ready to merge.

[^1]: https://doc.rust-lang.org/stable/nightly-rustc/rustc_lint/nonstandard_style/static.NON_SNAKE_CASE.html