### PR TITLE
prost-build: refactor code generator (ground work for builders)

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -952,8 +952,6 @@ impl<'a> CodeGenerator<'a> {
     }
 
     fn resolve_type(&self, field: &FieldDescriptorProto, fq_message_name: &str) -> String {
-        let prost_path = prost_path(self.config);
-
         match field.r#type() {
             Type::Float => String::from("f32"),
             Type::Double => String::from("f64"),
@@ -962,7 +960,7 @@ impl<'a> CodeGenerator<'a> {
             Type::Int32 | Type::Sfixed32 | Type::Sint32 | Type::Enum => String::from("i32"),
             Type::Int64 | Type::Sfixed64 | Type::Sint64 => String::from("i64"),
             Type::Bool => String::from("bool"),
-            Type::String => format!("{}::alloc::string::String", prost_path),
+            Type::String => format!("{}::alloc::string::String", prost_path(self.config)),
             Type::Bytes => self
                 .config
                 .bytes_type

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -44,6 +44,49 @@ fn push_indent(buf: &mut String, depth: u8) {
         buf.push_str("    ");
     }
 }
+
+fn prost_path(config: &Config) -> &str {
+    config.prost_path.as_deref().unwrap_or("::prost")
+}
+
+struct Field {
+    name: String,
+    proto: FieldDescriptorProto,
+    path_index: i32,
+}
+
+impl Field {
+    fn new(proto: FieldDescriptorProto, path_index: i32) -> Self {
+        Self {
+            name: to_snake(proto.name()),
+            proto,
+            path_index,
+        }
+    }
+}
+
+struct OneofField {
+    name: String,
+    proto: OneofDescriptorProto,
+    fields: Vec<(FieldDescriptorProto, i32)>,
+    path_index: i32,
+}
+
+impl OneofField {
+    fn new(
+        proto: OneofDescriptorProto,
+        fields: Vec<(FieldDescriptorProto, i32)>,
+        path_index: i32,
+    ) -> Self {
+        Self {
+            name: to_snake(proto.name()),
+            proto,
+            fields,
+            path_index,
+        }
+    }
+}
+
 impl<'a> CodeGenerator<'a> {
     pub fn generate(
         config: &mut Config,
@@ -159,21 +202,33 @@ impl<'a> CodeGenerator<'a> {
 
         // Split the fields into a vector of the normal fields, and oneof fields.
         // Path indexes are preserved so that comments can be retrieved.
-        type Fields = Vec<(FieldDescriptorProto, usize)>;
-        type OneofFields = MultiMap<i32, (FieldDescriptorProto, usize)>;
-        let (fields, mut oneof_fields): (Fields, OneofFields) = message
+        type OneofFieldsByIndex = MultiMap<i32, (FieldDescriptorProto, i32)>;
+        let (fields, mut oneof_map): (Vec<Field>, OneofFieldsByIndex) = message
             .field
             .into_iter()
             .enumerate()
-            .partition_map(|(idx, field)| {
-                if field.proto3_optional.unwrap_or(false) {
-                    Either::Left((field, idx))
-                } else if let Some(oneof_index) = field.oneof_index {
-                    Either::Right((oneof_index, (field, idx)))
+            .partition_map(|(idx, proto)| {
+                let idx = idx as i32;
+                if proto.proto3_optional.unwrap_or(false) {
+                    Either::Left(Field::new(proto, idx))
+                } else if let Some(oneof_index) = proto.oneof_index {
+                    Either::Right((oneof_index, (proto, idx)))
                 } else {
-                    Either::Left((field, idx))
+                    Either::Left(Field::new(proto, idx))
                 }
             });
+        // Optional fields create a synthetic oneof that we want to skip
+        let oneof_fields: Vec<OneofField> = message
+            .oneof_decl
+            .into_iter()
+            .enumerate()
+            .filter_map(move |(idx, proto)| {
+                let idx = idx as i32;
+                oneof_map
+                    .remove(&idx)
+                    .map(|fields| OneofField::new(proto, fields, idx))
+            })
+            .collect();
 
         self.append_doc(&fq_message_name, None);
         self.append_type_attributes(&fq_message_name);
@@ -183,7 +238,7 @@ impl<'a> CodeGenerator<'a> {
             .push_str("#[allow(clippy::derive_partial_eq_without_eq)]\n");
         self.buf.push_str(&format!(
             "#[derive(Clone, PartialEq, {}::Message)]\n",
-            self.config.prost_path.as_deref().unwrap_or("::prost")
+            prost_path(self.config)
         ));
         self.append_skip_debug(&fq_message_name);
         self.push_indent();
@@ -193,16 +248,15 @@ impl<'a> CodeGenerator<'a> {
 
         self.depth += 1;
         self.path.push(2);
-        for (field, idx) in fields {
-            self.path.push(idx as i32);
+        for field in &fields {
+            self.path.push(field.path_index);
             match field
+                .proto
                 .type_name
                 .as_ref()
                 .and_then(|type_name| map_types.get(type_name))
             {
-                Some(&(ref key, ref value)) => {
-                    self.append_map_field(&fq_message_name, field, key, value)
-                }
+                Some((key, value)) => self.append_map_field(&fq_message_name, field, key, value),
                 None => self.append_field(&fq_message_name, field),
             }
             self.path.pop();
@@ -210,16 +264,9 @@ impl<'a> CodeGenerator<'a> {
         self.path.pop();
 
         self.path.push(8);
-        for (idx, oneof) in message.oneof_decl.iter().enumerate() {
-            let idx = idx as i32;
-
-            let fields = match oneof_fields.get_vec(&idx) {
-                Some(fields) => fields,
-                None => continue,
-            };
-
-            self.path.push(idx);
-            self.append_oneof_field(&message_name, &fq_message_name, oneof, fields);
+        for oneof in &oneof_fields {
+            self.path.push(oneof.path_index);
+            self.append_oneof_field(&message_name, &fq_message_name, oneof);
             self.path.pop();
         }
         self.path.pop();
@@ -246,14 +293,8 @@ impl<'a> CodeGenerator<'a> {
             }
             self.path.pop();
 
-            for (idx, oneof) in message.oneof_decl.into_iter().enumerate() {
-                let idx = idx as i32;
-                // optional fields create a synthetic oneof that we want to skip
-                let fields = match oneof_fields.remove(&idx) {
-                    Some(fields) => fields,
-                    None => continue,
-                };
-                self.append_oneof(&fq_message_name, oneof, idx, fields);
+            for oneof in &oneof_fields {
+                self.append_oneof(&fq_message_name, oneof);
             }
 
             self.pop_mod();
@@ -362,23 +403,15 @@ impl<'a> CodeGenerator<'a> {
         }
     }
 
-    fn append_field(&mut self, fq_message_name: &str, field: FieldDescriptorProto) {
+    fn append_field(&mut self, fq_message_name: &str, field: &Field) {
+        let rust_name = &field.name;
+        let field = &field.proto;
         let type_ = field.r#type();
         let repeated = field.label == Some(Label::Repeated as i32);
-        let deprecated = self.deprecated(&field);
-        let optional = self.optional(&field);
-        let ty = self.resolve_type(&field, fq_message_name);
-
-        let boxed = !repeated
-            && ((type_ == Type::Message || type_ == Type::Group)
-                && self
-                    .message_graph
-                    .is_nested(field.type_name(), fq_message_name))
-            || (self
-                .config
-                .boxed
-                .get_first_field(&fq_message_name, field.name())
-                .is_some());
+        let deprecated = self.deprecated(field);
+        let optional = self.optional(field);
+        let boxed = self.boxed(field, fq_message_name);
+        let ty = self.resolve_type(field, fq_message_name);
 
         debug!(
             "    field: {:?}, type: {:?}, boxed: {}",
@@ -396,7 +429,7 @@ impl<'a> CodeGenerator<'a> {
 
         self.push_indent();
         self.buf.push_str("#[prost(");
-        let type_tag = self.field_type_tag(&field);
+        let type_tag = self.field_type_tag(field);
         self.buf.push_str(&type_tag);
 
         if type_ == Type::Bytes {
@@ -419,7 +452,7 @@ impl<'a> CodeGenerator<'a> {
             Label::Required => self.buf.push_str(", required"),
             Label::Repeated => {
                 self.buf.push_str(", repeated");
-                if can_pack(&field)
+                if can_pack(field)
                     && !field
                         .options
                         .as_ref()
@@ -470,10 +503,10 @@ impl<'a> CodeGenerator<'a> {
         self.append_field_attributes(fq_message_name, field.name());
         self.push_indent();
         self.buf.push_str("pub ");
-        self.buf.push_str(&to_snake(field.name()));
+        self.buf.push_str(rust_name);
         self.buf.push_str(": ");
 
-        let prost_path = self.config.prost_path.as_deref().unwrap_or("::prost");
+        let prost_path = prost_path(self.config);
 
         if repeated {
             self.buf
@@ -498,10 +531,12 @@ impl<'a> CodeGenerator<'a> {
     fn append_map_field(
         &mut self,
         fq_message_name: &str,
-        field: FieldDescriptorProto,
+        field: &Field,
         key: &FieldDescriptorProto,
         value: &FieldDescriptorProto,
     ) {
+        let rust_name = &field.name;
+        let field = &field.proto;
         let key_ty = self.resolve_type(key, fq_message_name);
         let value_ty = self.resolve_type(value, fq_message_name);
 
@@ -535,7 +570,7 @@ impl<'a> CodeGenerator<'a> {
         self.push_indent();
         self.buf.push_str(&format!(
             "pub {}: {}<{}, {}>,\n",
-            to_snake(field.name()),
+            rust_name,
             map_type.rust_type(),
             key_ty,
             value_ty
@@ -546,47 +581,40 @@ impl<'a> CodeGenerator<'a> {
         &mut self,
         message_name: &str,
         fq_message_name: &str,
-        oneof: &OneofDescriptorProto,
-        fields: &[(FieldDescriptorProto, usize)],
+        oneof: &OneofField,
     ) {
-        let name = format!(
+        let type_name = format!(
             "{}::{}",
             to_snake(message_name),
-            to_upper_camel(oneof.name())
+            to_upper_camel(oneof.proto.name())
         );
+        let field_tags = oneof
+            .fields
+            .iter()
+            .map(|(field, _)| field.number())
+            .join(", ");
         self.append_doc(fq_message_name, None);
         self.push_indent();
         self.buf.push_str(&format!(
             "#[prost(oneof=\"{}\", tags=\"{}\")]\n",
-            name,
-            fields
-                .iter()
-                .map(|&(ref field, _)| field.number())
-                .join(", ")
+            type_name, field_tags,
         ));
-        self.append_field_attributes(fq_message_name, oneof.name());
+        self.append_field_attributes(fq_message_name, oneof.proto.name());
         self.push_indent();
         self.buf.push_str(&format!(
             "pub {}: ::core::option::Option<{}>,\n",
-            to_snake(oneof.name()),
-            name
+            oneof.name, type_name
         ));
     }
 
-    fn append_oneof(
-        &mut self,
-        fq_message_name: &str,
-        oneof: OneofDescriptorProto,
-        idx: i32,
-        fields: Vec<(FieldDescriptorProto, usize)>,
-    ) {
+    fn append_oneof(&mut self, fq_message_name: &str, oneof: &OneofField) {
         self.path.push(8);
-        self.path.push(idx);
+        self.path.push(oneof.path_index);
         self.append_doc(fq_message_name, None);
         self.path.pop();
         self.path.pop();
 
-        let oneof_name = format!("{}.{}", fq_message_name, oneof.name());
+        let oneof_name = format!("{}.{}", fq_message_name, oneof.proto.name());
         self.append_type_attributes(&oneof_name);
         self.append_enum_attributes(&oneof_name);
         self.push_indent();
@@ -594,25 +622,25 @@ impl<'a> CodeGenerator<'a> {
             .push_str("#[allow(clippy::derive_partial_eq_without_eq)]\n");
         self.buf.push_str(&format!(
             "#[derive(Clone, PartialEq, {}::Oneof)]\n",
-            self.config.prost_path.as_deref().unwrap_or("::prost")
+            prost_path(self.config)
         ));
         self.append_skip_debug(&fq_message_name);
         self.push_indent();
         self.buf.push_str("pub enum ");
-        self.buf.push_str(&to_upper_camel(oneof.name()));
+        self.buf.push_str(&to_upper_camel(oneof.proto.name()));
         self.buf.push_str(" {\n");
 
         self.path.push(2);
         self.depth += 1;
-        for (field, idx) in fields {
+        for (field, idx) in &oneof.fields {
             let type_ = field.r#type();
 
-            self.path.push(idx as i32);
+            self.path.push(*idx);
             self.append_doc(fq_message_name, Some(field.name()));
             self.path.pop();
 
             self.push_indent();
-            let ty_tag = self.field_type_tag(&field);
+            let ty_tag = self.field_type_tag(field);
             self.buf.push_str(&format!(
                 "#[prost({}, tag=\"{}\")]\n",
                 ty_tag,
@@ -621,7 +649,7 @@ impl<'a> CodeGenerator<'a> {
             self.append_field_attributes(&oneof_name, field.name());
 
             self.push_indent();
-            let ty = self.resolve_type(&field, fq_message_name);
+            let ty = self.resolve_type(field, fq_message_name);
 
             let boxed = ((type_ == Type::Message || type_ == Type::Group)
                 && self
@@ -712,7 +740,7 @@ impl<'a> CodeGenerator<'a> {
         self.buf.push_str(&format!(
             "#[derive(Clone, Copy, {}PartialEq, Eq, Hash, PartialOrd, Ord, {}::Enumeration)]\n",
             dbg,
-            self.config.prost_path.as_deref().unwrap_or("::prost"),
+            prost_path(self.config),
         ));
         self.push_indent();
         self.buf.push_str("#[repr(i32)]\n");
@@ -924,7 +952,7 @@ impl<'a> CodeGenerator<'a> {
     }
 
     fn resolve_type(&self, field: &FieldDescriptorProto, fq_message_name: &str) -> String {
-        let prost_path = self.config.prost_path.as_deref().unwrap_or("::prost");
+        let prost_path = prost_path(self.config);
 
         match field.r#type() {
             Type::Float => String::from("f32"),
@@ -1034,6 +1062,20 @@ impl<'a> CodeGenerator<'a> {
             Type::Message => true,
             _ => self.syntax == Syntax::Proto2,
         }
+    }
+
+    fn boxed(&self, field: &FieldDescriptorProto, fq_message_name: &str) -> bool {
+        let fd_type = field.r#type();
+        field.label != Some(Label::Repeated as i32)
+            && ((fd_type == Type::Message || fd_type == Type::Group)
+                && self
+                    .message_graph
+                    .is_nested(field.type_name(), fq_message_name))
+            || (self
+                .config
+                .boxed
+                .get_first_field(fq_message_name, field.name())
+                .is_some())
     }
 
     /// Returns `true` if the field options includes the `deprecated` option.


### PR DESCRIPTION
Refactoring of existing code taken out of #901:

* Collect message field data into vectors of structs that can be reused in multiple passes. This will be useful for the upcoming generation of builders.
* Add `prost_path` helper function to DRY repetitive expressions constructing the path to the prost crate for generated code.
* Add `boxed` helper method to capture the logic of deciding whether a field is boxed.