### PR TITLE
improve encode_varint performance by bounding its loop

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -27,7 +27,8 @@ pub fn encode_varint<B>(mut value: u64, buf: &mut B)
 where
     B: BufMut,
 {
-    loop {
+    // Varints are never more than 10 bytes
+    for _ in 0..10 {
         if value < 0x80 {
             buf.put_u8(value as u8);
             break;


### PR DESCRIPTION
I believe this is probably allowing the compiler to unroll the loop where it could not before by giving it a more easily provable bound. This has significant performance improvement for me in benchmarks (on two different processors: a 7-series AMD and an old intel mobile processor; break-even on 3-series threadripper); if we have a process for validating these on more machines we should go through it and get more info.