### PR TITLE
fix(prost-types): Converting DateTime to Timestamp is fallible

### DIFF
--- a/prost-types/src/timestamp.rs
+++ b/prost-types/src/timestamp.rs
@@ -99,11 +99,7 @@ impl Timestamp {
             nanos,
         };
 
-        if date_time.is_valid() {
-            Ok(Timestamp::from(date_time))
-        } else {
-            Err(TimestampError::InvalidDateTime)
-        }
+        Timestamp::try_from(date_time)
     }
 }
 


### PR DESCRIPTION
The converstion from the private type DateTime to public type Timestamp is fallible when the DateTime is invalid. All code paths that used `DateTime::into::<Timestamp>()` first check whether the DateTime is valid and then do the conversion, therefore this problem was not visible. https://github.com/tokio-rs/prost/issues/893 points out that some conversions panic, however all these DateTime are invalid.

Solution: Replace `impl From<DateTime> for Timestamp` with `TryFrom` and remove the manual `is_valid` checks before the conversion.

I added the test cases from the issue and roundtrip test between DateTime and Timestamp.