### PR TITLE
style: Remove use of legacy numeric constants

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   PROTOC_VERSION: 3.20.3
-  clippy_rust_version: 1.78
+  clippy_rust_version: 1.79
 
 jobs:
   # Depends on all actions that are required for a "successful" CI run.

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -22,8 +22,6 @@ mod protobuf;
 
 use core::convert::TryFrom;
 use core::fmt;
-use core::i32;
-use core::i64;
 use core::str::FromStr;
 use core::time;
 

--- a/prost/src/encoding.rs
+++ b/prost/src/encoding.rs
@@ -11,8 +11,6 @@ use alloc::vec::Vec;
 use core::cmp::min;
 use core::mem;
 use core::str;
-use core::u32;
-use core::usize;
 
 use ::bytes::{Buf, BufMut, Bytes};
 
@@ -1350,7 +1348,6 @@ mod test {
     use alloc::string::ToString;
     use core::borrow::Borrow;
     use core::fmt::Debug;
-    use core::u64;
 
     use ::bytes::BytesMut;
     use proptest::{prelude::*, test_runner::TestCaseResult};

--- a/prost/src/lib.rs
+++ b/prost/src/lib.rs
@@ -68,7 +68,7 @@ pub fn length_delimiter_len(length: usize) -> usize {
 ///    delimiter, and typically the buffer should be considered corrupt.
 pub fn decode_length_delimiter(mut buf: impl Buf) -> Result<usize, DecodeError> {
     let length = decode_varint(&mut buf)?;
-    if length > usize::max_value() as u64 {
+    if length > usize::MAX as u64 {
         return Err(DecodeError::new(
             "length delimiter exceeds maximum usize value",
         ));


### PR DESCRIPTION
Cargo clippy reports:

```
warning: usage of a legacy numeric method
  --> prost/src/lib.rs:71:24
   |
71 |     if length > usize::max_value() as u64 {
   |                        ^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#legacy_numeric_constants
help: use the associated constant instead
   |
71 |     if length > usize::MAX as u64 {
   |                        ~~~
```