### PR TITLE
build: Fix prepare-release.sh

### DIFF
--- a/prepare-release.sh
+++ b/prepare-release.sh
@@ -14,6 +14,7 @@ fi
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 VERSION="$1"
+MINOR="$( echo ${VERSION} | cut -d\. -f1-2 )"
 
 VERSION_MATCHER="([a-z0-9\\.-]+)"
 PROST_CRATE_MATCHER="(prost|prost-[a-z]+)"
@@ -21,6 +22,8 @@ PROST_CRATE_MATCHER="(prost|prost-[a-z]+)"
 # Update the README.md.
 sed -i -E "s/version = \"${VERSION_MATCHER}\"/version = \"${VERSION}\"/" "$DIR/README.md"
 sed -i -E "s/version = \"${VERSION_MATCHER}\"/version = \"${VERSION}\"/" "$DIR/prost/README.md"
+sed -i -E "s/${PROST_CRATE_MATCHER} = \"${VERSION_MATCHER}\"/\1 = \"${MINOR}\"/" "$DIR/README.md"
+sed -i -E "s/${PROST_CRATE_MATCHER} = \"${VERSION_MATCHER}\"/\1 = \"${MINOR}\"/" "$DIR/prost/README.md"
 
 # Update html_root_url attributes.
 sed -i -E "s~html_root_url = \"https://docs\.rs/${PROST_CRATE_MATCHER}/$VERSION_MATCHER\"~html_root_url = \"https://docs.rs/\1/${VERSION}\"~" \
@@ -31,10 +34,7 @@ sed -i -E "s~html_root_url = \"https://docs\.rs/${PROST_CRATE_MATCHER}/$VERSION_
 
 # Update Cargo.toml version fields.
 sed -i -E "s/^version = \"${VERSION_MATCHER}\"$/version = \"${VERSION}\"/" \
-  "$DIR/prost/Cargo.toml" \
-  "$DIR/prost-derive/Cargo.toml" \
-  "$DIR/prost-build/Cargo.toml" \
-  "$DIR/prost-types/Cargo.toml"
+  "$DIR/Cargo.toml"
 
 # Update Cargo.toml dependency versions.
 sed -i -E "s/^${PROST_CRATE_MATCHER} = \{ version = \"${VERSION_MATCHER}\"/\1 = { version = \"${VERSION}\"/" \


### PR DESCRIPTION
The prepare release script got out of sync with the actual code.
- Automatically update the minor version in the readme
- Cargo.toml version was moved in #1036