### PR TITLE
Fixes 905, fix: Use full path of Result type + unit test

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
       {
         devShells.default = pkgs.mkShell {
           packages = with pkgs; [ cargo rustc ];
-          buildInputs = with pkgs; [ pkg-config protobuf curl ];
+          buildInputs = with pkgs; [ pkg-config protobuf curl cmake ninja ];
         };
       });
 }

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -276,14 +276,14 @@ impl Field {
                 #[doc=#get_doc]
                 pub fn #get(&self, key: #key_ref_ty) -> ::core::option::Option<#ty> {
                     self.#ident.get(#take_ref key).cloned().and_then(|x| {
-                        let result: Result<#ty, _> = ::core::convert::TryFrom::try_from(x);
+                        let result: ::core::result::Result<#ty, _> = ::core::convert::TryFrom::try_from(x);
                         result.ok()
                     })
                 }
                 #[doc=#insert_doc]
                 pub fn #insert(&mut self, key: #key_ty, value: #ty) -> ::core::option::Option<#ty> {
                     self.#ident.insert(key, value as i32).and_then(|x| {
-                        let result: Result<#ty, _> = ::core::convert::TryFrom::try_from(x);
+                        let result: ::core::result::Result<#ty, _> = ::core::convert::TryFrom::try_from(x);
                         result.ok()
                     })
                 }

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -219,7 +219,7 @@ impl Field {
                 struct #wrap_name<'a>(&'a i32);
                 impl<'a> ::core::fmt::Debug for #wrap_name<'a> {
                     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                        let res: Result<#ty, _> = ::core::convert::TryFrom::try_from(*self.0);
+                        let res: ::core::result::Result<#ty, _> = ::core::convert::TryFrom::try_from(*self.0);
                         match res {
                             Err(_) => ::core::fmt::Debug::fmt(&self.0, f),
                             Ok(en) => ::core::fmt::Debug::fmt(&en, f),
@@ -316,7 +316,7 @@ impl Field {
                         #[doc=#get_doc]
                         pub fn #get(&self) -> #ty {
                             self.#ident.and_then(|x| {
-                                let result: Result<#ty, _> = ::core::convert::TryFrom::try_from(x);
+                                let result: ::core::result::Result<#ty, _> = ::core::convert::TryFrom::try_from(x);
                                 result.ok()
                             }).unwrap_or(#default)
                         }
@@ -341,7 +341,7 @@ impl Field {
                             fn(i32) -> ::core::option::Option<#ty>,
                         > {
                             self.#ident.iter().cloned().filter_map(|x| {
-                                let result: Result<#ty, _> = ::core::convert::TryFrom::try_from(x);
+                                let result: ::core::result::Result<#ty, _> = ::core::convert::TryFrom::try_from(x);
                                 result.ok()
                             })
                         }

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -95,6 +95,14 @@ fn main() {
         .compile_protos(&[src.join("custom_debug.proto")], includes)
         .unwrap();
 
+    config
+        .compile_protos(&[src.join("result_enum.proto")], includes)
+        .unwrap();
+
+    config
+        .compile_protos(&[src.join("result_struct.proto")], includes)
+        .unwrap();
+
     prost_build::Config::new()
         .protoc_arg("--experimental_allow_proto3_optional")
         .compile_protos(&[src.join("proto3_presence.proto")], includes)

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -45,8 +45,14 @@ mod no_unused_results;
 #[cfg(test)]
 #[cfg(feature = "std")]
 mod skip_debug;
-#[cfg(test)]
-mod well_known_types;
+
+mod test_enum_named_value {
+    include!(concat!(env!("OUT_DIR"), "/myenum.result.rs"));
+}
+
+mod test_result_named_value {
+    include!(concat!(env!("OUT_DIR"), "/mystruct.result.rs"));
+}
 
 pub mod foo {
     pub mod bar_baz {

--- a/tests/src/mod.rs
+++ b/tests/src/mod.rs
@@ -1,0 +1,3 @@
+
+include!(concat!(env!("OUT_DIR"), "/myenum.result.rs"));
+include!(concat!(env!("OUT_DIR"), "/mymessage.result.rs"));

--- a/tests/src/result_enum.proto
+++ b/tests/src/result_enum.proto
@@ -1,0 +1,11 @@
+syntax = "proto3";
+package myenum.result;
+
+
+enum Result {
+  HELLO = 0;
+}
+
+message FailMessage {
+  Result result = 1;
+}

--- a/tests/src/result_struct.proto
+++ b/tests/src/result_struct.proto
@@ -1,0 +1,8 @@
+syntax = "proto3";
+package mystruct.result;
+
+
+message Result {
+  string msg = 1;
+}
+


### PR DESCRIPTION
this pull request contains 3 commits: 

1.  [add cmake and ninja in the flake](https://github.com/tokio-rs/prost/commit/7b15ffd0d1774f78244e3a35068f657f09723331): Was needed to run cargo test from the test directory
2. [unit-test added to replicate issue](https://github.com/tokio-rs/prost/commit/30c800d03f75e376293a49e1271760d8985ff418): Replicates the error described in issue #905 in a unit-test
3. [fix: Use full path of Result type](https://github.com/tokio-rs/prost/commit/16e7e35865a16cfa8dc877c1986d0bffda0944eb): Fixes issue #905