### PR TITLE
chore: Bump msrv to 1.70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - "1.65"
+          - "1.70"
         os:
           - ubuntu-latest
           - macos-latest

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ start-to-finish example.
 
 ### MSRV
 
-`prost` follows the `tokio-rs` project's MSRV model and supports 1.60. For more
+`prost` follows the `tokio-rs` project's MSRV model and supports 1.70. For more
 information on the tokio msrv policy you can check it out [here][tokio msrv]
 
 [tokio msrv]: https://github.com/tokio-rs/tokio/#supported-rust-versions

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/prost-build"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.70"
 
 [features]
 default = ["format"]


### PR DESCRIPTION
`home` 0.5.9 requires Rust 1.70.