### PR TITLE
build(deps): Allow heck 0.5

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -21,7 +21,7 @@ cleanup-markdown = ["dep:pulldown-cmark", "dep:pulldown-cmark-to-cmark"]
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-heck = "0.4"
+heck = { version = ">=0.4, <=0.5" }
 itertools = { version = ">=0.10, <=0.12", default-features = false, features = ["use_alloc"] }
 log = "0.4.4"
 multimap = { version = "0.8", default-features = false }


### PR DESCRIPTION
heck 0.5 didn't change the syntax of any APIs in-use.