### PR TITLE
build: Add features `edition-2015` and `std` to all tests crates

### DIFF
--- a/tests-2018/Cargo.toml
+++ b/tests-2018/Cargo.toml
@@ -17,6 +17,9 @@ path = "../tests/src/lib.rs"
 [features]
 default = ["std"]
 std = []
+# This crate shares code with `tests-2015` crate. Define this feature, but 
+# never enable it for this crate.
+edition-2015 = []
 
 [dependencies]
 anyhow = "1.0.1"

--- a/tests-no-std/Cargo.toml
+++ b/tests-no-std/Cargo.toml
@@ -7,6 +7,15 @@ authors.workspace = true
 
 build = "../tests/src/build.rs"
 
+[features]
+default = []
+# This crate shares code with `tests-2015` crate. Define this feature, but 
+# never enable it for this crate.
+edition-2015 = []
+# This crate shares code with `tests` crate. Define this feature, but 
+# never enable it for this crate.
+std = []
+
 [lib]
 doctest = false
 path = "../tests/src/lib.rs"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,6 +10,9 @@ build = "src/build.rs"
 [features]
 default = ["std"]
 std = []
+# This crate shares code with `tests-2015` crate. Define this feature, but 
+# never enable it for this crate.
+edition-2015 = []
 
 [dependencies]
 anyhow = "1.0.1"


### PR DESCRIPTION
Only the crate `tests-2015` uses the feature `edition-2015` but the code is shared with the other tests crates variants.

Same for `tests-no-std` which disables feature `std` but reuses the code with the `tests` crate.

Therefore all tests crates should define all features, but not enable it.

Cargo clippy reports:
```
warning: unexpected `cfg` condition value: `edition-2015`
 --> tests-no-std/../tests/src/build.rs:5:14
  |
5 |     if #[cfg(feature = "edition-2015")] {
  |              ^^^^^^^-----------------
  |              |
  |              help: remove the condition
  |
  = note: no expected values for `feature`
  = help: consider adding `edition-2015` as a feature in `Cargo.toml`
  = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
  = note: `#[warn(unexpected_cfgs)]` on by default
```