### PR TITLE
chore: Add ci to check MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,6 @@ jobs:
       matrix:
         toolchain:
           - stable
-          - "1.70"
         os:
           - ubuntu-latest
           - macos-latest
@@ -82,6 +81,21 @@ jobs:
         run: cargo test --doc
       - name: test doc no-default-features
         run: cargo test -p prost-build -p prost-derive -p prost-types --doc --no-default-features
+
+  msrv:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: install protoc
+        uses: taiki-e/install-action@v2
+        with:
+          tool: protoc@${{ env.PROTOC_VERSION }}
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: Swatinem/rust-cache@v2
+      - name: check with no-default-features
+        run: cargo hack --rust-version --no-private --no-dev-deps check --no-default-features
+      - name: check with all-features
+        run: cargo hack --rust-version --no-private --no-dev-deps check --all-features
 
   minimal-versions:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Instead of rebuilding everything with Rust 1.70 (MSRV), use `cargo hack` to only build published crates at their specified `rust-version`.