### PR TITLE
fix: generate `Name::full_name` properly

### DIFF
--- a/src/name.rs
+++ b/src/name.rs
@@ -16,7 +16,7 @@ pub trait Name: Message {
     /// Full name of this message type containing both the package name and
     /// type name, e.g. `google.protobuf.TypeName`.
     fn full_name() -> String {
-        format!("{}.{}", Self::NAME, Self::PACKAGE)
+        format!("{}.{}", Self::PACKAGE, Self::NAME)
     }
 
     /// Type URL for this message, which by default is the full name with a


### PR DESCRIPTION
`full_name()` seems to generate the full name in the wrong order (given the examples in the doc comments, `TypeName.google.protobuf` instead of `google.protobuf.TypeName`).