### PR TITLE
ci: Add all tests pass job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,24 @@ env:
   PROTOC_VERSION: 3.20.3
 
 jobs:
+  # Depends on all actions that are required for a "successful" CI run.
+  tests-pass:
+    name: all systems go
+    runs-on: ubuntu-latest
+    needs:
+      - rustfmt
+      - toml_validation
+      - clippy
+      - machete
+      - unused_dependencies
+      - test
+      - msrv
+      - minimal-versions
+      - kani
+      - no-std
+    steps:
+      - run: exit 0
+
   rustfmt:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Add a job that only finished if all tests pass. This will be configured as a required test to make sure all jobs pass on every commit.