### PR TITLE
feat: Make allocations fallible

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -2,6 +2,7 @@
 
 use alloc::borrow::Cow;
 use alloc::boxed::Box;
+use alloc::collections::TryReserveError;
 use alloc::vec::Vec;
 
 use core::fmt;
@@ -66,6 +67,12 @@ impl fmt::Display for DecodeError {
             write!(f, "{}.{}: ", message, field)?;
         }
         f.write_str(&self.inner.description)
+    }
+}
+
+impl From<TryReserveError> for DecodeError {
+    fn from(error: TryReserveError) -> Self {
+        DecodeError::new(error.to_string())
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -343,7 +343,7 @@ impl Message for Vec<u8> {
         B: Buf,
     {
         if tag == 1 {
-            bytes::merge(wire_type, self, buf, ctx)
+            bytes::merge_one_copy(wire_type, self, buf, ctx)
         } else {
             skip_field(wire_type, tag, buf, ctx)
         }


### PR DESCRIPTION
This PR makes any allocations that occur in the decode path fallible, without any public API changes.

The changes are specifically scoped to repeated fields, `Vec<u8>`, and `String`.
* Repeated fields, before pushing onto the `Vec<...>` of values, we now call `Vec::try_reserve(1)` and map the possible `TryReserveError` to a `DecodeError`. Reserving for a single element is what [Vec already does](https://github.com/rust-lang/rust/blob/master/library/alloc/src/raw_vec.rs#L318) so there shouldn't be a performance impact, and `DecodeError` is already opaque so this doesn't change the public API surface.
* `Vec<u8>` and `String`, these types reserve space as part of the `sealed::BytesAdapter::repliace_with` trait. This trait method was updated to return a `Result<(), TryReserveError>` and now will fail if we can't reserve enough space. Given this is a sealed trait there are no public API changes.

In addition to making allocations fallible, I also changed the merge impl of `Vec<u8>` to use `bytes::merge_one_copy` like `String` does, this should result in strictly less allocations.

## Why make this change?

Previously users had no way to guard against OOMs in decoding. You could try to make a guess based on the size of the encoded message, but this fairly inaccurate because it would be very difficult (impossible?) to account for things like the ammortized growth of a Vec. Even if you did guess based on the size of the encoded message, there is no way you could account for multiple messages being decoded in parallel in individual tasks, e.g. handling multiple network requests in parallel.

## What about the encoding path?

A similar change is not needed for the encoding path because you can already guard against OOMs by using the `encoded_len()` to allocate a buffer yourself guarding against OOMs, and then encode into this newly allocated buffer.