### PR TITLE
chore: Prepare `v0.12.0` release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost"
-version = "0.11.9"
+version = "0.12.0"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Lucio Franco <luciofranco14@gmail.com",
@@ -48,7 +48,7 @@ std = []
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-prost-derive = { version = "0.11.9", path = "prost-derive", optional = true }
+prost-derive = { version = "0.12.0", path = "prost-derive", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.4", default-features = false }

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ First, add `prost` and its public dependencies to your `Cargo.toml`:
 
 ```ignore
 [dependencies]
-prost = "0.11"
+prost = "0.12"
 # Only necessary if using Protobuf well-known types:
-prost-types = "0.11"
+prost-types = "0.12"
 ```
 
 The recommended way to add `.proto` compilation to a Cargo project is to use the

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost-build"
-version = "0.11.9"
+version = "0.12.0"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Lucio Franco <luciofranco14@gmail.com>",
@@ -27,8 +27,8 @@ itertools = { version = ">=0.10, <0.12", default-features = false, features = ["
 log = "0.4"
 multimap = { version = "0.8", default-features = false }
 petgraph = { version = "0.6", default-features = false }
-prost = { version = "0.11.9", path = "..", default-features = false }
-prost-types = { version = "0.11.9", path = "../prost-types", default-features = false }
+prost = { version = "0.12.0", path = "..", default-features = false }
+prost-types = { version = "0.12.0", path = "../prost-types", default-features = false }
 tempfile = "3"
 once_cell = "1.17.1"
 regex = { version = "1.8.1", default-features = false, features = ["std", "unicode-bool"] }

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-build/0.11.9")]
+#![doc(html_root_url = "https://docs.rs/prost-build/0.12.0")]
 #![allow(clippy::option_as_ref_deref, clippy::format_push_string)]
 
 //! `prost-build` compiles `.proto` files into Rust.

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost-derive"
-version = "0.11.9"
+version = "0.12.0"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Lucio Franco <luciofranco14@gmail.com>",

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-derive/0.11.9")]
+#![doc(html_root_url = "https://docs.rs/prost-derive/0.12.0")]
 // The `quote!` macro requires deep recursion.
 #![recursion_limit = "4096"]
 

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost-types"
-version = "0.11.9"
+version = "0.12.0"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Lucio Franco <luciofranco14@gmail.com",
@@ -22,7 +22,7 @@ default = ["std"]
 std = ["prost/std"]
 
 [dependencies]
-prost = { version = "0.11.9", path = "..", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.12.0", path = "..", default-features = false, features = ["prost-derive"] }
 
 [dev-dependencies]
 proptest = "1"

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-types/0.11.9")]
+#![doc(html_root_url = "https://docs.rs/prost-types/0.12.0")]
 
 //! Protocol Buffers well-known types.
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost/0.11.9")]
+#![doc(html_root_url = "https://docs.rs/prost/0.12.0")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![doc = include_str!("../README.md")]
 


### PR DESCRIPTION
_PROST!_ is a [Protocol Buffers](https://developers.google.com/protocol-buffers/) implementation for the [Rust Language](https://www.rust-lang.org/). `prost` generates simple, idiomatic Rust code from `proto2` and `proto3` files.

This patch updates brings a few new features and fixes:

- Bump `syn`  to version 2
- Bump MSRV to 1.64
- Added `TryFrom<i32>` for enums
- Optional debug implementations
- Initial generic `Any` and `Name` impl/traits.