### PR TITLE
chore: Update internal crates to Rust edition 2021

### DIFF
--- a/conformance/Cargo.toml
+++ b/conformance/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Tokio Contributors <team@tokio.rs>",
 ]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 bytes = "1"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Tokio Contributors <team@tokio.rs>",
 ]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [package.metadata]
 cargo-fuzz = true

--- a/fuzz/afl/proto3/Cargo.toml
+++ b/fuzz/afl/proto3/Cargo.toml
@@ -2,7 +2,7 @@
 name = "fuzz-target-proto3"
 version = "0.1.0"
 authors = ["Prost developers"]
-edition = "2018"
+edition = "2021"
 
 [[bin]]
 name = "fuzz-target"

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Tokio Contributors <team@tokio.rs>",
 ]
 publish = false
-edition = "2018"
+edition = "2021"
 
 [dependencies]
 prost = { path = "../prost" }

--- a/tests-2018/Cargo.toml
+++ b/tests-2018/Cargo.toml
@@ -1,14 +1,18 @@
 [package]
-name = "tests"
+name = "tests-2018"
 version = "0.0.0"
 authors = [
     "Dan Burkert <dan@danburkert.com>",
     "Tokio Contributors <team@tokio.rs>",
 ]
 publish = false
-edition = "2021"
+edition = "2018"
 
-build = "src/build.rs"
+build = "../tests/src/build.rs"
+
+[lib]
+doctest = false
+path = "../tests/src/lib.rs"
 
 [features]
 default = ["std"]
@@ -16,7 +20,7 @@ std = []
 
 [dependencies]
 anyhow = "1.0.1"
-# bytes = "1"
+bytes = "1"
 cfg-if = "1"
 prost = { path = "../prost" }
 prost-types = { path = "../prost-types" }

--- a/tests-no-std/Cargo.toml
+++ b/tests-no-std/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Tokio Contributors <team@tokio.rs>",
 ]
 publish = false
-edition = "2018"
+edition = "2021"
 
 build = "../tests/src/build.rs"
 

--- a/tests/single-include/Cargo.toml
+++ b/tests/single-include/Cargo.toml
@@ -2,7 +2,7 @@
 name = "single_include"
 version = "0.1.0"
 authors = ["Cameron Dart <cdart2@illinois.edu>"]
-edition = "2018"
+edition = "2021"
 publish = false
 license = "MIT"
 


### PR DESCRIPTION
The published crates were already using edition 2021. Update all internal crates as well.

Also add a new tests-2018 crate that runs all tests using edition 2018.