### PR TITLE
build: Add development container config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+	"name": "Rust",
+	"image": "mcr.microsoft.com/devcontainers/rust:1-1-bullseye",
+	"features": {
+		"ghcr.io/devcontainers-contrib/features/apt-packages:1": {
+			"packages": "cmake,ninja-build,protobuf-compiler,libprotoc-dev"
+		}
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"zxh404.vscode-proto3"
+			]
+		}
+	}
+}


### PR DESCRIPTION
Add configuration to dev container [1] to ease development for new contributors. Github Codespaces will automatically load the correct environment to start development. VSCode will suggest to re-open the project in a dev container.

[1]: https://containers.dev/