### PR TITLE
chore: Release version 0.12.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost"
-version = "0.12.3"
+version = "0.12.4"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Lucio Franco <luciofranco14@gmail.com",
@@ -50,7 +50,7 @@ std = []
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-prost-derive = { version = "0.12.3", path = "prost-derive", optional = true }
+prost-derive = { version = "0.12.4", path = "prost-derive", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.4", default-features = false }

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost-build"
-version = "0.12.3"
+version = "0.12.4"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Lucio Franco <luciofranco14@gmail.com>",
@@ -26,8 +26,8 @@ itertools = { version = ">=0.10, <=0.12", default-features = false, features = [
 log = "0.4.4"
 multimap = { version = ">=0.8, <=0.10", default-features = false }
 petgraph = { version = "0.6", default-features = false }
-prost = { version = "0.12.3", path = "..", default-features = false }
-prost-types = { version = "0.12.3", path = "../prost-types", default-features = false }
+prost = { version = "0.12.4", path = "..", default-features = false }
+prost-types = { version = "0.12.4", path = "../prost-types", default-features = false }
 tempfile = "3"
 once_cell = "1.17.1"
 regex = { version = "1.8.1", default-features = false, features = ["std", "unicode-bool"] }

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost-derive"
-version = "0.12.3"
+version = "0.12.4"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Lucio Franco <luciofranco14@gmail.com>",

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost-types"
-version = "0.12.3"
+version = "0.12.4"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Lucio Franco <luciofranco14@gmail.com",
@@ -22,7 +22,7 @@ default = ["std"]
 std = ["prost/std"]
 
 [dependencies]
-prost = { version = "0.12.3", path = "..", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.12.4", path = "..", default-features = false, features = ["prost-derive"] }
 
 [dev-dependencies]
 proptest = "1"


### PR DESCRIPTION
_PROST!_ is a [Protocol Buffers](https://developers.google.com/protocol-buffers/) implementation for the [Rust Language](https://www.rust-lang.org/). `prost` generates simple, idiomatic Rust code from `proto2` and `proto3` files.

This patch update brings new features and fixes:

- Bump MSRV to 1.70 (minimum supported Rust version)
- Rename cargo feature `prost-derive` to `derive` (#992)
- Add @generated comment on top of generated files (#935)
- Optimize implementation of prost::Name when generated by prost-build (#956)

## Dependencies
- build(deps): Allow itertools 0.12 (#948)
- build(deps): Allow heck 0.5 (#1012)
- build(deps): Allow multimap 0.10 (#1013)

## Documentation
- Improve protoc not found error message (#937)
- build: Add development container config (#949)
- docs: Fixed README typos (#952 / #967 / #970)

## Internal
- chore: Fix minimal versions (#920)
- fix: fq_message_name should begin with one dot (#981)
- improve encode_varint performance by bounding its loop (#940)
- style: Remove duplicate function call (#989)
- test: Improve test decode_varint_slow (#977)
- chore: Add dep: prefix to feature dependencies (#919)
- Minor clippy lint fixes. (#1006)
- chore: Use taiki-e/install-action to setup cargo-machete (#909)
- chore: Remove which dependency. (#962)
- chore: Update to actions/checkout@v4 (#910)