### PR TITLE
build(deps): Remove unused libz-sys

### DIFF
--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -17,13 +17,6 @@ anyhow = "1.0.1"
 prost-build = { path = "../prost-build" }
 tempfile = "3"
 
-# With libz-sys `1.1.8` the msrv has been bumped to 1.54. Since, this dep
-# is not a dep of the actual prost crates we will force cargo to not include
-# the new version.
-#
-# https://github.com/rust-lang/libz-sys/issues/101
-libz-sys = { version = "1.1, < 1.1.7", optional = true }
-
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false }
 


### PR DESCRIPTION
libz-sys is a optional dependency of a private crate that is never enabled.