### PR TITLE
fix(prost-types): Fix date-time parsing

### DIFF
--- a/prost-types/src/datetime.rs
+++ b/prost-types/src/datetime.rs
@@ -327,7 +327,9 @@ fn parse_offset(s: &str) -> Option<(i8, i8, &str)> {
 /// string.
 fn parse_two_digit_numeric(s: &str) -> Option<(u8, &str)> {
     debug_assert!(s.is_ascii());
-
+    if s.len() < 2 {
+        return None;
+    }
     let (digits, s) = s.split_at(2);
     Some((digits.parse().ok()?, s))
 }
@@ -420,8 +422,8 @@ pub(crate) fn year_to_seconds(year: i64) -> (i128, bool) {
     let is_leap;
     let year = year - 1900;
 
-    // Fast path for years 1900 - 2038.
-    if year as u64 <= 138 {
+    // Fast path for years 1901 - 2038.
+    if (1..=138).contains(&year) {
         let mut leaps: i64 = (year - 68) >> 2;
         if (year - 68).trailing_zeros() >= 2 {
             leaps -= 1;

--- a/prost-types/src/datetime.rs
+++ b/prost-types/src/datetime.rs
@@ -771,6 +771,19 @@ mod tests {
             "2020-06-15 00:01:02.123 +0800".parse::<Timestamp>(),
             Timestamp::date_time_nanos(2020, 6, 14, 16, 1, 2, 123_000_000),
         );
+
+        // Regression tests
+        assert_eq!(
+            "-11111111-z".parse::<Timestamp>(),
+            Err(crate::TimestampError::ParseFailure),
+        );
+        assert_eq!(
+            "1900-01-10".parse::<Timestamp>(),
+            Ok(Timestamp {
+                seconds: -2208211200,
+                nanos: 0
+            }),
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two bugs revealed so far from fuzz testing in `bilrost`:

* `parse_two_digit_numeric` does not check the length of its input before calling `split_at`, potentially causing a panic
* a logic error in the translation of `year_to_seconds` from the original musl implementation caused it to treat the year 1900 as a leap year, causing (i believe) every date from 1900-01-01 to 1900-03-01 to be offset one day into the past when converting from `DateTime` to `Timestamp`.