### PR TITLE
Allow encode BufMut arg to be unsized

### DIFF
--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -175,7 +175,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     let expanded = quote! {
         impl #impl_generics ::prost::Message for #ident #ty_generics #where_clause {
             #[allow(unused_variables)]
-            fn encode_raw(&self, buf: &mut impl ::prost::bytes::BufMut) {
+            fn encode_raw(&self, buf: &mut (impl ::prost::bytes::BufMut + ?Sized)) {
                 #(#encode)*
             }
 
@@ -462,7 +462,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
     let expanded = quote! {
         impl #impl_generics #ident #ty_generics #where_clause {
             /// Encodes the message to a buffer.
-            pub fn encode(&self, buf: &mut impl ::prost::bytes::BufMut) {
+            pub fn encode(&self, buf: &mut (impl ::prost::bytes::BufMut + ?Sized)) {
                 match *self {
                     #(#encode,)*
                 }

--- a/prost/src/lib.rs
+++ b/prost/src/lib.rs
@@ -36,7 +36,7 @@ const RECURSION_LIMIT: u32 = 100;
 ///
 /// An error will be returned if the buffer does not have sufficient capacity to encode the
 /// delimiter.
-pub fn encode_length_delimiter(length: usize, buf: &mut impl BufMut) -> Result<(), EncodeError> {
+pub fn encode_length_delimiter(length: usize, buf: &mut (impl BufMut + ?Sized)) -> Result<(), EncodeError> {
     let length = length as u64;
     let required = encoded_len_varint(length);
     let remaining = buf.remaining_mut();

--- a/prost/src/lib.rs
+++ b/prost/src/lib.rs
@@ -36,7 +36,10 @@ const RECURSION_LIMIT: u32 = 100;
 ///
 /// An error will be returned if the buffer does not have sufficient capacity to encode the
 /// delimiter.
-pub fn encode_length_delimiter(length: usize, buf: &mut (impl BufMut + ?Sized)) -> Result<(), EncodeError> {
+pub fn encode_length_delimiter(
+    length: usize,
+    buf: &mut (impl BufMut + ?Sized),
+) -> Result<(), EncodeError> {
     let length = length as u64;
     let required = encoded_len_varint(length);
     let remaining = buf.remaining_mut();

--- a/prost/src/message.rs
+++ b/prost/src/message.rs
@@ -21,7 +21,7 @@ pub trait Message: Debug + Send + Sync {
     ///
     /// Meant to be used only by `Message` implementations.
     #[doc(hidden)]
-    fn encode_raw(&self, buf: &mut impl BufMut)
+    fn encode_raw(&self, buf: &mut (impl BufMut + ?Sized))
     where
         Self: Sized;
 
@@ -45,7 +45,7 @@ pub trait Message: Debug + Send + Sync {
     /// Encodes the message to a buffer.
     ///
     /// An error will be returned if the buffer does not have sufficient capacity.
-    fn encode(&self, buf: &mut impl BufMut) -> Result<(), EncodeError>
+    fn encode(&self, buf: &mut (impl BufMut + ?Sized)) -> Result<(), EncodeError>
     where
         Self: Sized,
     {
@@ -73,7 +73,7 @@ pub trait Message: Debug + Send + Sync {
     /// Encodes the message with a length-delimiter to a buffer.
     ///
     /// An error will be returned if the buffer does not have sufficient capacity.
-    fn encode_length_delimited(&self, buf: &mut impl BufMut) -> Result<(), EncodeError>
+    fn encode_length_delimited(&self, buf: &mut (impl BufMut + ?Sized)) -> Result<(), EncodeError>
     where
         Self: Sized,
     {
@@ -159,7 +159,7 @@ impl<M> Message for Box<M>
 where
     M: Message,
 {
-    fn encode_raw(&self, buf: &mut impl BufMut) {
+    fn encode_raw(&self, buf: &mut (impl BufMut + ?Sized)) {
         (**self).encode_raw(buf)
     }
     fn merge_field(

--- a/prost/src/types.rs
+++ b/prost/src/types.rs
@@ -22,7 +22,7 @@ use crate::{
 
 /// `google.protobuf.BoolValue`
 impl Message for bool {
-    fn encode_raw(&self, buf: &mut impl BufMut) {
+    fn encode_raw(&self, buf: &mut (impl BufMut + ?Sized)) {
         if *self {
             bool::encode(1, self, buf)
         }
@@ -54,7 +54,7 @@ impl Message for bool {
 
 /// `google.protobuf.UInt32Value`
 impl Message for u32 {
-    fn encode_raw(&self, buf: &mut impl BufMut) {
+    fn encode_raw(&self, buf: &mut (impl BufMut + ?Sized)) {
         if *self != 0 {
             uint32::encode(1, self, buf)
         }
@@ -86,7 +86,7 @@ impl Message for u32 {
 
 /// `google.protobuf.UInt64Value`
 impl Message for u64 {
-    fn encode_raw(&self, buf: &mut impl BufMut) {
+    fn encode_raw(&self, buf: &mut (impl BufMut + ?Sized)) {
         if *self != 0 {
             uint64::encode(1, self, buf)
         }
@@ -118,7 +118,7 @@ impl Message for u64 {
 
 /// `google.protobuf.Int32Value`
 impl Message for i32 {
-    fn encode_raw(&self, buf: &mut impl BufMut) {
+    fn encode_raw(&self, buf: &mut (impl BufMut + ?Sized)) {
         if *self != 0 {
             int32::encode(1, self, buf)
         }
@@ -150,7 +150,7 @@ impl Message for i32 {
 
 /// `google.protobuf.Int64Value`
 impl Message for i64 {
-    fn encode_raw(&self, buf: &mut impl BufMut) {
+    fn encode_raw(&self, buf: &mut (impl BufMut + ?Sized)) {
         if *self != 0 {
             int64::encode(1, self, buf)
         }
@@ -182,7 +182,7 @@ impl Message for i64 {
 
 /// `google.protobuf.FloatValue`
 impl Message for f32 {
-    fn encode_raw(&self, buf: &mut impl BufMut) {
+    fn encode_raw(&self, buf: &mut (impl BufMut + ?Sized)) {
         if *self != 0.0 {
             float::encode(1, self, buf)
         }
@@ -214,7 +214,7 @@ impl Message for f32 {
 
 /// `google.protobuf.DoubleValue`
 impl Message for f64 {
-    fn encode_raw(&self, buf: &mut impl BufMut) {
+    fn encode_raw(&self, buf: &mut (impl BufMut + ?Sized)) {
         if *self != 0.0 {
             double::encode(1, self, buf)
         }
@@ -246,7 +246,7 @@ impl Message for f64 {
 
 /// `google.protobuf.StringValue`
 impl Message for String {
-    fn encode_raw(&self, buf: &mut impl BufMut) {
+    fn encode_raw(&self, buf: &mut (impl BufMut + ?Sized)) {
         if !self.is_empty() {
             string::encode(1, self, buf)
         }
@@ -278,7 +278,7 @@ impl Message for String {
 
 /// `google.protobuf.BytesValue`
 impl Message for Vec<u8> {
-    fn encode_raw(&self, buf: &mut impl BufMut) {
+    fn encode_raw(&self, buf: &mut (impl BufMut + ?Sized)) {
         if !self.is_empty() {
             bytes::encode(1, self, buf)
         }
@@ -310,7 +310,7 @@ impl Message for Vec<u8> {
 
 /// `google.protobuf.BytesValue`
 impl Message for Bytes {
-    fn encode_raw(&self, buf: &mut impl BufMut) {
+    fn encode_raw(&self, buf: &mut (impl BufMut + ?Sized)) {
         if !self.is_empty() {
             bytes::encode(1, self, buf)
         }
@@ -342,7 +342,7 @@ impl Message for Bytes {
 
 /// `google.protobuf.Empty`
 impl Message for () {
-    fn encode_raw(&self, _buf: &mut impl BufMut) {}
+    fn encode_raw(&self, _buf: &mut (impl BufMut + ?Sized)) {}
     fn merge_field(
         &mut self,
         tag: u32,


### PR DESCRIPTION
This means it's possible to pass in a `&mut dyn BufMut`

This allows for creating a custom "zero-copy" implementor of `Message` for bytes fields which are themselves encoded protobuf values as follows (useful when trying to model generics with protobuf):

```
trait MySerializer {
  fn serialize_to(&self, b: &mut dyn BufMut);
  fn encoded_len(&self) -> usize;
}

/// message MessageValue {
///   bytes serialized_value = 1;
/// }
#[derive_where(Debug)]
pub enum MessageValue {
    Empty,
    Encoding(#[derive_where(skip)] Arc<dyn MySerializer>),
    Decoding(#[derive_where(skip)] Bytes),
}

impl From<Arc<dyn MySerializer>> for MessageValue {
    fn from(val: Arc<dyn MySerializer>) -> Self {
        MessageValue::Encoding(val)
    }
}

impl Message for MessageValue {
    fn encode_raw<B>(&self, mut buf: &mut (impl bytes::BufMut + ?Sized))
    where
        Self: Sized,
    {
        match self {
            MessageValue::Empty => (),
            MessageValue::Encoding(val) => {
                encode_metadata(val.encoded_len(), buf);
                val.serialize_to(&mut buf);
            }
            MessageValue::Decoding(val) => {
                encode_metadata(val.len(), buf);
                buf.put_slice(&val)
            }
        }
    }

    fn merge_field<B>(
        &mut self,
        tag: u32,
        wire_type: WireType,
        buf: &mut B,
        _ctx: DecodeContext,
    ) -> Result<(), prost::DecodeError>
    where
        B: bytes::Buf,
        Self: Sized,
    {
        if tag != 1 {
            return Ok(());
        }
        if wire_type != WireType::LengthDelimited {
            return Err(prost::DecodeError::new(format!(
                "invalid wire type; expected length delimited, got {wire_type:?}"
            )));
        }
        let len = prost::encoding::decode_varint(buf)?;
        *self = MessageValue::Decoding(buf.copy_to_bytes(len as usize));
        Ok(())
    }

    fn encoded_len(&self) -> usize {
        match self {
            MessageValue::Empty => 0,
            MessageValue::Encoding(val) => message_len_from_byte_len(val.encoded_len()),
            MessageValue::Decoding(val) => message_len_from_byte_len(val.len()),
        }
    }

    fn clear(&mut self) {
        *self = Self::Empty;
    }
}

fn encode_metadata(encoded_len: usize, buf: &mut impl bytes::BufMut) {
    prost::encoding::encode_key(1, prost::encoding::WireType::LengthDelimited, buf);
    prost::encoding::encode_varint(encoded_len as u64, buf);
}

fn message_len_from_byte_len(encoded_len: usize) -> usize {
    1 + prost::encoding::encoded_len_varint(encoded_len as u64) + encoded_len
}
```

This change won't break compilation for existing uses of `prost-build`, but custom implementations will have to add the `+ ?Sized` param, so it's not fully backwards-compatible