### PR TITLE
chore: Release version 0.12.5

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost-build"
-version = "0.12.4"
+version = "0.12.5"
 authors = [
   "Dan Burkert <dan@danburkert.com>",
   "Lucio Franco <luciofranco14@gmail.com>",
@@ -27,8 +27,8 @@ itertools = { version = ">=0.10, <=0.12", default-features = false, features = [
 log = "0.4.4"
 multimap = { version = ">=0.8, <=0.10", default-features = false }
 petgraph = { version = "0.6", default-features = false }
-prost = { version = "0.12.4", path = "../prost", default-features = false }
-prost-types = { version = "0.12.4", path = "../prost-types", default-features = false }
+prost = { version = "0.12.5", path = "../prost", default-features = false }
+prost-types = { version = "0.12.5", path = "../prost-types", default-features = false }
 tempfile = "3"
 once_cell = "1.17.1"
 regex = { version = "1.8.1", default-features = false, features = ["std", "unicode-bool"] }

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-build/0.12.2")]
+#![doc(html_root_url = "https://docs.rs/prost-build/0.12.5")]
 #![allow(clippy::option_as_ref_deref, clippy::format_push_string)]
 
 //! `prost-build` compiles `.proto` files into Rust.

--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost-derive"
-version = "0.12.4"
+version = "0.12.5"
 authors = [
   "Dan Burkert <dan@danburkert.com>",
   "Lucio Franco <luciofranco14@gmail.com>",

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-derive/0.12.2")]
+#![doc(html_root_url = "https://docs.rs/prost-derive/0.12.5")]
 // The `quote!` macro requires deep recursion.
 #![recursion_limit = "4096"]
 

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost-types"
-version = "0.12.4"
+version = "0.12.5"
 authors = [
   "Dan Burkert <dan@danburkert.com>",
   "Lucio Franco <luciofranco14@gmail.com>",
@@ -23,7 +23,7 @@ default = ["std"]
 std = ["prost/std"]
 
 [dependencies]
-prost = { version = "0.12.4", path = "../prost", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.12.5", path = "../prost", default-features = false, features = ["prost-derive"] }
 
 [dev-dependencies]
 proptest = "1"

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-types/0.12.2")]
+#![doc(html_root_url = "https://docs.rs/prost-types/0.12.5")]
 
 //! Protocol Buffers well-known types.
 //!

--- a/prost/Cargo.toml
+++ b/prost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prost"
-version = "0.12.4"
+version = "0.12.5"
 authors = [
   "Dan Burkert <dan@danburkert.com>",
   "Lucio Franco <luciofranco14@gmail.com>",
@@ -30,7 +30,7 @@ std = []
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-prost-derive = { version = "0.12.4", path = "../prost-derive", optional = true }
+prost-derive = { version = "0.12.5", path = "../prost-derive", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.4", default-features = false }

--- a/prost/src/lib.rs
+++ b/prost/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost/0.12.2")]
+#![doc(html_root_url = "https://docs.rs/prost/0.12.5")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![doc = include_str!("../../README.md")]
 


### PR DESCRIPTION
_PROST!_ is a [Protocol Buffers](https://developers.google.com/protocol-buffers/) implementation for the [Rust Language](https://www.rust-lang.org/). `prost` generates simple, idiomatic Rust code from `proto2` and `proto3` files.

This patch update brings new fixes:

- fix: include_file should handle proto without package (#1002)
- Place Config::format behind the format feature flag
- Handle keyword `Self` after stripping enum type prefix (#998)

## Documentation
- fix(readme): fix the link and badge for CI (#1049)

## Internal
- style(codegen): `Syntax` to a separate file (#1029)
- chore(codegen): extract c string escaping to a separate file (#1028)
- style(prost-build): `CodeGenerator::boxed` method (#1019)
- style(prost-build): Consolidate field data into struct (#1017)
- style(prost-build): `BytesType and MapType` into a `collections` module. (#1030)
- style(prost-build): Split `Config` and `Module` into a separate module and files (#1020)
- style(prost-build): prost_path helper (#1018)
- style: Fix toml indent (#1048)
- style: Fix clippy warnings and enable clippy in CI (#1008)
- build: Use git submodule to download protobuf sources (#1014)
- ci: Add TOML validation with `taplo` (#1034)
- tests: Create a separate tempdir for each test (#1044)
- tests: Remove GoogleMessage3 and GoogleMessage4 benchmarks (#1037)
- chore: Update internal crates to Rust edition 2021 (#1039)
- chore: Update crate descriptions (#1038)
- chore: Fix clippy checks in CI (#1032)
- chore: Add Casper Meijn as author (#1025)