### PR TITLE
`OpenEnum`: an enum to represent protobuf's enumeration field values

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -404,7 +404,7 @@ impl<'a> CodeGenerator<'a> {
 
     fn append_field(&mut self, fq_message_name: &str, field: &Field) {
         let type_ = field.descriptor.r#type();
-        let repeated = field.descriptor.label == Some(Label::Repeated as i32);
+        let repeated = field.descriptor.label.and_then(|v| v.known()) == Some(Label::Repeated);
         let deprecated = self.deprecated(&field.descriptor);
         let optional = self.optional(&field.descriptor);
         let boxed = self.boxed(&field.descriptor, fq_message_name, None);
@@ -958,7 +958,7 @@ impl<'a> CodeGenerator<'a> {
             Type::Double => String::from("f64"),
             Type::Uint32 | Type::Fixed32 => String::from("u32"),
             Type::Uint64 | Type::Fixed64 => String::from("u64"),
-            Type::Int32 | Type::Sfixed32 | Type::Sint32 | Type::Enum => String::from("i32"),
+            Type::Int32 | Type::Sfixed32 | Type::Sint32 => String::from("i32"),
             Type::Int64 | Type::Sfixed64 | Type::Sint64 => String::from("i64"),
             Type::Bool => String::from("bool"),
             Type::String => format!("{}::alloc::string::String", prost_path(self.config)),
@@ -971,6 +971,11 @@ impl<'a> CodeGenerator<'a> {
                 .rust_type()
                 .to_owned(),
             Type::Group | Type::Message => self.resolve_ident(field.type_name()),
+            Type::Enum => format!(
+                "{}::OpenEnum<{}>",
+                prost_path(self.config),
+                self.resolve_ident(field.type_name())
+            ),
         }
     }
 
@@ -1074,7 +1079,7 @@ impl<'a> CodeGenerator<'a> {
         fq_message_name: &str,
         oneof: Option<&str>,
     ) -> bool {
-        let repeated = field.label == Some(Label::Repeated as i32);
+        let repeated = field.label.and_then(|v| v.known()) == Some(Label::Repeated);
         let fd_type = field.r#type();
         if !repeated
             && (fd_type == Type::Message || fd_type == Type::Group)

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -132,13 +132,13 @@ impl Field {
         let module = self.map_ty.module();
         match &self.value_ty {
             ValueTy::Scalar(scalar::Ty::Enumeration(ty)) => {
-                let default = quote!(#ty::default() as i32);
+                let default = quote!(::prost::OpenEnum::from(#ty::default()));
                 quote! {
                     ::prost::encoding::#module::encode_with_default(
                         #ke,
                         #kl,
-                        ::prost::encoding::int32::encode,
-                        ::prost::encoding::int32::encoded_len,
+                        ::prost::encoding::enumeration::encode,
+                        ::prost::encoding::enumeration::encoded_len,
                         &(#default),
                         #tag,
                         &#ident,
@@ -184,11 +184,11 @@ impl Field {
         let module = self.map_ty.module();
         match &self.value_ty {
             ValueTy::Scalar(scalar::Ty::Enumeration(ty)) => {
-                let default = quote!(#ty::default() as i32);
+                let default = quote!(::prost::OpenEnum::from(#ty::default()));
                 quote! {
                     ::prost::encoding::#module::merge_with_default(
                         #km,
-                        ::prost::encoding::int32::merge,
+                        ::prost::encoding::enumeration::merge,
                         #default,
                         &mut #ident,
                         buf,
@@ -221,11 +221,11 @@ impl Field {
         let module = self.map_ty.module();
         match &self.value_ty {
             ValueTy::Scalar(scalar::Ty::Enumeration(ty)) => {
-                let default = quote!(#ty::default() as i32);
+                let default = quote!(::prost::OpenEnum::from(#ty::default()));
                 quote! {
                     ::prost::encoding::#module::encoded_len_with_default(
                         #kl,
-                        ::prost::encoding::int32::encoded_len,
+                        ::prost::encoding::enumeration::encoded_len,
                         &(#default),
                         #tag,
                         &#ident,
@@ -275,17 +275,11 @@ impl Field {
             Some(quote! {
                 #[doc=#get_doc]
                 pub fn #get(&self, key: #key_ref_ty) -> ::core::option::Option<#ty> {
-                    self.#ident.get(#take_ref key).cloned().and_then(|x| {
-                        let result: ::core::result::Result<#ty, _> = ::core::convert::TryFrom::try_from(x);
-                        result.ok()
-                    })
+                    self.#ident.get(#take_ref key).cloned().and_then(|x| { x.known() })
                 }
                 #[doc=#insert_doc]
                 pub fn #insert(&mut self, key: #key_ty, value: #ty) -> ::core::option::Option<#ty> {
-                    self.#ident.insert(key, value as i32).and_then(|x| {
-                        let result: ::core::result::Result<#ty, _> = ::core::convert::TryFrom::try_from(x);
-                        result.ok()
-                    })
+                    self.#ident.insert(key, value.into()).and_then(|x| { x.known() })
                 }
             })
         } else {

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -216,10 +216,10 @@ impl Field {
     fn debug_inner(&self, wrap_name: TokenStream) -> TokenStream {
         if let Ty::Enumeration(ref ty) = self.ty {
             quote! {
-                struct #wrap_name<'a>(&'a i32);
+                struct #wrap_name<'a>(&'a ::prost::OpenEnum<#ty>);
                 impl<'a> ::core::fmt::Debug for #wrap_name<'a> {
                     fn fmt(&self, f: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
-                        let res: ::core::result::Result<#ty, _> = ::core::convert::TryFrom::try_from(*self.0);
+                        let res = self.0.known_or(());
                         match res {
                             Err(_) => ::core::fmt::Debug::fmt(&self.0, f),
                             Ok(en) => ::core::fmt::Debug::fmt(&en, f),
@@ -297,12 +297,12 @@ impl Field {
                     quote! {
                         #[doc=#get_doc]
                         pub fn #get(&self) -> #ty {
-                            ::core::convert::TryFrom::try_from(self.#ident).unwrap_or(#default)
+                            self.#ident.unwrap_or(#default)
                         }
 
                         #[doc=#set_doc]
                         pub fn #set(&mut self, value: #ty) {
-                            self.#ident = value as i32;
+                            self.#ident = value.into();
                         }
                     }
                 }
@@ -315,15 +315,12 @@ impl Field {
                     quote! {
                         #[doc=#get_doc]
                         pub fn #get(&self) -> #ty {
-                            self.#ident.and_then(|x| {
-                                let result: ::core::result::Result<#ty, _> = ::core::convert::TryFrom::try_from(x);
-                                result.ok()
-                            }).unwrap_or(#default)
+                            self.#ident.and_then(|x| { x.known() }).unwrap_or(#default)
                         }
 
                         #[doc=#set_doc]
                         pub fn #set(&mut self, value: #ty) {
-                            self.#ident = ::core::option::Option::Some(value as i32);
+                            self.#ident = ::core::option::Option::Some(value.into());
                         }
                     }
                 }
@@ -334,20 +331,18 @@ impl Field {
                     );
                     let push = Ident::new(&format!("push_{}", ident_str), Span::call_site());
                     let push_doc = format!("Appends the provided enum value to `{}`.", ident_str);
+                    let wrapped_ty = quote!(::prost::OpenEnum<#ty>);
                     quote! {
                         #[doc=#iter_doc]
                         pub fn #get(&self) -> ::core::iter::FilterMap<
-                            ::core::iter::Cloned<::core::slice::Iter<i32>>,
-                            fn(i32) -> ::core::option::Option<#ty>,
+                            ::core::iter::Cloned<::core::slice::Iter<#wrapped_ty>>,
+                            fn(#wrapped_ty) -> ::core::option::Option<#ty>,
                         > {
-                            self.#ident.iter().cloned().filter_map(|x| {
-                                let result: ::core::result::Result<#ty, _> = ::core::convert::TryFrom::try_from(x);
-                                result.ok()
-                            })
+                            self.#ident.iter().cloned().filter_map(|x| { x.known() })
                         }
                         #[doc=#push_doc]
                         pub fn #push(&mut self, value: #ty) {
-                            self.#ident.push(value as i32);
+                            self.#ident.push(value.into());
                         }
                     }
                 }
@@ -533,13 +528,14 @@ impl Ty {
         match self {
             Ty::String => quote!(::prost::alloc::string::String),
             Ty::Bytes(ty) => ty.rust_type(),
+            Ty::Enumeration(path) => quote!(::prost::OpenEnum<#path>),
             _ => self.rust_ref_type(),
         }
     }
 
     // TODO: rename to 'ref_type'
     pub fn rust_ref_type(&self) -> TokenStream {
-        match *self {
+        match self {
             Ty::Double => quote!(f64),
             Ty::Float => quote!(f32),
             Ty::Int32 => quote!(i32),
@@ -555,13 +551,13 @@ impl Ty {
             Ty::Bool => quote!(bool),
             Ty::String => quote!(&str),
             Ty::Bytes(..) => quote!(&[u8]),
-            Ty::Enumeration(..) => quote!(i32),
+            Ty::Enumeration(..) => unreachable!("an enum should never be queried for its ref type"),
         }
     }
 
     pub fn module(&self) -> Ident {
         match *self {
-            Ty::Enumeration(..) => Ident::new("int32", Span::call_site()),
+            Ty::Enumeration(..) => Ident::new("enumeration", Span::call_site()),
             _ => Ident::new(self.as_str(), Span::call_site()),
         }
     }
@@ -799,7 +795,7 @@ impl DefaultValue {
 
     pub fn typed(&self) -> TokenStream {
         if let DefaultValue::Enumeration(_) = *self {
-            quote!(#self as i32)
+            quote!(::prost::OpenEnum::from(#self))
         } else {
             quote!(#self)
         }

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -120,11 +120,11 @@ pub struct FieldDescriptorProto {
     #[prost(int32, optional, tag = "3")]
     pub number: ::core::option::Option<i32>,
     #[prost(enumeration = "field_descriptor_proto::Label", optional, tag = "4")]
-    pub label: ::core::option::Option<i32>,
+    pub label: ::core::option::Option<::prost::OpenEnum<field_descriptor_proto::Label>>,
     /// If type_name is set, this need not be set.  If both this and type_name
     /// are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
     #[prost(enumeration = "field_descriptor_proto::Type", optional, tag = "5")]
-    pub r#type: ::core::option::Option<i32>,
+    pub r#type: ::core::option::Option<::prost::OpenEnum<field_descriptor_proto::Type>>,
     /// For message and enum types, this is the name of the type.  If the name
     /// starts with a '.', it is fully-qualified.  Otherwise, C++-like scoping
     /// rules are used to find the type (i.e. first the nested types within this
@@ -484,7 +484,9 @@ pub struct FileOptions {
         tag = "9",
         default = "Speed"
     )]
-    pub optimize_for: ::core::option::Option<i32>,
+    pub optimize_for: ::core::option::Option<
+        ::prost::OpenEnum<file_options::OptimizeMode>,
+    >,
     /// Sets the Go package where structs generated from this .proto will be
     /// placed. If omitted, the Go package will be derived from the following:
     ///
@@ -680,7 +682,7 @@ pub struct FieldOptions {
         tag = "1",
         default = "String"
     )]
-    pub ctype: ::core::option::Option<i32>,
+    pub ctype: ::core::option::Option<::prost::OpenEnum<field_options::CType>>,
     /// The packed option can be enabled for repeated primitive fields to enable
     /// a more efficient representation on the wire. Rather than repeatedly
     /// writing the tag and type for each element, the entire array is encoded as
@@ -705,7 +707,7 @@ pub struct FieldOptions {
         tag = "6",
         default = "JsNormal"
     )]
-    pub jstype: ::core::option::Option<i32>,
+    pub jstype: ::core::option::Option<::prost::OpenEnum<field_options::JsType>>,
     /// Should this field be parsed lazily?  Lazy applies only to message-type
     /// fields.  It means that when the outer message is initially parsed, the
     /// inner message's contents will not be parsed but instead stored in encoded
@@ -898,7 +900,9 @@ pub struct MethodOptions {
         tag = "34",
         default = "IdempotencyUnknown"
     )]
-    pub idempotency_level: ::core::option::Option<i32>,
+    pub idempotency_level: ::core::option::Option<
+        ::prost::OpenEnum<method_options::IdempotencyLevel>,
+    >,
     /// The parser stores options it doesn't recognize here. See above.
     #[prost(message, repeated, tag = "999")]
     pub uninterpreted_option: ::prost::alloc::vec::Vec<UninterpretedOption>,
@@ -1332,7 +1336,7 @@ pub struct Type {
     pub source_context: ::core::option::Option<SourceContext>,
     /// The source syntax.
     #[prost(enumeration = "Syntax", tag = "6")]
-    pub syntax: i32,
+    pub syntax: ::prost::OpenEnum<Syntax>,
 }
 /// A single field of a message type.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1340,10 +1344,10 @@ pub struct Type {
 pub struct Field {
     /// The field type.
     #[prost(enumeration = "field::Kind", tag = "1")]
-    pub kind: i32,
+    pub kind: ::prost::OpenEnum<field::Kind>,
     /// The field cardinality.
     #[prost(enumeration = "field::Cardinality", tag = "2")]
-    pub cardinality: i32,
+    pub cardinality: ::prost::OpenEnum<field::Cardinality>,
     /// The field number.
     #[prost(int32, tag = "3")]
     pub number: i32,
@@ -1546,7 +1550,7 @@ pub struct Enum {
     pub source_context: ::core::option::Option<SourceContext>,
     /// The source syntax.
     #[prost(enumeration = "Syntax", tag = "5")]
-    pub syntax: i32,
+    pub syntax: ::prost::OpenEnum<Syntax>,
 }
 /// Enum value definition.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1661,7 +1665,7 @@ pub struct Api {
     pub mixins: ::prost::alloc::vec::Vec<Mixin>,
     /// The source syntax of the service.
     #[prost(enumeration = "Syntax", tag = "7")]
-    pub syntax: i32,
+    pub syntax: ::prost::OpenEnum<Syntax>,
 }
 /// Method represents a method of an API interface.
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -1687,7 +1691,7 @@ pub struct Method {
     pub options: ::prost::alloc::vec::Vec<Option>,
     /// The source syntax of this method.
     #[prost(enumeration = "Syntax", tag = "7")]
-    pub syntax: i32,
+    pub syntax: ::prost::OpenEnum<Syntax>,
 }
 /// Declares an API Interface to be included in this interface. The including
 /// interface must redeclare all the methods from the included interface, but
@@ -2137,7 +2141,7 @@ pub mod value {
     pub enum Kind {
         /// Represents a null value.
         #[prost(enumeration = "super::NullValue", tag = "1")]
-        NullValue(i32),
+        NullValue(::prost::OpenEnum<super::NullValue>),
         /// Represents a double value.
         #[prost(double, tag = "2")]
         NumberValue(f64),

--- a/prost/src/encoding.rs
+++ b/prost/src/encoding.rs
@@ -721,6 +721,128 @@ fixed_width!(
     get_i64_le
 );
 
+pub mod enumeration {
+    use super::*;
+    use crate::OpenEnum;
+
+    pub fn encode<T, B>(tag: u32, value: &OpenEnum<T>, buf: &mut B)
+    where
+        T: Clone + Into<i32>,
+        B: BufMut,
+    {
+        int32::encode(tag, &value.to_raw(), buf)
+    }
+
+    pub fn merge<T, B>(
+        wire_type: WireType,
+        value: &mut OpenEnum<T>,
+        buf: &mut B,
+        _ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        i32: TryInto<T>,
+        B: Buf,
+    {
+        let mut raw = 0;
+        int32::merge(wire_type, &mut raw, buf, DecodeContext::default())?;
+        *value = OpenEnum::from_raw(raw);
+        Ok(())
+    }
+
+    pub fn encode_repeated<T, B>(tag: u32, values: &[OpenEnum<T>], buf: &mut B)
+    where
+        T: Clone + Into<i32>,
+        B: BufMut,
+    {
+        for value in values {
+            encode(tag, value, buf);
+        }
+    }
+
+    pub fn encode_packed<T, B>(tag: u32, values: &[OpenEnum<T>], buf: &mut B)
+    where
+        T: Clone + Into<i32>,
+        B: BufMut,
+    {
+        if values.is_empty() {
+            return;
+        }
+
+        encode_key(tag, WireType::LengthDelimited, buf);
+        let len: usize = values
+            .iter()
+            .map(|value| encoded_len_varint(value.to_raw() as u64))
+            .sum();
+        encode_varint(len as u64, buf);
+
+        for value in values {
+            encode_varint(value.to_raw() as u64, buf);
+        }
+    }
+
+    pub fn merge_repeated<T, B>(
+        wire_type: WireType,
+        values: &mut Vec<OpenEnum<T>>,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        T: Default,
+        i32: TryInto<T>,
+        B: Buf,
+    {
+        if wire_type == WireType::LengthDelimited {
+            // Packed.
+            merge_loop(values, buf, ctx, |values, buf, ctx| {
+                let mut value = Default::default();
+                merge(WireType::Varint, &mut value, buf, ctx)?;
+                values.push(value);
+                Ok(())
+            })
+        } else {
+            // Unpacked.
+            check_wire_type(WireType::Varint, wire_type)?;
+            let mut value = Default::default();
+            merge(wire_type, &mut value, buf, ctx)?;
+            values.push(value);
+            Ok(())
+        }
+    }
+
+    pub fn encoded_len<T>(tag: u32, value: &OpenEnum<T>) -> usize
+    where
+        T: Clone + Into<i32>,
+    {
+        int32::encoded_len(tag, &value.to_raw())
+    }
+
+    pub fn encoded_len_repeated<T>(tag: u32, values: &[OpenEnum<T>]) -> usize
+    where
+        T: Clone + Into<i32>,
+    {
+        key_len(tag) * values.len()
+            + values
+                .iter()
+                .map(|value| encoded_len_varint(value.to_raw() as u64))
+                .sum::<usize>()
+    }
+
+    pub fn encoded_len_packed<T>(tag: u32, values: &[OpenEnum<T>]) -> usize
+    where
+        T: Clone + Into<i32>,
+    {
+        if values.is_empty() {
+            0
+        } else {
+            let len = values
+                .iter()
+                .map(|value| encoded_len_varint(value.to_raw() as u64))
+                .sum::<usize>();
+            key_len(tag) + encoded_len_varint(len as u64) + len
+        }
+    }
+}
+
 /// Macro which emits encoding functions for a length-delimited type.
 macro_rules! length_delimited {
     ($ty:ty) => {

--- a/prost/src/lib.rs
+++ b/prost/src/lib.rs
@@ -12,6 +12,7 @@ pub use bytes;
 mod error;
 mod message;
 mod name;
+mod open_enum;
 mod types;
 
 #[doc(hidden)]
@@ -20,6 +21,7 @@ pub mod encoding;
 pub use crate::error::{DecodeError, EncodeError, UnknownEnumValue};
 pub use crate::message::Message;
 pub use crate::name::Name;
+pub use crate::open_enum::OpenEnum;
 
 use bytes::{Buf, BufMut};
 

--- a/prost/src/open_enum.rs
+++ b/prost/src/open_enum.rs
@@ -1,0 +1,150 @@
+use crate::encoding::{DecodeContext, WireType};
+use crate::{DecodeError, Message};
+
+use bytes::{Buf, BufMut};
+
+use core::fmt::Debug;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum OpenEnum<T> {
+    Known(T),
+    Unknown(i32),
+}
+
+impl<T> Default for OpenEnum<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Self::Known(T::default())
+    }
+}
+
+impl<T> From<T> for OpenEnum<T> {
+    fn from(value: T) -> Self {
+        Self::Known(value)
+    }
+}
+
+impl<T> OpenEnum<T> {
+    pub fn from_raw(value: i32) -> Self
+    where
+        i32: TryInto<T>,
+    {
+        match value.try_into() {
+            Ok(v) => Self::Known(v),
+            Err(_) => Self::Unknown(value),
+        }
+    }
+
+    pub fn into_raw(self) -> i32
+    where
+        T: Into<i32>,
+    {
+        match self {
+            Self::Known(v) => v.into(),
+            Self::Unknown(v) => v,
+        }
+    }
+
+    pub fn to_raw(&self) -> i32
+    where
+        T: Clone + Into<i32>,
+    {
+        match self {
+            Self::Known(v) => v.clone().into(),
+            Self::Unknown(v) => *v,
+        }
+    }
+}
+
+impl<T> OpenEnum<T> {
+    pub fn unwrap(self) -> T {
+        match self {
+            Self::Known(v) => v,
+            Self::Unknown(v) => panic!("unknown field value {}", v),
+        }
+    }
+
+    pub fn unwrap_or(self, default: T) -> T {
+        match self {
+            Self::Known(v) => v,
+            Self::Unknown(_) => default,
+        }
+    }
+
+    pub fn unwrap_or_else<F>(self, f: F) -> T
+    where
+        F: FnOnce(i32) -> T,
+    {
+        match self {
+            Self::Known(v) => v,
+            Self::Unknown(v) => f(v),
+        }
+    }
+
+    pub fn unwrap_or_default(self) -> T
+    where
+        T: Default,
+    {
+        match self {
+            Self::Known(v) => v,
+            Self::Unknown(_) => T::default(),
+        }
+    }
+
+    pub fn known(self) -> Option<T> {
+        match self {
+            Self::Known(v) => Some(v),
+            Self::Unknown(_) => None,
+        }
+    }
+
+    pub fn known_or<E>(self, err: E) -> Result<T, E> {
+        match self {
+            Self::Known(v) => Ok(v),
+            Self::Unknown(_) => Err(err),
+        }
+    }
+
+    pub fn known_or_else<E, F>(self, err: F) -> Result<T, E>
+    where
+        F: FnOnce(i32) -> E,
+    {
+        match self {
+            Self::Known(v) => Ok(v),
+            Self::Unknown(v) => Err(err(v)),
+        }
+    }
+}
+
+impl<T> Message for OpenEnum<T>
+where
+    T: Clone + Into<i32> + Debug + Send + Sync,
+    i32: TryInto<T>,
+{
+    fn encoded_len(&self) -> usize {
+        self.to_raw().encoded_len()
+    }
+
+    fn encode_raw(&self, buf: &mut impl BufMut) {
+        self.to_raw().encode_raw(buf)
+    }
+
+    fn merge_field(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut impl Buf,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError> {
+        let mut raw = 0;
+        <i32 as Message>::merge_field(&mut raw, tag, wire_type, buf, ctx)?;
+        *self = OpenEnum::from_raw(raw);
+        Ok(())
+    }
+
+    fn clear(&mut self) {
+        *self = OpenEnum::from_raw(0);
+    }
+}

--- a/tests/src/bootstrap.rs
+++ b/tests/src/bootstrap.rs
@@ -92,6 +92,8 @@ fn bootstrap() {
             .unwrap();
     }
 
+    let _ = tempdir.into_path();
+
     assert_eq!(protobuf, bootstrapped_protobuf);
     assert_eq!(compiler, bootstrapped_compiler);
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -330,7 +330,7 @@ mod tests {
                 t: BTreeMap::<i32, foo::bar_baz::FooBarBaz>::new(),
                 nested_self: None,
             }],
-            p_i_e: 0,
+            p_i_e: foo::bar_baz::foo_bar_baz::StrawberryRhubarbPie::Foo.into(),
             r#as: 4,
             r#break: 5,
             r#const: 6,

--- a/tests/src/message_encoding.rs
+++ b/tests/src/message_encoding.rs
@@ -3,6 +3,7 @@ use prost::alloc::vec;
 use prost::alloc::{borrow::ToOwned, string::String, vec::Vec};
 
 use prost::bytes::Bytes;
+use prost::OpenEnum;
 use prost::{Enumeration, Message, Oneof};
 
 use crate::check_message;
@@ -216,7 +217,7 @@ fn check_tags_inferred() {
         two: Some(42),
         three: vec![0.0, 1.0, 1.0],
         skip_to_nine: "nine".to_owned(),
-        ten: 0,
+        ten: BasicEnumeration::ZERO.into(),
         eleven: ::alloc::collections::BTreeMap::new(),
         back_to_five: vec![1, 0, 1],
         six: Basic::default(),
@@ -230,7 +231,7 @@ fn check_tags_inferred() {
         five: vec![1, 0, 1],
         six: Basic::default(),
         nine: "nine".to_owned(),
-        ten: 0,
+        ten: BasicEnumeration::ZERO.into(),
         eleven: ::alloc::collections::BTreeMap::new(),
     };
     check_serialize_equivalent(&tags_inferred, &tags_qualified);
@@ -249,7 +250,7 @@ pub struct TagsInferred {
     #[prost(tag = "9", string, required)]
     pub skip_to_nine: String,
     #[prost(enumeration = "BasicEnumeration", default = "ONE")]
-    pub ten: i32,
+    pub ten: OpenEnum<BasicEnumeration>,
     #[prost(btree_map = "string, string")]
     pub eleven: ::alloc::collections::BTreeMap<String, String>,
 
@@ -277,7 +278,7 @@ pub struct TagsQualified {
     #[prost(tag = "9", string, required)]
     pub nine: String,
     #[prost(tag = "10", enumeration = "BasicEnumeration", default = "ONE")]
-    pub ten: i32,
+    pub ten: OpenEnum<BasicEnumeration>,
     #[prost(tag = "11", btree_map = "string, string")]
     pub eleven: ::alloc::collections::BTreeMap<String, String>,
 }
@@ -302,13 +303,13 @@ pub struct DefaultValues {
     pub bytes_buf: Bytes,
 
     #[prost(enumeration = "BasicEnumeration", tag = "4", default = "ONE")]
-    pub enumeration: i32,
+    pub enumeration: OpenEnum<BasicEnumeration>,
 
     #[prost(enumeration = "BasicEnumeration", optional, tag = "5", default = "TWO")]
-    pub optional_enumeration: Option<i32>,
+    pub optional_enumeration: Option<OpenEnum<BasicEnumeration>>,
 
     #[prost(enumeration = "BasicEnumeration", repeated, tag = "6")]
-    pub repeated_enumeration: Vec<i32>,
+    pub repeated_enumeration: Vec<OpenEnum<BasicEnumeration>>,
 }
 
 #[test]
@@ -319,7 +320,7 @@ fn check_default_values() {
     assert_eq!(&default.string, "forty two");
     assert_eq!(&default.bytes_vec.as_ref(), b"foo\0bar");
     assert_eq!(&default.bytes_buf.as_ref(), b"foo\0bar");
-    assert_eq!(default.enumeration, BasicEnumeration::ONE as i32);
+    assert_eq!(default.enumeration, BasicEnumeration::ONE.into());
     assert_eq!(default.optional_enumeration, None);
     assert_eq!(&default.repeated_enumeration, &[]);
     assert_eq!(0, default.encoded_len());
@@ -351,18 +352,18 @@ pub struct Basic {
     pub optional_string: Option<String>,
 
     #[prost(enumeration = "BasicEnumeration", tag = "5")]
-    pub enumeration: i32,
+    pub enumeration: OpenEnum<BasicEnumeration>,
 
     #[prost(map = "int32, enumeration(BasicEnumeration)", tag = "6")]
     #[cfg(feature = "std")]
-    pub enumeration_map: ::std::collections::HashMap<i32, i32>,
+    pub enumeration_map: ::std::collections::HashMap<i32, OpenEnum<BasicEnumeration>>,
 
     #[prost(hash_map = "string, string", tag = "7")]
     #[cfg(feature = "std")]
     pub string_map: ::std::collections::HashMap<String, String>,
 
     #[prost(btree_map = "int32, enumeration(BasicEnumeration)", tag = "10")]
-    pub enumeration_btree_map: prost::alloc::collections::BTreeMap<i32, i32>,
+    pub enumeration_btree_map: prost::alloc::collections::BTreeMap<i32, OpenEnum<BasicEnumeration>>,
 
     #[prost(btree_map = "string, string", tag = "11")]
     pub string_btree_map: prost::alloc::collections::BTreeMap<String, String>,

--- a/tests/src/skip_debug.rs
+++ b/tests/src/skip_debug.rs
@@ -5,6 +5,7 @@ use std::fmt;
 use prost::alloc::format;
 #[cfg(not(feature = "std"))]
 use prost::alloc::string::String;
+use prost::OpenEnum;
 
 use crate::custom_debug::{msg, AnEnum, Msg};
 use crate::message_encoding::BasicEnumeration;
@@ -14,17 +15,22 @@ use crate::message_encoding::BasicEnumeration;
 fn tuple_struct_custom_debug() {
     #[derive(Clone, PartialEq, prost::Message)]
     #[prost(skip_debug)]
-    struct NewType(#[prost(enumeration = "BasicEnumeration", tag = "5")] i32);
+    struct NewType(
+        #[prost(enumeration = "BasicEnumeration", tag = "5")] OpenEnum<BasicEnumeration>,
+    );
     impl fmt::Debug for NewType {
         fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
             f.write_str("NewType(custom_debug)")
         }
     }
     assert_eq!(
-        format!("{:?}", NewType(BasicEnumeration::TWO as i32)),
+        format!("{:?}", NewType(BasicEnumeration::TWO.into())),
         "NewType(custom_debug)"
     );
-    assert_eq!(format!("{:?}", NewType(42)), "NewType(custom_debug)");
+    assert_eq!(
+        format!("{:?}", NewType(OpenEnum::from_raw(42))),
+        "NewType(custom_debug)"
+    );
 }
 
 #[allow(clippy::derive_partial_eq_without_eq)]
@@ -36,7 +42,7 @@ pub enum OneofWithEnumCustomDebug {
     #[prost(string, tag = "9")]
     String(String),
     #[prost(enumeration = "BasicEnumeration", tag = "10")]
-    Enumeration(i32),
+    Enumeration(OpenEnum<BasicEnumeration>),
 }
 
 #[derive(Clone, PartialEq, prost::Message)]
@@ -57,7 +63,7 @@ impl fmt::Debug for MessageWithOneofCustomDebug {
 fn oneof_with_enum_custom_debug() {
     let msg = MessageWithOneofCustomDebug {
         of: Some(OneofWithEnumCustomDebug::Enumeration(
-            BasicEnumeration::TWO as i32,
+            BasicEnumeration::TWO.into(),
         )),
     };
     assert_eq!(format!("{:?}", msg), "MessageWithOneofCustomDebug {..}");
@@ -69,7 +75,7 @@ fn test_proto_msg_custom_debug() {
     let msg = Msg {
         a: 0,
         b: "".to_string(),
-        c: Some(msg::C::D(AnEnum::A as i32)),
+        c: Some(msg::C::D(AnEnum::A.into())),
     };
     assert_eq!(format!("{:?}", msg), "Msg {..}");
 }


### PR DESCRIPTION
Another solution for #276, amenable to destructuring.