### PR TITLE
prost_build: `BytesType and MapType` into a `collections` module.

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -18,7 +18,7 @@ use crate::ast::{Comments, Method, Service};
 use crate::extern_paths::ExternPaths;
 use crate::ident::{strip_enum_prefix, to_snake, to_upper_camel};
 use crate::message_graph::MessageGraph;
-use crate::{BytesType, Config, MapType};
+use crate::Config;
 
 mod c_escaping;
 use c_escaping::unescape_c_escape_string;
@@ -1122,40 +1122,4 @@ fn build_enum_value_mappings<'a>(
         })
     }
     mappings
-}
-
-impl MapType {
-    /// The `prost-derive` annotation type corresponding to the map type.
-    fn annotation(&self) -> &'static str {
-        match self {
-            MapType::HashMap => "map",
-            MapType::BTreeMap => "btree_map",
-        }
-    }
-
-    /// The fully-qualified Rust type corresponding to the map type.
-    fn rust_type(&self) -> &'static str {
-        match self {
-            MapType::HashMap => "::std::collections::HashMap",
-            MapType::BTreeMap => "::prost::alloc::collections::BTreeMap",
-        }
-    }
-}
-
-impl BytesType {
-    /// The `prost-derive` annotation type corresponding to the bytes type.
-    fn annotation(&self) -> &'static str {
-        match self {
-            BytesType::Vec => "vec",
-            BytesType::Bytes => "bytes",
-        }
-    }
-
-    /// The fully-qualified Rust type corresponding to the bytes type.
-    fn rust_type(&self) -> &'static str {
-        match self {
-            BytesType::Vec => "::prost::alloc::vec::Vec<u8>",
-            BytesType::Bytes => "::prost::bytes::Bytes",
-        }
-    }
 }

--- a/prost-build/src/collections.rs
+++ b/prost-build/src/collections.rs
@@ -1,0 +1,57 @@
+/// The map collection type to output for Protobuf `map` fields.
+#[non_exhaustive]
+#[derive(Default, Clone, Copy, Debug, PartialEq)]
+pub(crate) enum MapType {
+    /// The [`std::collections::HashMap`] type.
+    #[default]
+    HashMap,
+    /// The [`std::collections::BTreeMap`] type.
+    BTreeMap,
+}
+
+/// The bytes collection type to output for Protobuf `bytes` fields.
+#[non_exhaustive]
+#[derive(Default, Clone, Copy, Debug, PartialEq)]
+pub(crate) enum BytesType {
+    /// The [`alloc::collections::Vec::<u8>`] type.
+    #[default]
+    Vec,
+    /// The [`bytes::Bytes`] type.
+    Bytes,
+}
+
+impl MapType {
+    /// The `prost-derive` annotation type corresponding to the map type.
+    pub fn annotation(&self) -> &'static str {
+        match self {
+            MapType::HashMap => "map",
+            MapType::BTreeMap => "btree_map",
+        }
+    }
+
+    /// The fully-qualified Rust type corresponding to the map type.
+    pub fn rust_type(&self) -> &'static str {
+        match self {
+            MapType::HashMap => "::std::collections::HashMap",
+            MapType::BTreeMap => "::prost::alloc::collections::BTreeMap",
+        }
+    }
+}
+
+impl BytesType {
+    /// The `prost-derive` annotation type corresponding to the bytes type.
+    pub fn annotation(&self) -> &'static str {
+        match self {
+            BytesType::Vec => "vec",
+            BytesType::Bytes => "bytes",
+        }
+    }
+
+    /// The fully-qualified Rust type corresponding to the bytes type.
+    pub fn rust_type(&self) -> &'static str {
+        match self {
+            BytesType::Vec => "::prost::alloc::vec::Vec<u8>",
+            BytesType::Bytes => "::prost::bytes::Bytes",
+        }
+    }
+}

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -139,6 +139,9 @@ use prost_types::FileDescriptorSet;
 mod ast;
 pub use crate::ast::{Comments, Method, Service};
 
+mod collections;
+pub(crate) use collections::{BytesType, MapType};
+
 mod code_generator;
 mod extern_paths;
 mod ident;
@@ -194,28 +197,6 @@ pub trait ServiceGenerator {
     ///
     /// The default implementation is empty and does nothing.
     fn finalize_package(&mut self, _package: &str, _buf: &mut String) {}
-}
-
-/// The map collection type to output for Protobuf `map` fields.
-#[non_exhaustive]
-#[derive(Default, Clone, Copy, Debug, PartialEq)]
-enum MapType {
-    /// The [`std::collections::HashMap`] type.
-    #[default]
-    HashMap,
-    /// The [`std::collections::BTreeMap`] type.
-    BTreeMap,
-}
-
-/// The bytes collection type to output for Protobuf `bytes` fields.
-#[non_exhaustive]
-#[derive(Default, Clone, Copy, Debug, PartialEq)]
-enum BytesType {
-    /// The [`alloc::collections::Vec::<u8>`] type.
-    #[default]
-    Vec,
-    /// The [`bytes::Bytes`] type.
-    Bytes,
 }
 
 /// Compile `.proto` files into Rust files during a Cargo build.


### PR DESCRIPTION
Part of a series of module splits which became clear from #1026. Also functions as a way to improve the final reviewability of #1026.

~~Depends on #1020~~(rebased)