### PR TITLE
chore: Relax MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - "1.70"
+          - "1.70"              # max version of msrv
         os:
           - ubuntu-latest
           - macos-latest
@@ -67,6 +67,21 @@ jobs:
         run: cargo test --workspace --doc
       - name: test doc no-default-features
         run: cargo test -p prost-build -p prost-derive -p prost-types --doc --no-default-features
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: install protoc
+        uses: taiki-e/install-action@v2
+        with:
+          tool: protoc@${{ env.PROTOC_VERSION }}
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: Swatinem/rust-cache@v2
+      - name: check with no-default-features
+        run: cargo hack --rust-version --no-private --no-dev-deps check --workspace --no-default-features
+      - name: check with all-features
+        run: cargo hack --rust-version --no-private --no-dev-deps check --workspace --all-features
 
   minimal-versions:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "A Protocol Buffers implementation for the Rust Language."
 keywords = ["protobuf", "serialization"]
 categories = ["encoding"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.60"
 
 [workspace]
 members = [

--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ See the [snazzy repository][snazzy] for a simple start-to-finish example.
 
 ### MSRV
 
-`prost` follows the `tokio-rs` project's MSRV model and supports 1.70. For more
-information on the tokio msrv policy you can check it out [here][tokio msrv]
+`prost` follows the `tokio-rs` project's MSRV model and supports 1.70. Some
+crates' MSRV might be lower than this version, see each `rust-version` field of
+the manifest file. For more information on the tokio msrv policy you can check
+it out [here][tokio msrv]
 
 [tokio msrv]: https://github.com/tokio-rs/tokio/#supported-rust-versions
 

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/prost-derive"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.60"
 
 [lib]
 proc_macro = true

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/prost-types"
 readme = "README.md"
 description = "A Protocol Buffers implementation for the Rust Language."
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.60"
 
 [lib]
 doctest = false


### PR DESCRIPTION
Relaxes MSRV which are bumped in #982. As the use of `prost-build` can be separated to the different build process, it is too strict to set the same MSRV of `prost-build` to the other crates for users. `cargo-hack`'s `--rust-version` option can be used to perform checking different MSRVs on the project crates.