### PR TITLE
style(prost-build): Consolidate field data into struct

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -601,16 +601,16 @@ impl<'a> CodeGenerator<'a> {
             to_snake(message_name),
             to_upper_camel(oneof.descriptor.name())
         );
-        let field_tags = oneof
-            .fields
-            .iter()
-            .map(|(field, _)| field.number())
-            .join(", ");
         self.append_doc(fq_message_name, None);
         self.push_indent();
         self.buf.push_str(&format!(
             "#[prost(oneof=\"{}\", tags=\"{}\")]\n",
-            type_name, field_tags,
+            type_name,
+            oneof
+                .fields
+                .iter()
+                .map(|(field, _)| field.number())
+                .join(", "),
         ));
         self.append_field_attributes(fq_message_name, oneof.descriptor.name());
         self.push_indent();


### PR DESCRIPTION
When massaging field data in `CodeGenerator::append_message`, move it into lists of `Field` and `OneofField` structs so that later generation passes can operate on the data with less code duplication.

Subsidiary `append_*` methods are changed to take references to these structs rather than moved data, as generation of lexical tokens does not actually consume any owned data, and we will need more passes over the same field lists for the upcoming builder codegen in #901.