### PR TITLE
fix: Improve protoc not found error message

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1516,24 +1516,21 @@ pub fn protoc_from_env() -> PathBuf {
 }
 
 pub fn error_message_protoc_not_found() -> String {
-    let os_specific_hint = if cfg!(target_os = "macos") {
-        "You could try running `brew install protobuf` or downloading it from https://github.com/protocolbuffers/protobuf/releases"
-    } else if cfg!(target_os = "linux") {
-        "If you're on debian, try `apt-get install protobuf-compiler` or download it from https://github.com/protocolbuffers/protobuf/releases"
-    } else {
-        "You can download it from https://github.com/protocolbuffers/protobuf/releases or from your package manager."
-    };
-    let error_msg =
-        "Could not find `protoc` installation and this build crate cannot proceed without
-    this knowledge. If `protoc` is installed and this crate had trouble finding
-    it, you can set the `PROTOC` environment variable with the specific path to your
-    installed `protoc` binary.";
-    format!(
-        "{}{}
+    let error_msg = "Could not find `protoc`. If `protoc` is installed, try setting the `PROTOC` environment variable to the path of the `protoc` binary.";
 
-For more information: https://docs.rs/prost-build/#sourcing-protoc
-",
-        error_msg, os_specific_hint
+    let os_specific_hint = if cfg!(target_os = "macos") {
+        "To install it on macOS, run `brew install protobuf`."
+    } else if cfg!(target_os = "linux") {
+        "To install it on Debian, run `apt-get install protobuf-compiler`."
+    } else {
+        "Try installing `protobuf-compiler` or `protobuf` using your package manager."
+    };
+    let download_msg =
+        "It is also available at https://github.com/protocolbuffers/protobuf/releases";
+
+    format!(
+        "{} {} {}  For more information: https://docs.rs/prost-build/#sourcing-protoc",
+        error_msg, os_specific_hint, download_msg
     )
 }
 


### PR DESCRIPTION
- fixes missing whitespace between the error message and the OS-specific hint
- more succinct wording in error message
- capitalization ("debian" -> "Debian")
- consistent grammar tenses, slightly more formal and direct tone
- `os_specific_hint` now has hard breaks at 80 chars (just like `error_msg`)

Before:
```
 --- stderr
  thread 'main' panicked at /home/allan/.cargo/registry/src/index.crates.io-6f17d22bba15001f/prost-build-0.12.1/src/lib.rs:1475:10:
  Could not find `protoc` installation and this build crate cannot proceed without
      this knowledge. If `protoc` is installed and this crate had trouble finding
      it, you can set the `PROTOC` environment variable with the specific path to your
      installed `protoc` binary.If you're on debian, try `apt-get install protobuf-compiler` or download it from https://github.com/protocolbuffers/protobuf/releases

  For more information: https://docs.rs/prost-build/#sourcing-protoc
  ```

Proposed:
```
 --- stderr
  thread 'main' panicked at tests/single-include/build.rs:7:10:
  called `Result::unwrap()` on an `Err` value: Custom { kind: NotFound, error: "Could not find `protoc`. If `protoc` is installed, try setting the `PROTOC` environment variable to the path of the `protoc` binary. To install it on Debian, run `apt-get install protobuf-compiler`. It is also available at https://github.com/protocolbuffers/protobuf/releases  For more information: https://docs.rs/prost-build/#sourcing-protoc" }
```

One difference is that the previous message has a hanging indent, but this PR removes it. I would be happy to add it back.