### PR TITLE
fix: #942

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ First, add `prost` and its public dependencies to your `Cargo.toml`:
 
 ```ignore
 [dependencies]
-prost = "0.12"
+prost = "*"
 # Only necessary if using Protobuf well-known types:
-prost-types = "0.12"
+prost-types = "*"
 ```
 
 The recommended way to add `.proto` compilation to a Cargo project is to use the
@@ -380,9 +380,9 @@ the `std` features in `prost` and `prost-types`:
 
 ```ignore
 [dependencies]
-prost = { version = "0.6", default-features = false, features = ["prost-derive"] }
+prost = { version = "*", default-features = false, features = ["prost-derive"] }
 # Only necessary if using Protobuf well-known types:
-prost-types = { version = "0.6", default-features = false }
+prost-types = { version = "*", default-features = false }
 ```
 
 Additionally, configure `prost-build` to output `BTreeMap`s instead of `HashMap`s


### PR DESCRIPTION
Changes version numbers to start imports rather than the latest, reducing the need to make sure that the documentation numbers are always up-to-date.

One downside is that the users must set an explicit the version number before publishing their own crates.