### PR TITLE
feat: `Name` trait + `Any` encoding support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - "1.63"
+          - "1.64"
         os:
           - ubuntu-latest
           - macos-latest

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -25,6 +25,7 @@ use core::str::FromStr;
 use core::time;
 
 use prost::alloc::format;
+use prost::alloc::string::String;
 use prost::alloc::vec::Vec;
 use prost::{DecodeError, EncodeError, Message, Name};
 
@@ -864,7 +865,7 @@ mod tests {
 
     #[test]
     fn check_any_serialization() {
-        let message = Timestamp::from(UNIX_EPOCH);
+        let message = Timestamp::date(2000, 01, 01).unwrap();
         let any = Any::from_msg(&message).unwrap();
         assert_eq!(
             &any.type_url,

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -57,16 +57,24 @@ impl Any {
     {
         let expected_type_url = M::type_url();
 
-        if self.type_url == expected_type_url {
-            Ok(M::decode(&*self.value)?)
-        } else {
-            let mut err = DecodeError::new(format!(
-                "expected type URL: \"{}\" (got: \"{}\")",
-                expected_type_url, &self.type_url
-            ));
-            err.push("unexpected type URL", "type_url");
-            Err(err)
+        match (
+            TypeUrl::new(&expected_type_url),
+            TypeUrl::new(&self.type_url),
+        ) {
+            (Some(expected), Some(actual)) => {
+                if expected == actual {
+                    return Ok(M::decode(&*self.value)?);
+                }
+            }
+            _ => (),
         }
+
+        let mut err = DecodeError::new(format!(
+            "expected type URL: \"{}\" (got: \"{}\")",
+            expected_type_url, &self.type_url
+        ));
+        err.push("unexpected type URL", "type_url");
+        Err(err)
     }
 }
 
@@ -458,6 +466,43 @@ impl fmt::Display for Timestamp {
     }
 }
 
+/// URL/resource name that uniquely identifies the type of the serialized protocol buffer message,
+/// e.g. `type.googleapis.com/google.protobuf.Duration`.
+///
+/// This string must contain at least one "/" character.
+///
+/// The last segment of the URL's path must represent the fully qualified name of the type (as in
+/// `path/google.protobuf.Duration`). The name should be in a canonical form (e.g., leading "." is
+/// not accepted).
+///
+/// If no scheme is provided, `https` is assumed.
+///
+/// Schemes other than `http`, `https` (or the empty scheme) might be used with implementation
+/// specific semantics.
+#[derive(Debug, Eq, PartialEq)]
+struct TypeUrl<'a> {
+    /// Fully qualified name of the type, e.g. `google.protobuf.Duration`
+    full_name: &'a str,
+}
+
+impl<'a> TypeUrl<'a> {
+    fn new(s: &'a str) -> core::option::Option<Self> {
+        // Must contain at least one "/" character.
+        let slash_pos = s.rfind('/')?;
+
+        // The last segment of the URL's path must represent the fully qualified name
+        // of the type (as in `path/google.protobuf.Duration`)
+        let full_name = s.get((slash_pos + 1)..)?;
+
+        // The name should be in a canonical form (e.g., leading "." is not accepted).
+        if full_name.starts_with('.') {
+            return None;
+        }
+
+        Some(Self { full_name })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -780,5 +825,26 @@ mod tests {
                 case.0,
             );
         }
+    }
+
+    #[test]
+    fn check_type_url_parsing() {
+        let example_type_name = "google.protobuf.Duration";
+
+        let url = TypeUrl::new("type.googleapis.com/google.protobuf.Duration").unwrap();
+        assert_eq!(url.full_name, example_type_name);
+
+        let full_url =
+            TypeUrl::new("https://type.googleapis.com/google.protobuf.Duration").unwrap();
+        assert_eq!(full_url.full_name, example_type_name);
+
+        let relative_url = TypeUrl::new("/google.protobuf.Duration").unwrap();
+        assert_eq!(relative_url.full_name, example_type_name);
+
+        // The name should be in a canonical form (e.g., leading "." is not accepted).
+        assert_eq!(TypeUrl::new("/.google.protobuf.Duration"), None);
+
+        // Must contain at least one "/" character.
+        assert_eq!(TypeUrl::new("google.protobuf.Duration"), None);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ pub use bytes;
 
 mod error;
 mod message;
+mod name;
 mod types;
 
 #[doc(hidden)]
@@ -18,6 +19,7 @@ pub mod encoding;
 
 pub use crate::error::{DecodeError, EncodeError};
 pub use crate::message::Message;
+pub use crate::name::Name;
 
 use bytes::{Buf, BufMut};
 

--- a/src/name.rs
+++ b/src/name.rs
@@ -1,0 +1,28 @@
+//! Support for associating type name information with a [`Message`].
+
+use crate::Message;
+use alloc::{format, string::String};
+
+/// Associate a type name with a [`Message`] type.
+pub trait Name: Message {
+    /// Type name for this [`Message`]. This is the camel case name,
+    /// e.g. `TypeName`.
+    const NAME: &'static str;
+
+    /// Package name this message type is contained in. They are domain-like
+    /// and delimited by `.`, e.g. `google.protobuf`.
+    const PACKAGE: &'static str;
+
+    /// Full name of this message type containing both the package name and
+    /// type name, e.g. `google.protobuf.TypeName`.
+    fn full_name() -> String {
+        format!("{}.{}", Self::NAME, Self::PACKAGE)
+    }
+
+    /// Type URL for this message, which by default is the full name with a
+    /// leading slash, but may also include a leading domain name, e.g.
+    /// `type.googleapis.com/google.profile.Person`.
+    fn type_url() -> String {
+        format!("/{}", Self::full_name())
+    }
+}


### PR DESCRIPTION
As discussed in #299 and #858, adds a `Name` trait which associates a type name and package constants with a `Message` type. It also provides `full_name` and `type_url` methods.

The `type_url` method is used by newly added methods on the `Any` type which can be used for decoding/encoding messages:

- `Any::from_msg`: encodes a given `Message`, returning `Any`.
- `Any::to_msg`: decodes `Any::value` as the given `Message`, first validating the message type has the expected type URL.