### PR TITLE
Use workspace dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ diff = "0.1"
 env_logger = { version = "0.10", default-features = false }
 heck = ">=0.4, <=0.5"
 itertools = { version = ">=0.10, <=0.12", default-features = false }
+libfuzzer-sys = "0.4.7"
 libz-sys = "1.1, <1.1.7"
 log = "0.4.4"
 multimap = { version = ">=0.8, <=0.10", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 resolver = "2"
 
 [workspace.dependencies]
-prost = { version = "0.12.4", path = "prost" }
+prost = { version = "0.12.4", path = "prost", default-features = false }
 prost-build = { path = "prost-build" }
 prost-derive = { version = "0.12.4", path = "prost-derive" }
 prost-types = { path = "prost-types", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,13 @@ exclude = [
 resolver = "2"
 
 [workspace.dependencies]
+prost = { version = "0.12.4", path = "prost" }
+prost-build = { path = "prost-build" }
+prost-derive = { version = "0.12.4", path = "prost-derive" }
+prost-types = { path = "prost-types" }
+protobuf = { path = "protobuf" }
+tests = { path = "tests" }
+
 anyhow = { version = "1.0.45", default-features = false }
 bytes = { version = "1", default-features = false }
 cfg-if = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ resolver = "2"
 prost = { version = "0.12.4", path = "prost" }
 prost-build = { path = "prost-build" }
 prost-derive = { version = "0.12.4", path = "prost-derive" }
-prost-types = { path = "prost-types" }
+prost-types = { path = "prost-types", default-features = false }
 protobuf = { path = "protobuf" }
 tests = { path = "tests" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,5 +22,30 @@ exclude = [
 
 resolver = "2"
 
+[workspace.dependencies]
+anyhow = { version = "1.0.45", default-features = false }
+bytes = { version = "1", default-features = false }
+cfg-if = "1"
+criterion = { version = "0.4", default-features = false }
+diff = "0.1"
+env_logger = { version = "0.10", default-features = false }
+heck = ">=0.4, <=0.5"
+itertools = { version = ">=0.10, <=0.12", default-features = false }
+libz-sys = "1.1, <1.1.7"
+log = "0.4.4"
+multimap = { version = ">=0.8, <=0.10", default-features = false }
+once_cell = "1.17.1"
+petgraph = { version = "0.6", default-features = false }
+prettyplease = "0.2"
+proc-macro2 = "1"
+proptest = "1"
+pulldown-cmark = { version = "0.9.1", default-features = false }
+pulldown-cmark-to-cmark = "10.0.1"
+quote = "1"
+rand = "0.8"
+regex = { version = "1.8.1", default-features = false }
+syn = "2"
+tempfile = "3"
+
 [profile.bench]
 debug = true

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytes = { workspace = true }
-env_logger = { workspace = true }
+bytes.workspace = true
+env_logger.workspace = true
 prost = { path = "../prost" }
 protobuf = { path = "../protobuf" }
 tests = { path = "../tests" }

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -9,8 +9,9 @@ publish = false
 edition = "2018"
 
 [dependencies]
+prost.workspace = true
+protobuf.workspace = true
+tests.workspace = true
+
 bytes.workspace = true
 env_logger.workspace = true
-prost = { path = "../prost" }
-protobuf = { path = "../protobuf" }
-tests = { path = "../tests" }

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-prost.workspace = true
+prost = { workspace = true, features = ["default"] }
 protobuf.workspace = true
 tests.workspace = true
 

--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 edition = "2018"
 
 [dependencies]
-bytes = "1"
-env_logger = { version = "0.10", default-features = false }
+bytes = { workspace = true }
+env_logger = { workspace = true }
 prost = { path = "../prost" }
 protobuf = { path = "../protobuf" }
 tests = { path = "../tests" }

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,9 +12,10 @@ edition = "2018"
 cargo-fuzz = true
 
 [dependencies]
+protobuf.workspace = true
+tests.workspace = true
+
 libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
-protobuf = { path = "../protobuf" }
-tests = { path = "../tests" }
 
 [[bin]]
 name = "proto3"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -15,7 +15,7 @@ cargo-fuzz = true
 protobuf.workspace = true
 tests.workspace = true
 
-libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
+libfuzzer-sys.workspace = true
 
 [[bin]]
 name = "proto3"

--- a/fuzz/afl/proto3/Cargo.toml
+++ b/fuzz/afl/proto3/Cargo.toml
@@ -13,6 +13,7 @@ name = "reproduce"
 path = "src/reproduce.rs"
 
 [dependencies]
+protobuf.workspace = true
+tests.workspace = true
+
 afl = "0.4"
-protobuf = { path = "../../protobuf/" }
-tests = { path = "../../tests/" }

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -28,7 +28,7 @@ log.workspace = true
 multimap.workspace = true
 petgraph.workspace = true
 prost = { workspace = true, features = [] }
-prost-types = { workspace = true, features = [] }
+prost-types = { workspace = true, features = ["std"] }
 tempfile.workspace = true
 once_cell.workspace = true
 regex = { workspace = true, features = ["std", "unicode-bool"] }

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -27,7 +27,7 @@ itertools = { workspace = true, features = ["use_alloc"] }
 log.workspace = true
 multimap.workspace = true
 petgraph.workspace = true
-prost = { workspace = true, features = [] }
+prost = { workspace = true, features = ["default"] }
 prost-types = { workspace = true, features = ["std"] }
 tempfile.workspace = true
 once_cell.workspace = true

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -21,24 +21,24 @@ format = ["dep:prettyplease", "dep:syn"]
 cleanup-markdown = ["dep:pulldown-cmark", "dep:pulldown-cmark-to-cmark"]
 
 [dependencies]
-bytes = { version = "1", default-features = false }
-heck = { version = ">=0.4, <=0.5" }
-itertools = { version = ">=0.10, <=0.12", default-features = false, features = ["use_alloc"] }
-log = "0.4.4"
-multimap = { version = ">=0.8, <=0.10", default-features = false }
-petgraph = { version = "0.6", default-features = false }
+bytes = { workspace = true }
+heck = { workspace = true }
+itertools = { workspace = true, features = ["use_alloc"] }
+log = { workspace = true }
+multimap = { workspace = true }
+petgraph = { workspace = true }
 prost = { version = "0.12.4", path = "../prost", default-features = false }
 prost-types = { version = "0.12.4", path = "../prost-types", default-features = false }
-tempfile = "3"
-once_cell = "1.17.1"
-regex = { version = "1.8.1", default-features = false, features = ["std", "unicode-bool"] }
+tempfile = { workspace = true }
+once_cell = { workspace = true }
+regex = { workspace = true, features = ["std", "unicode-bool"] }
 
-prettyplease = { version = "0.2", optional = true }
-syn = { version = "2", features = ["full"], optional = true }
+prettyplease = { workspace = true, optional = true }
+syn = { workspace = true, features = ["full"], optional = true }
 
 # These two must be kept in sync, used for `cleanup-markdown` feature.
-pulldown-cmark = { version = "0.9.1", optional = true, default-features = false }
-pulldown-cmark-to-cmark = { version = "10.0.1", optional = true }
+pulldown-cmark = { workspace = true, optional = true }
+pulldown-cmark-to-cmark = { workspace = true, optional = true }
 
 [dev-dependencies]
-env_logger = { version = "0.10", default-features = false }
+env_logger = { workspace = true }

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -21,16 +21,16 @@ format = ["dep:prettyplease", "dep:syn"]
 cleanup-markdown = ["dep:pulldown-cmark", "dep:pulldown-cmark-to-cmark"]
 
 [dependencies]
-bytes = { workspace = true }
-heck = { workspace = true }
+bytes.workspace = true
+heck.workspace = true
 itertools = { workspace = true, features = ["use_alloc"] }
-log = { workspace = true }
-multimap = { workspace = true }
-petgraph = { workspace = true }
+log.workspace = true
+multimap.workspace = true
+petgraph.workspace = true
 prost = { version = "0.12.4", path = "../prost", default-features = false }
 prost-types = { version = "0.12.4", path = "../prost-types", default-features = false }
-tempfile = { workspace = true }
-once_cell = { workspace = true }
+tempfile.workspace = true
+once_cell.workspace = true
 regex = { workspace = true, features = ["std", "unicode-bool"] }
 
 prettyplease = { workspace = true, optional = true }
@@ -41,4 +41,4 @@ pulldown-cmark = { workspace = true, optional = true }
 pulldown-cmark-to-cmark = { workspace = true, optional = true }
 
 [dev-dependencies]
-env_logger = { workspace = true }
+env_logger.workspace = true

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -27,8 +27,8 @@ itertools = { workspace = true, features = ["use_alloc"] }
 log.workspace = true
 multimap.workspace = true
 petgraph.workspace = true
-prost = { version = "0.12.4", path = "../prost", default-features = false }
-prost-types = { version = "0.12.4", path = "../prost-types", default-features = false }
+prost = { workspace = true, features = [] }
+prost-types = { workspace = true, features = [] }
 tempfile.workspace = true
 once_cell.workspace = true
 regex = { workspace = true, features = ["std", "unicode-bool"] }

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -19,8 +19,8 @@ rust-version = "1.70"
 proc_macro = true
 
 [dependencies]
-anyhow = { workspace = true }
+anyhow.workspace = true
 itertools = { workspace = true, features = ["use_alloc"] }
-proc-macro2 = { workspace = true }
-quote = { workspace = true }
+proc-macro2.workspace = true
+quote.workspace = true
 syn = { workspace = true, features = ["extra-traits"] }

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -19,8 +19,8 @@ rust-version = "1.70"
 proc_macro = true
 
 [dependencies]
-anyhow = "1.0.1"
-itertools = { version = ">=0.10, <=0.12", default-features = false, features = ["use_alloc"] }
-proc-macro2 = "1"
-quote = "1"
-syn = { version = "2", features = [ "extra-traits" ] }
+anyhow = { workspace = true }
+itertools = { workspace = true, features = ["use_alloc"] }
+proc-macro2 = { workspace = true }
+quote = { workspace = true }
+syn = { workspace = true, features = ["extra-traits"] }

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -19,7 +19,7 @@ rust-version = "1.70"
 proc_macro = true
 
 [dependencies]
-anyhow.workspace = true
+anyhow = { workspace = true, features = ["std"] }
 itertools = { workspace = true, features = ["use_alloc"] }
 proc-macro2.workspace = true
 quote.workspace = true

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -26,4 +26,4 @@ std = ["prost/std"]
 prost = { version = "0.12.4", path = "../prost", default-features = false, features = ["prost-derive"] }
 
 [dev-dependencies]
-proptest = { workspace = true }
+proptest.workspace = true

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -26,4 +26,4 @@ std = ["prost/std"]
 prost = { version = "0.12.4", path = "../prost", default-features = false, features = ["prost-derive"] }
 
 [dev-dependencies]
-proptest = "1"
+proptest = { workspace = true }

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -23,7 +23,7 @@ default = ["std"]
 std = ["prost/std"]
 
 [dependencies]
-prost = { version = "0.12.4", path = "../prost", default-features = false, features = ["prost-derive"] }
+prost = { workspace = true, features = ["prost-derive"] }
 
 [dev-dependencies]
 proptest.workspace = true

--- a/prost/Cargo.toml
+++ b/prost/Cargo.toml
@@ -29,15 +29,15 @@ no-recursion-limit = []
 std = []
 
 [dependencies]
-bytes = { version = "1", default-features = false }
+bytes = { workspace = true }
 prost-derive = { version = "0.12.4", path = "../prost-derive", optional = true }
 
 [dev-dependencies]
-criterion = { version = "0.4", default-features = false }
-env_logger = { version = "0.10", default-features = false }
-log = "0.4"
-proptest = "1"
-rand = "0.8"
+criterion = { workspace = true }
+env_logger = { workspace = true }
+log = { workspace = true }
+proptest = { workspace = true }
+rand = { workspace = true }
 
 [[bench]]
 name = "varint"

--- a/prost/Cargo.toml
+++ b/prost/Cargo.toml
@@ -29,15 +29,15 @@ no-recursion-limit = []
 std = []
 
 [dependencies]
-bytes = { workspace = true }
+bytes.workspace = true
 prost-derive = { version = "0.12.4", path = "../prost-derive", optional = true }
 
 [dev-dependencies]
-criterion = { workspace = true }
-env_logger = { workspace = true }
-log = { workspace = true }
-proptest = { workspace = true }
-rand = { workspace = true }
+criterion.workspace = true
+env_logger.workspace = true
+log.workspace = true
+proptest.workspace = true
+rand.workspace = true
 
 [[bench]]
 name = "varint"

--- a/prost/Cargo.toml
+++ b/prost/Cargo.toml
@@ -30,7 +30,7 @@ std = []
 
 [dependencies]
 bytes.workspace = true
-prost-derive = { version = "0.12.4", path = "../prost-derive", optional = true }
+prost-derive = { workspace = true, optional = true }
 
 [dev-dependencies]
 criterion.workspace = true

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -13,7 +13,7 @@ prost = { path = "../prost" }
 prost-types = { path = "../prost-types" }
 
 [build-dependencies]
-anyhow.workspace = true
+anyhow = { workspace = true, features = ["std"] }
 prost-build = { path = "../prost-build" }
 tempfile.workspace = true
 

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 prost.workspace = true
-prost-types.workspace = true
+prost-types = { workspace = true, features = ["std"] }
 
 [build-dependencies]
 prost-build.workspace = true

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 edition = "2018"
 
 [dependencies]
-prost.workspace = true
+prost = { workspace = true, features = ["default"] }
 prost-types = { workspace = true, features = ["std"] }
 
 [build-dependencies]

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -9,12 +9,13 @@ publish = false
 edition = "2018"
 
 [dependencies]
-prost = { path = "../prost" }
-prost-types = { path = "../prost-types" }
+prost.workspace = true
+prost-types.workspace = true
 
 [build-dependencies]
+prost-build.workspace = true
+
 anyhow = { workspace = true, features = ["std"] }
-prost-build = { path = "../prost-build" }
 tempfile.workspace = true
 
 # With libz-sys `1.1.8` the msrv has been bumped to 1.54. Since, this dep

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -13,9 +13,9 @@ prost = { path = "../prost" }
 prost-types = { path = "../prost-types" }
 
 [build-dependencies]
-anyhow = { workspace = true }
+anyhow.workspace = true
 prost-build = { path = "../prost-build" }
-tempfile = { workspace = true }
+tempfile.workspace = true
 
 # With libz-sys `1.1.8` the msrv has been bumped to 1.54. Since, this dep
 # is not a dep of the actual prost crates we will force cargo to not include
@@ -25,8 +25,8 @@ tempfile = { workspace = true }
 libz-sys = { workspace = true, optional = true }
 
 [dev-dependencies]
-criterion = { workspace = true }
-cfg-if = { workspace = true }
+criterion.workspace = true
+cfg-if.workspace = true
 
 [lib]
 # https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -13,20 +13,20 @@ prost = { path = "../prost" }
 prost-types = { path = "../prost-types" }
 
 [build-dependencies]
-anyhow = "1.0.1"
+anyhow = { workspace = true }
 prost-build = { path = "../prost-build" }
-tempfile = "3"
+tempfile = { workspace = true }
 
 # With libz-sys `1.1.8` the msrv has been bumped to 1.54. Since, this dep
 # is not a dep of the actual prost crates we will force cargo to not include
 # the new version.
 #
 # https://github.com/rust-lang/libz-sys/issues/101
-libz-sys = { version = "1.1, < 1.1.7", optional = true }
+libz-sys = { workspace = true, optional = true }
 
 [dev-dependencies]
-criterion = { version = "0.4", default-features = false }
-cfg-if = "1"
+criterion = { workspace = true }
+cfg-if = { workspace = true }
 
 [lib]
 # https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

--- a/tests-2015/Cargo.toml
+++ b/tests-2015/Cargo.toml
@@ -20,20 +20,20 @@ edition-2015 = []
 std = []
 
 [dependencies]
-anyhow = { workspace = true }
-bytes = { workspace = true }
-cfg-if = { workspace = true }
+anyhow.workspace = true
+bytes.workspace = true
+cfg-if.workspace = true
 prost = { path = "../prost" }
 prost-types = { path = "../prost-types" }
 protobuf = { path = "../protobuf" }
 
 [dev-dependencies]
-diff = { workspace = true }
+diff.workspace = true
 prost-build = { path = "../prost-build" }
-tempfile = { workspace = true }
+tempfile.workspace = true
 
 [build-dependencies]
-cfg-if = { workspace = true }
-env_logger = { workspace = true }
+cfg-if.workspace = true
+env_logger.workspace = true
 prost-build = { path = "../prost-build" }
 protobuf = { path = "../protobuf" }

--- a/tests-2015/Cargo.toml
+++ b/tests-2015/Cargo.toml
@@ -20,20 +20,23 @@ edition-2015 = []
 std = ["anyhow/std"]
 
 [dependencies]
+prost.workspace = true
+prost-types.workspace = true
+protobuf.workspace = true
+
 anyhow.workspace = true
 bytes.workspace = true
 cfg-if.workspace = true
-prost = { path = "../prost" }
-prost-types = { path = "../prost-types" }
-protobuf = { path = "../protobuf" }
 
 [dev-dependencies]
+prost-build.workspace = true
+
 diff.workspace = true
-prost-build = { path = "../prost-build" }
 tempfile.workspace = true
 
 [build-dependencies]
+prost-build.workspace = true
+protobuf.workspace = true
+
 cfg-if.workspace = true
 env_logger.workspace = true
-prost-build = { path = "../prost-build" }
-protobuf = { path = "../protobuf" }

--- a/tests-2015/Cargo.toml
+++ b/tests-2015/Cargo.toml
@@ -20,20 +20,20 @@ edition-2015 = []
 std = []
 
 [dependencies]
-anyhow = "1.0.1"
-bytes = "1"
-cfg-if = "1"
+anyhow = { workspace = true }
+bytes = { workspace = true }
+cfg-if = { workspace = true }
 prost = { path = "../prost" }
 prost-types = { path = "../prost-types" }
 protobuf = { path = "../protobuf" }
 
 [dev-dependencies]
-diff = "0.1"
+diff = { workspace = true }
 prost-build = { path = "../prost-build" }
-tempfile = "3"
+tempfile = { workspace = true }
 
 [build-dependencies]
-cfg-if = "1"
-env_logger = { version = "0.10", default-features = false }
+cfg-if = { workspace = true }
+env_logger = { workspace = true }
 prost-build = { path = "../prost-build" }
 protobuf = { path = "../protobuf" }

--- a/tests-2015/Cargo.toml
+++ b/tests-2015/Cargo.toml
@@ -17,7 +17,7 @@ path = "../tests/src/lib.rs"
 [features]
 default = ["edition-2015", "std"]
 edition-2015 = []
-std = ["anyhow/std", "prost-types/std"]
+std = ["anyhow/std", "prost-types/std", "prost/std"]
 
 [dependencies]
 prost.workspace = true

--- a/tests-2015/Cargo.toml
+++ b/tests-2015/Cargo.toml
@@ -17,7 +17,7 @@ path = "../tests/src/lib.rs"
 [features]
 default = ["edition-2015", "std"]
 edition-2015 = []
-std = []
+std = ["anyhow/std"]
 
 [dependencies]
 anyhow.workspace = true

--- a/tests-2015/Cargo.toml
+++ b/tests-2015/Cargo.toml
@@ -17,7 +17,7 @@ path = "../tests/src/lib.rs"
 [features]
 default = ["edition-2015", "std"]
 edition-2015 = []
-std = ["anyhow/std"]
+std = ["anyhow/std", "prost-types/std"]
 
 [dependencies]
 prost.workspace = true

--- a/tests-no-std/Cargo.toml
+++ b/tests-no-std/Cargo.toml
@@ -21,20 +21,23 @@ path = "../tests/src/lib.rs"
 # [1]: https://github.com/rust-lang/cargo/pull/8074
 
 [dependencies]
+prost = { workspace = true, features = ["derive"] }
+prost-types = { workspace = true, features = [] }
+protobuf = { workspace = true }
+
 anyhow.workspace = true
 bytes.workspace = true
 cfg-if.workspace = true
-prost = { path = "../prost", default-features = false, features = ["derive"] }
-prost-types = { path = "../prost-types", default-features = false }
-protobuf = { path = "../protobuf" }
 
 [dev-dependencies]
+prost-build.workspace = true
+
 diff.workspace = true
-prost-build = { path = "../prost-build" }
 tempfile.workspace = true
 
 [build-dependencies]
+prost-build.workspace = true
+protobuf.workspace = true
+
 cfg-if.workspace = true
 env_logger.workspace = true
-prost-build = { path = "../prost-build" }
-protobuf = { path = "../protobuf" }

--- a/tests-no-std/Cargo.toml
+++ b/tests-no-std/Cargo.toml
@@ -21,20 +21,20 @@ path = "../tests/src/lib.rs"
 # [1]: https://github.com/rust-lang/cargo/pull/8074
 
 [dependencies]
-anyhow = { workspace = true }
-bytes = { workspace = true }
-cfg-if = { workspace = true }
+anyhow.workspace = true
+bytes.workspace = true
+cfg-if.workspace = true
 prost = { path = "../prost", default-features = false, features = ["derive"] }
 prost-types = { path = "../prost-types", default-features = false }
 protobuf = { path = "../protobuf" }
 
 [dev-dependencies]
-diff = { workspace = true }
+diff.workspace = true
 prost-build = { path = "../prost-build" }
-tempfile = { workspace = true }
+tempfile.workspace = true
 
 [build-dependencies]
-cfg-if = { workspace = true }
-env_logger = { workspace = true }
+cfg-if.workspace = true
+env_logger.workspace = true
 prost-build = { path = "../prost-build" }
 protobuf = { path = "../protobuf" }

--- a/tests-no-std/Cargo.toml
+++ b/tests-no-std/Cargo.toml
@@ -22,7 +22,7 @@ path = "../tests/src/lib.rs"
 
 [dependencies]
 prost = { workspace = true, features = ["derive"] }
-prost-types = { workspace = true, features = [] }
+prost-types.workspace = true
 protobuf = { workspace = true }
 
 anyhow.workspace = true

--- a/tests-no-std/Cargo.toml
+++ b/tests-no-std/Cargo.toml
@@ -21,20 +21,20 @@ path = "../tests/src/lib.rs"
 # [1]: https://github.com/rust-lang/cargo/pull/8074
 
 [dependencies]
-anyhow = { version = "1.0.45", default-features = false }
-bytes = { version = "1", default-features = false }
-cfg-if = "1"
+anyhow = { workspace = true }
+bytes = { workspace = true }
+cfg-if = { workspace = true }
 prost = { path = "../prost", default-features = false, features = ["derive"] }
 prost-types = { path = "../prost-types", default-features = false }
 protobuf = { path = "../protobuf" }
 
 [dev-dependencies]
-diff = "0.1"
+diff = { workspace = true }
 prost-build = { path = "../prost-build" }
-tempfile = "3"
+tempfile = { workspace = true }
 
 [build-dependencies]
-cfg-if = "1"
-env_logger = { version = "0.10", default-features = false }
+cfg-if = { workspace = true }
+env_logger = { workspace = true }
 prost-build = { path = "../prost-build" }
 protobuf = { path = "../protobuf" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,7 +12,7 @@ build = "src/build.rs"
 
 [features]
 default = ["std"]
-std = ["anyhow/std"]
+std = ["anyhow/std", "prost-types/std"]
 
 [dependencies]
 prost.workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,7 +12,7 @@ build = "src/build.rs"
 
 [features]
 default = ["std"]
-std = ["anyhow/std", "prost-types/std"]
+std = ["anyhow/std", "prost-types/std", "prost/std"]
 
 [dependencies]
 prost.workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,20 +15,20 @@ default = ["std"]
 std = []
 
 [dependencies]
-anyhow = { workspace = true }
+anyhow.workspace = true
 # bytes = "1"
-cfg-if = { workspace = true }
+cfg-if.workspace = true
 prost = { path = "../prost" }
 prost-types = { path = "../prost-types" }
 protobuf = { path = "../protobuf" }
 
 [dev-dependencies]
-diff = { workspace = true }
+diff.workspace = true
 prost-build = { path = "../prost-build", features = ["cleanup-markdown"] }
-tempfile = { workspace = true }
+tempfile.workspace = true
 
 [build-dependencies]
-cfg-if = { workspace = true }
-env_logger = { workspace = true }
+cfg-if.workspace = true
+env_logger.workspace = true
 prost-build = { path = "../prost-build" }
 protobuf = { path = "../protobuf" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,20 +15,23 @@ default = ["std"]
 std = ["anyhow/std"]
 
 [dependencies]
+prost.workspace = true
+prost-types.workspace = true
+protobuf.workspace = true
+
 anyhow.workspace = true
 # bytes = "1"
 cfg-if.workspace = true
-prost = { path = "../prost" }
-prost-types = { path = "../prost-types" }
-protobuf = { path = "../protobuf" }
 
 [dev-dependencies]
+prost-build = { workspace = true, features = ["cleanup-markdown"] }
+
 diff.workspace = true
-prost-build = { path = "../prost-build", features = ["cleanup-markdown"] }
 tempfile.workspace = true
 
 [build-dependencies]
+prost-build.workspace = true
+protobuf.workspace = true
+
 cfg-if.workspace = true
 env_logger.workspace = true
-prost-build = { path = "../prost-build" }
-protobuf = { path = "../protobuf" }

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -12,7 +12,7 @@ build = "src/build.rs"
 
 [features]
 default = ["std"]
-std = []
+std = ["anyhow/std"]
 
 [dependencies]
 anyhow.workspace = true

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -15,20 +15,20 @@ default = ["std"]
 std = []
 
 [dependencies]
-anyhow = "1.0.1"
+anyhow = { workspace = true }
 # bytes = "1"
-cfg-if = "1"
+cfg-if = { workspace = true }
 prost = { path = "../prost" }
 prost-types = { path = "../prost-types" }
 protobuf = { path = "../protobuf" }
 
 [dev-dependencies]
-diff = "0.1"
+diff = { workspace = true }
 prost-build = { path = "../prost-build", features = ["cleanup-markdown"] }
-tempfile = "3"
+tempfile = { workspace = true }
 
 [build-dependencies]
-cfg-if = "1"
-env_logger = { version = "0.10", default-features = false }
+cfg-if = { workspace = true }
+env_logger = { workspace = true }
 prost-build = { path = "../prost-build" }
 protobuf = { path = "../protobuf" }

--- a/tests/single-include/Cargo.toml
+++ b/tests/single-include/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 license = "MIT"
 
 [dependencies]
-prost.workspace = true
+prost = { workspace = true, features = ["default"] }
 
 [build-dependencies]
 prost-build.workspace = true

--- a/tests/single-include/Cargo.toml
+++ b/tests/single-include/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 license = "MIT"
 
 [dependencies]
-prost = { path = "../../prost" }
+prost.workspace = true
 
 [build-dependencies]
-prost-build = { path = "../../prost-build" }
+prost-build.workspace = true


### PR DESCRIPTION
Makes dependency version handling easier. Relates in some way to https://github.com/tokio-rs/prost/pull/957

~~Depends on #1033~~ (merged into master and rebased here) 