### PR TITLE
build(deps): Allow multimap 0.10

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -24,7 +24,7 @@ bytes = { version = "1", default-features = false }
 heck = "0.4"
 itertools = { version = ">=0.10, <=0.12", default-features = false, features = ["use_alloc"] }
 log = "0.4.4"
-multimap = { version = "0.8", default-features = false }
+multimap = { version = ">=0.8, <=0.10", default-features = false }
 petgraph = { version = "0.6", default-features = false }
 prost = { version = "0.12.3", path = "..", default-features = false }
 prost-types = { version = "0.12.3", path = "../prost-types", default-features = false }


### PR DESCRIPTION
multimap 0.10 didn't change the syntax of any APIs in-use.