### PR TITLE
chore: Fix clippy checks in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
       - name: install protoc
         uses: taiki-e/install-action@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - run: cargo clippy --workspace --all-features --tests -- -D warnings
+      - run: cargo clippy --workspace --exclude protobuf --all-features --tests -- -D warnings
 
   machete:
     runs-on: ubuntu-latest

--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -131,7 +131,7 @@ fn apply_patches(src_dir: &Path) -> Result<()> {
         .arg("-p1")
         .arg("-i")
         .arg(patch_src)
-        .current_dir(&src_dir)
+        .current_dir(src_dir)
         .status()
         .context("failed to apply patch")?;
     // exit code: 0 means success; 1 means already applied


### PR DESCRIPTION
- chore: Fix needless borrow
- ci: Clippy requires checking out submodules
- ci: Exclude `protobuf` project from clippy