### PR TITLE
chore: Use taiki-e/install-action to setup cargo-machete

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,10 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
-      - name: install cargo-machete
-        uses: baptiste0928/cargo-install@v2
-        with:
-          crate: cargo-machete
+      - uses: taiki-e/install-action@cargo-machete
       - name: Check unused dependencies
         run: cargo machete
 


### PR DESCRIPTION
`taiki-e/install-action` supports `cargo-machete` at [2.16.0](https://github.com/taiki-e/install-action/blob/v2.16.0/CHANGELOG.md#2160---2023-08-19). This action downloads the binary release.