### PR TITLE
ci: Ensure both README are the same and prost version is correct 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       - minimal-versions
       - kani
       - no-std
+      - check-readme
     steps:
       - run: exit 0
 
@@ -202,3 +203,15 @@ jobs:
       # prost's default features to compile.
       - name: prost-build check
         run: cargo check --manifest-path prost-build/Cargo.toml
+
+  check-readme:
+    name: Check README
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify that both READMEs are identical
+        run: diff README.md prost/README.md
+
+      - name: Verify that Prost version is up to date in README
+        working-directory: prost
+        run: grep -q "$(sed '/^version = /!d' Cargo.toml | head -n1)" README.md

--- a/README.md
+++ b/README.md
@@ -380,9 +380,9 @@ the `std` features in `prost` and `prost-types`:
 
 ```ignore
 [dependencies]
-prost = { version = "0.6", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.12.6", default-features = false, features = ["prost-derive"] }
 # Only necessary if using Protobuf well-known types:
-prost-types = { version = "0.6", default-features = false }
+prost-types = { version = "0.12.6", default-features = false }
 ```
 
 Additionally, configure `prost-build` to output `BTreeMap`s instead of `HashMap`s

--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -14,13 +14,13 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 VERSION="$1"
-MINOR="$( echo ${VERSION} | cut -d\. -f1-2 )"
 
 VERSION_MATCHER="([a-z0-9\\.-]+)"
 PROST_CRATE_MATCHER="(prost|prost-[a-z]+)"
 
 # Update the README.md.
-sed -i -E "s/${PROST_CRATE_MATCHER} = \"${VERSION_MATCHER}\"/\1 = \"${MINOR}\"/" "$DIR/README.md"
+sed -i -E "s/version = \"${VERSION_MATCHER}\"/version = \"${VERSION}\"/" "$DIR/README.md"
+sed -i -E "s/version = \"${VERSION_MATCHER}\"/version = \"${VERSION}\"/" "$DIR/prost/README.md"
 
 # Update html_root_url attributes.
 sed -i -E "s~html_root_url = \"https://docs\.rs/${PROST_CRATE_MATCHER}/$VERSION_MATCHER\"~html_root_url = \"https://docs.rs/\1/${VERSION}\"~" \

--- a/prost/README.md
+++ b/prost/README.md
@@ -380,9 +380,9 @@ the `std` features in `prost` and `prost-types`:
 
 ```ignore
 [dependencies]
-prost = { version = "0.6", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.12.6", default-features = false, features = ["prost-derive"] }
 # Only necessary if using Protobuf well-known types:
-prost-types = { version = "0.6", default-features = false }
+prost-types = { version = "0.12.6", default-features = false }
 ```
 
 Additionally, configure `prost-build` to output `BTreeMap`s instead of `HashMap`s


### PR DESCRIPTION
- ci: Ensure both README are the same and prost version is correct
- docs: Update prost version in README
- build: Fix prepare-release.sh for README

Fixes #1053