### PR TITLE
chore: Bump MSRV to 1.70

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - "1.65"
+          - "1.70"
         os:
           - ubuntu-latest
           - macos-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "A Protocol Buffers implementation for the Rust Language."
 keywords = ["protobuf", "serialization"]
 categories = ["encoding"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.70"
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ start-to-finish example.
 
 ### MSRV
 
-`prost` follows the `tokio-rs` project's MSRV model and supports 1.60. For more
+`prost` follows the `tokio-rs` project's MSRV model and supports 1.70. For more
 information on the tokio msrv policy you can check it out [here][tokio msrv]
 
 [tokio msrv]: https://github.com/tokio-rs/tokio/#supported-rust-versions

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/prost-build"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.70"
 
 [features]
 default = ["format"]

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/prost-derive"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.70"
 
 [lib]
 proc_macro = true

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/prost-types"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.70"
 
 [lib]
 doctest = false


### PR DESCRIPTION
Rust 1.70 is 7 month old at this time. A transient dependency `home` requires at least rust 1.70.

```
prost-build v0.12.3 (/workspaces/prost/prost-build) 
└── which v4.4.2
    └── home v0.5.9
```