### PR TITLE
Remove which dependency

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -32,7 +32,6 @@ prost-types = { version = "0.12.3", path = "../prost-types", default-features = 
 tempfile = "3"
 once_cell = "1.17.1"
 regex = { version = "1.8.1", default-features = false, features = ["std", "unicode-bool"] }
-which = "4"
 
 prettyplease = { version = "0.2", optional = true }
 syn = { version = "2", features = ["full"], optional = true }


### PR DESCRIPTION
Rather than trying to predict if the OS will be able to find the binary before executing it we can just execute the binary and let the OS tell us if it found it or not.
This is IMO more correct and lets us remove a dependency that required a rust version far above the projects MSRV.