### PR TITLE
prost-type: impl Hash for Duration

### DIFF
--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -90,6 +90,14 @@ impl Name for Any {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::hash::Hash for Duration {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
+        self.seconds.hash(state);
+        self.nanos.hash(state);
+    }
+}
+
 impl Duration {
     /// Normalizes the duration to a canonical format.
     ///


### PR DESCRIPTION
👋 

Our proxy, which checks if we are not making the same RPC with the same payload at the same time, requires the implementation of a hash.