### PR TITLE
chore: Add dep: prefix to feature dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ bench = false
 
 [features]
 default = ["prost-derive", "std"]
+prost-derive = ["dep:prost-derive"]
 no-recursion-limit = []
 std = []
 

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -16,9 +16,8 @@ rust-version = "1.70"
 
 [features]
 default = ["format"]
-format = ["prettyplease", "syn"]
-# When MSRV moves to 1.60, these can change to dep:
-cleanup-markdown = ["pulldown-cmark", "pulldown-cmark-to-cmark"]
+format = ["dep:prettyplease", "dep:syn"]
+cleanup-markdown = ["dep:pulldown-cmark", "dep:pulldown-cmark-to-cmark"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }


### PR DESCRIPTION
Adds `dep:` prefix to feature dependencies.