### PR TITLE
fix protoc install link

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ With `prost-build` v0.11 release, `protoc` will be required to invoke
 bundled a `protoc` or attempt to compile `protoc` for users. For install
 instructions for `protoc` please check out the [protobuf install] instructions.
 
-[protobuf install]: https://github.com/protocolbuffers/protobuf#protocol-compiler-installation
+[protobuf install]: https://github.com/protocolbuffers/protobuf#protobuf-compiler-installation
 
 
 ### Packages


### PR DESCRIPTION
The upstream change https://github.com/protocolbuffers/protobuf/commit/3c3dfe0efa859563e1fdbe51badd0ebf74760ff9 broke the anchor link

This corrects the link