### PR TITLE
build(deps): update to env_logger 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ prost-derive = { version = "0.12.3", path = "prost-derive", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.4", default-features = false }
-env_logger = { version = "0.10", default-features = false }
+env_logger = { version = "0.11", default-features = false }
 log = "0.4"
 proptest = "1"
 rand = "0.8"

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 bytes = "1"
-env_logger = { version = "0.10", default-features = false }
+env_logger = { version = "0.11", default-features = false }
 prost = { path = ".." }
 protobuf = { path = "../protobuf" }
 tests = { path = "../tests" }

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -40,4 +40,4 @@ pulldown-cmark = { version = "0.9.1", optional = true, default-features = false 
 pulldown-cmark-to-cmark = { version = "10.0.1", optional = true }
 
 [dev-dependencies]
-env_logger = { version = "0.10", default-features = false }
+env_logger = { version = "0.11", default-features = false }

--- a/tests-2015/Cargo.toml
+++ b/tests-2015/Cargo.toml
@@ -34,6 +34,6 @@ tempfile = "3"
 
 [build-dependencies]
 cfg-if = "1"
-env_logger = { version = "0.10", default-features = false }
+env_logger = { version = "0.11", default-features = false }
 prost-build = { path = "../prost-build" }
 protobuf = { path = "../protobuf" }

--- a/tests-no-std/Cargo.toml
+++ b/tests-no-std/Cargo.toml
@@ -35,6 +35,6 @@ tempfile = "3"
 
 [build-dependencies]
 cfg-if = "1"
-env_logger = { version = "0.10", default-features = false }
+env_logger = { version = "0.11", default-features = false }
 prost-build = { path = "../prost-build" }
 protobuf = { path = "../protobuf" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -29,6 +29,6 @@ tempfile = "3"
 
 [build-dependencies]
 cfg-if = "1"
-env_logger = { version = "0.10", default-features = false }
+env_logger = { version = "0.11", default-features = false }
 prost-build = { path = "../prost-build" }
 protobuf = { path = "../protobuf" }


### PR DESCRIPTION
`env_logger` is only used as dev-dependencies or in private crates