### PR TITLE
fix(prost-build): re-export `error_message_protoc_not_found`, `protoc_from_env` & `protoc_include_from_env`

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -149,7 +149,9 @@ mod message_graph;
 mod path;
 
 mod config;
-pub use config::Config;
+pub use config::{
+    error_message_protoc_not_found, protoc_from_env, protoc_include_from_env, Config,
+};
 
 mod module;
 pub use module::Module;


### PR DESCRIPTION
fixes: #1062

I'm adding this to fix a breaking change introduced in https://github.com/tokio-rs/prost/pull/1020 where these items were moved.

Since `0.12.5` this is causing build failures after `cargo update`.

```
   Compiling grpc-build v6.1.0
error[E0432]: unresolved imports `prost_build::protoc_from_env`, `prost_build::protoc_include_from_env`
 --> /Users/ethan.brierley/.cargo/registry/src/index.crates.io-6f17d22bba15001f/grpc-build-6.1.0/src/lib.rs:3:19
  |
3 | use prost_build::{protoc_from_env, protoc_include_from_env, Module};
  |                   ^^^^^^^^^^^^^^^  ^^^^^^^^^^^^^^^^^^^^^^^ no `protoc_include_from_env` in the root
  |                   |
  |                   no `protoc_from_env` in the root
```