### PR TITLE
prost-build: `CodeGenerator::boxed` method

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -1052,6 +1052,11 @@ impl<'a> CodeGenerator<'a> {
         }
     }
 
+    /// Returns whether the Rust type for this field needs to be `Box<_>`.
+    ///
+    /// This can be explicitly configured with `Config::boxed`, or necessary
+    /// to prevent an infinitely sized type definition in case when the type of
+    /// a non-repeated message field transitively contains the message itself.
     fn boxed(
         &self,
         field: &FieldDescriptorProto,

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -1083,11 +1083,13 @@ impl<'a> CodeGenerator<'a> {
             .get_first_field(&config_path, field.name())
             .is_some()
         {
-            println!(
-                "cargo:warning=\
-                Field X is repeated and manually marked as boxed. \
-                This is deprecated and support will be removed in a later release"
-            );
+            if repeated {
+                println!(
+                    "cargo:warning=\
+                    Field X is repeated and manually marked as boxed. \
+                    This is deprecated and support will be removed in a later release"
+                );
+            }
             return true;
         }
         false


### PR DESCRIPTION
A helper method to capture the logic of deciding whether a field needs to be boxed. This follows the pattern with other methods like `optional`, and will allow reusing the logic in the upcoming builder codegen in #901.