### PR TITLE
fix: Enum variant named `Error` causes ambiguous item

### DIFF
--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -351,7 +351,7 @@ fn try_enumeration(input: TokenStream) -> Result<TokenStream, Error> {
         impl #impl_generics ::core::convert::TryFrom::<i32> for #ident #ty_generics #where_clause {
             type Error = ::prost::UnknownEnumValue;
 
-            fn try_from(value: i32) -> ::core::result::Result<#ident, Self::Error> {
+            fn try_from(value: i32) -> ::core::result::Result<#ident, ::prost::UnknownEnumValue> {
                 match value {
                     #(#try_from,)*
                     _ => ::core::result::Result::Err(::prost::UnknownEnumValue(value)),

--- a/tests/src/enum_keyword_variant.proto
+++ b/tests/src/enum_keyword_variant.proto
@@ -8,6 +8,7 @@ enum Feeding {
   // Careful: code generation resulted in "Self". Now it is "Self_".
   FEEDING_SELF = 2;
   FEEDING_ELSE = 3;
+  FEEDING_ERROR = 4;
 }
 
 enum Grooming {


### PR DESCRIPTION
The generated code uses `Self::Error` to refer to `::prost::UnknownEnumValue`, but the term `Error` is not unique when an enum variant is called `Error`. Use the full type name to resolve the ambiguity.

The compiler reported:
```
error: ambiguous associated item
   --> /home/ircdev/src/prost/target/debug/build/tests-no-std-e27db7197924752f/out/enum_keyword_variant.rs:2:68
    |
2   | #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
    |                                                                    ^^^^^^^^^^^^^^^^^^^^
    |
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #57644 <https://github.com/rust-lang/rust/issues/57644>
note: `Error` could refer to the variant defined here
   --> /home/ircdev/src/prost/target/debug/build/tests-no-std-e27db7197924752f/out/enum_keyword_variant.rs:10:5
    |
10  |     Error = 4,
    |     ^^^^^
note: `Error` could also refer to the associated type defined here
   --> /home/ircdev/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/convert/mod.rs:682:5
    |
682 |     type Error;
    |     ^^^^^^^^^^
    = note: `#[deny(ambiguous_associated_items)]` on by default
    = note: this error originates in the derive macro `::prost::Enumeration` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Fixes #1097 