### PR TITLE
build(deps): update to itertools 0.12

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -32,7 +32,8 @@ prost-types = { version = "0.12.3", path = "../prost-types", default-features = 
 tempfile = "3"
 once_cell = "1.17.1"
 regex = { version = "1.8.1", default-features = false, features = ["std", "unicode-bool"] }
-which = "4"
+# pin to avoid having to bump msrv to 1.63
+which = "=4.4.1"
 
 prettyplease = { version = "0.2", optional = true }
 syn = { version = "2", features = ["full"], optional = true }

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -23,7 +23,7 @@ cleanup-markdown = ["pulldown-cmark", "pulldown-cmark-to-cmark"]
 [dependencies]
 bytes = { version = "1", default-features = false }
 heck = "0.4"
-itertools = { version = ">=0.10, <0.12", default-features = false, features = ["use_alloc"] }
+itertools = { version = ">=0.10, <=0.12", default-features = false, features = ["use_alloc"] }
 log = "0.4"
 multimap = { version = "0.8", default-features = false }
 petgraph = { version = "0.6", default-features = false }

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -19,7 +19,7 @@ proc_macro = true
 
 [dependencies]
 anyhow = "1.0.1"
-itertools = { version = ">=0.10, <0.12", default-features = false, features = ["use_alloc"] }
+itertools = { version = ">=0.10, <=0.12", default-features = false, features = ["use_alloc"] }
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = [ "extra-traits" ] }


### PR DESCRIPTION
First, thanks for all your work on this crate!

I'm trying to dedup some deps in my project and currently prost is the only dep I have that is still on `itertools 0.11`.
I saw in #875 a mention of the MSRV needing to be bumped, but it seems this new update doesn't affect that.