### PR TITLE
fix: Build error due to merge conflict

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -619,9 +619,9 @@ impl<'a> CodeGenerator<'a> {
         self.buf
             .push_str("#[allow(clippy::derive_partial_eq_without_eq)]\n");
 
-        let can_oneof_derive_copy = fields.iter().map(|(field, _idx)| field).all(|field| {
+        let can_oneof_derive_copy = oneof.fields.iter().all(|field| {
             self.message_graph
-                .can_field_derive_copy(fq_message_name, field)
+                .can_field_derive_copy(fq_message_name, &field.descriptor)
         });
         self.buf.push_str(&format!(
             "#[derive(Clone, {}PartialEq, {}::Oneof)]\n",

--- a/tests/src/derive_copy.rs
+++ b/tests/src/derive_copy.rs
@@ -1,5 +1,6 @@
 include!(concat!(env!("OUT_DIR"), "/derive_copy.rs"));
 
+#[allow(dead_code)]
 trait TestCopyIsImplemented: Copy {}
 
 impl TestCopyIsImplemented for EmptyMsg {}


### PR DESCRIPTION
Due to two pull requests changing the same function a build error occurred. `fields` has move to inside `oneof` and has changed type.