### PR TITLE
fix the link and badge for CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![continuous integration](https://github.com/tokio-rs/prost/workflows/continuous%20integration/badge.svg)
+[![continuous integration](https://github.com/tokio-rs/prost/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/tokio-rs/prost/actions/workflows/ci.yml?query=branch%3Amaster)
 [![Documentation](https://docs.rs/prost/badge.svg)](https://docs.rs/prost/)
 [![Crate](https://img.shields.io/crates/v/prost.svg)](https://crates.io/crates/prost)
 [![Dependency Status](https://deps.rs/repo/github/tokio-rs/prost/status.svg)](https://deps.rs/repo/github/tokio-rs/prost)


### PR DESCRIPTION
the badge image has been incorrect and not reflective of CI status since august 2023 (9c877ce32ec0c465e437144c1bf4a27cb3aa705c).