### PR TITLE
feat: derive Copy trait for messages where possible

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -190,7 +190,12 @@ impl<'a> CodeGenerator<'a> {
         self.buf
             .push_str("#[allow(clippy::derive_partial_eq_without_eq)]\n");
         self.buf.push_str(&format!(
-            "#[derive(Clone, PartialEq, {}::Message)]\n",
+            "#[derive(Clone, {}PartialEq, {}::Message)]\n",
+            if self.message_graph.can_message_derive_copy(&fq_message_name) {
+                "Copy, "
+            } else {
+                ""
+            },
             prost_path(self.config)
         ));
         self.append_skip_debug(&fq_message_name);
@@ -595,8 +600,14 @@ impl<'a> CodeGenerator<'a> {
         self.push_indent();
         self.buf
             .push_str("#[allow(clippy::derive_partial_eq_without_eq)]\n");
+
+        let can_oneof_derive_copy = fields.iter().map(|(field, _idx)| field).all(|field| {
+            self.message_graph
+                .can_field_derive_copy(fq_message_name, field)
+        });
         self.buf.push_str(&format!(
-            "#[derive(Clone, PartialEq, {}::Oneof)]\n",
+            "#[derive(Clone, {}PartialEq, {}::Oneof)]\n",
+            if can_oneof_derive_copy { "Copy, " } else { "" },
             prost_path(self.config)
         ));
         self.append_skip_debug(fq_message_name);

--- a/prost-build/src/fixtures/field_attributes/_expected_field_attributes.rs
+++ b/prost-build/src/fixtures/field_attributes/_expected_field_attributes.rs
@@ -23,12 +23,12 @@ pub struct Foo {
     pub foo: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Bar {
     #[prost(message, optional, boxed, tag="1")]
     pub qux: ::core::option::Option<::prost::alloc::boxed::Box<Qux>>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Qux {
 }

--- a/prost-build/src/fixtures/field_attributes/_expected_field_attributes_formatted.rs
+++ b/prost-build/src/fixtures/field_attributes/_expected_field_attributes_formatted.rs
@@ -23,11 +23,11 @@ pub struct Foo {
     pub foo: ::prost::alloc::string::String,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Bar {
     #[prost(message, optional, boxed, tag = "1")]
     pub qux: ::core::option::Option<::prost::alloc::boxed::Box<Qux>>,
 }
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Qux {}

--- a/prost-types/src/datetime.rs
+++ b/prost-types/src/datetime.rs
@@ -614,7 +614,7 @@ mod tests {
             };
             assert_eq!(
                 expected,
-                format!("{}", DateTime::from(timestamp.clone())),
+                format!("{}", DateTime::from(timestamp)),
                 "timestamp: {:?}",
                 timestamp
             );

--- a/prost-types/src/duration.rs
+++ b/prost-types/src/duration.rs
@@ -105,7 +105,7 @@ impl TryFrom<Duration> for time::Duration {
 
 impl fmt::Display for Duration {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut d = self.clone();
+        let mut d = *self;
         d.normalize();
         if self.seconds < 0 && self.nanos < 0 {
             write!(f, "-")?;
@@ -193,7 +193,7 @@ mod tests {
                 Ok(duration) => duration,
                 Err(_) => return Err(TestCaseError::reject("duration out of range")),
             };
-            prop_assert_eq!(time::Duration::try_from(prost_duration.clone()).unwrap(), std_duration);
+            prop_assert_eq!(time::Duration::try_from(prost_duration).unwrap(), std_duration);
 
             if std_duration != time::Duration::default() {
                 let neg_prost_duration = Duration {
@@ -220,7 +220,7 @@ mod tests {
                 Ok(duration) => duration,
                 Err(_) => return Err(TestCaseError::reject("duration out of range")),
             };
-            prop_assert_eq!(time::Duration::try_from(prost_duration.clone()).unwrap(), std_duration);
+            prop_assert_eq!(time::Duration::try_from(prost_duration).unwrap(), std_duration);
 
             if std_duration != time::Duration::default() {
                 let neg_prost_duration = Duration {

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -94,7 +94,7 @@ pub mod descriptor_proto {
     /// fields or extension ranges in the same message. Reserved ranges may
     /// not overlap.
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Message)]
+    #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct ReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag = "1")]
@@ -360,7 +360,7 @@ pub mod enum_descriptor_proto {
     /// is inclusive such that it can appropriately represent the entire int32
     /// domain.
     #[allow(clippy::derive_partial_eq_without_eq)]
-    #[derive(Clone, PartialEq, ::prost::Message)]
+    #[derive(Clone, Copy, PartialEq, ::prost::Message)]
     pub struct EnumReservedRange {
         /// Inclusive.
         #[prost(int32, optional, tag = "1")]
@@ -1853,7 +1853,7 @@ pub struct Mixin {
 /// be expressed in JSON format as "3.000000001s", and 3 seconds and 1
 /// microsecond should be expressed in JSON format as "3.000001s".
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Duration {
     /// Signed seconds of the span of time. Must be from -315,576,000,000
     /// to +315,576,000,000 inclusive. Note: these bounds are computed from:
@@ -2293,7 +2293,7 @@ impl NullValue {
 /// the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
 /// the Joda Time's [`ISODateTimeFormat.dateTime()`](<http://www.joda.org/joda-time/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime%2D%2D>) to obtain a formatter capable of generating timestamps in this format.
 #[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, ::prost::Message)]
 pub struct Timestamp {
     /// Represents seconds of UTC time since Unix epoch
     /// 1970-01-01T00:00:00Z. Must be from 0001-01-01T00:00:00Z to

--- a/prost-types/src/timestamp.rs
+++ b/prost-types/src/timestamp.rs
@@ -50,7 +50,7 @@ impl Timestamp {
     ///
     /// [1]: https://github.com/google/protobuf/blob/v3.3.2/src/google/protobuf/util/time_util.cc#L59-L77
     pub fn try_normalize(mut self) -> Result<Timestamp, Timestamp> {
-        let before = self.clone();
+        let before = self;
         self.normalize();
         // If the seconds value has changed, and is either i64::MIN or i64::MAX, then the timestamp
         // normalization overflowed.
@@ -201,7 +201,7 @@ impl TryFrom<Timestamp> for std::time::SystemTime {
     type Error = TimestampError;
 
     fn try_from(mut timestamp: Timestamp) -> Result<std::time::SystemTime, Self::Error> {
-        let orig_timestamp = timestamp.clone();
+        let orig_timestamp = timestamp;
         timestamp.normalize();
 
         let system_time = if timestamp.seconds >= 0 {
@@ -211,8 +211,7 @@ impl TryFrom<Timestamp> for std::time::SystemTime {
                 timestamp
                     .seconds
                     .checked_neg()
-                    .ok_or_else(|| TimestampError::OutOfSystemRange(timestamp.clone()))?
-                    as u64,
+                    .ok_or(TimestampError::OutOfSystemRange(timestamp))? as u64,
             ))
         };
 
@@ -234,7 +233,7 @@ impl FromStr for Timestamp {
 
 impl fmt::Display for Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        datetime::DateTime::from(self.clone()).fmt(f)
+        datetime::DateTime::from(*self).fmt(f)
     }
 }
 #[cfg(test)]
@@ -262,7 +261,7 @@ mod tests {
         ) {
             let mut timestamp = Timestamp { seconds, nanos };
             timestamp.normalize();
-            if let Ok(system_time) = SystemTime::try_from(timestamp.clone()) {
+            if let Ok(system_time) = SystemTime::try_from(timestamp) {
                 prop_assert_eq!(Timestamp::from(system_time), timestamp);
             }
         }

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -92,6 +92,10 @@ fn main() {
         .unwrap();
 
     config
+        .compile_protos(&[src.join("derive_copy.proto")], includes)
+        .unwrap();
+
+    config
         .compile_protos(&[src.join("default_string_escape.proto")], includes)
         .unwrap();
 

--- a/tests/src/derive_copy.proto
+++ b/tests/src/derive_copy.proto
@@ -1,0 +1,51 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+
+package derive_copy;
+
+message EmptyMsg {}
+
+message IntegerMsg {
+  int32 field1 = 1;
+  int64 field2 = 2;
+  uint32 field3 = 3;
+  uint64 field4 = 4;
+  sint32 field5 = 5;
+  sint64 field6 = 6;
+  fixed32 field7 = 7;
+  fixed64 field8 = 8;
+  sfixed32 field9 = 9;
+  sfixed64 field10 = 10;
+}
+
+message FloatMsg {
+  double field1 = 1;
+  float field2 = 2;
+}
+
+message BoolMsg { bool field1 = 1; }
+
+enum AnEnum {
+  A = 0;
+  B = 1;
+};
+
+message EnumMsg { AnEnum field1 = 1; }
+
+message OneOfMsg {
+  oneof data {
+    int32 field1 = 1;
+    int64 field2 = 2;
+  }
+}
+
+message ComposedMsg {
+  IntegerMsg field1 = 1;
+  EnumMsg field2 = 2;
+  OneOfMsg field3 = 3;
+}
+
+message WellKnownMsg {
+  google.protobuf.Timestamp timestamp = 1;
+}

--- a/tests/src/derive_copy.rs
+++ b/tests/src/derive_copy.rs
@@ -1,0 +1,21 @@
+include!(concat!(env!("OUT_DIR"), "/derive_copy.rs"));
+
+trait TestCopyIsImplemented: Copy {}
+
+impl TestCopyIsImplemented for EmptyMsg {}
+
+impl TestCopyIsImplemented for IntegerMsg {}
+
+impl TestCopyIsImplemented for FloatMsg {}
+
+impl TestCopyIsImplemented for BoolMsg {}
+
+impl TestCopyIsImplemented for AnEnum {}
+
+impl TestCopyIsImplemented for EnumMsg {}
+
+impl TestCopyIsImplemented for OneOfMsg {}
+
+impl TestCopyIsImplemented for ComposedMsg {}
+
+impl TestCopyIsImplemented for WellKnownMsg {}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -37,6 +37,8 @@ mod debug;
 #[cfg(test)]
 mod deprecated_field;
 #[cfg(test)]
+mod derive_copy;
+#[cfg(test)]
 mod enum_keyword_variant;
 #[cfg(test)]
 mod generic_derive;


### PR DESCRIPTION
Rust primitive types can be copied by simply copying the bits. Rust structs can also have this property by deriving the Copy trait.

Automatically derive Copy for:
- messages that only have fields with primitive types
- the Rust enum for one-of fields
- messages whose field type are messages that also implement Copy

Generated code for Protobuf enums already derives Copy.

