### PR TITLE
nit: update broken prost-build documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ prost-types = "0.12"
 ```
 
 The recommended way to add `.proto` compilation to a Cargo project is to use the
-`prost-build` library. See the [`prost-build` documentation](prost-build) for
+`prost-build` library. See the [`prost-build` documentation](https://docs.rs/prost-build/latest/prost_build/) for
 more details and examples.
 
 See the [snazzy repository](https://github.com/danburkert/snazzy) for a simple


### PR DESCRIPTION
Reference Issue: #960 

This is a PR to update the Prost-build link at that top of the read me to go to the doc.rs page. On the docs.rs for prost, the the link in question is broken as its using markdown link relative to the repo. This works on GitHub and cargo.io but breaks on doc.rs which is where we probably want it to be the most reliable.

Thanks.