### PR TITLE
build(deps): Depend on multimap 0.8 or 0.9

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -25,7 +25,7 @@ bytes = { version = "1", default-features = false }
 heck = "0.4"
 itertools = { version = "0.10", default-features = false, features = ["use_alloc"] }
 log = "0.4"
-multimap = { version = "0.8", default-features = false }
+multimap = { version = ">=0.8, <0.10", default-features = false }
 petgraph = { version = "0.6", default-features = false }
 prost = { version = "0.11.8", path = "..", default-features = false }
 prost-types = { version = "0.11.8", path = "../prost-types", default-features = false }


### PR DESCRIPTION
Depend on `multimap` version 0.8 or 0.9.
