### PR TITLE
Allow itertools 0.12

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -22,7 +22,7 @@ cleanup-markdown = ["dep:pulldown-cmark", "dep:pulldown-cmark-to-cmark"]
 [dependencies]
 bytes = { version = "1", default-features = false }
 heck = "0.4"
-itertools = { version = ">=0.10, <0.12", default-features = false, features = ["use_alloc"] }
+itertools = { version = ">=0.10, <=0.12", default-features = false, features = ["use_alloc"] }
 log = "0.4.4"
 multimap = { version = "0.8", default-features = false }
 petgraph = { version = "0.6", default-features = false }

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -19,7 +19,7 @@ proc_macro = true
 
 [dependencies]
 anyhow = "1.0.1"
-itertools = { version = ">=0.10, <0.12", default-features = false, features = ["use_alloc"] }
+itertools = { version = ">=0.10, <=0.12", default-features = false, features = ["use_alloc"] }
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = [ "extra-traits" ] }


### PR DESCRIPTION
0.12 didn't change the syntax of any APIs in-use.

Additionally, the tests do pass with 0.12.