### PR TITLE
chore: prepare 0.13.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
+# Prost version 0.13.1
+
+_PROST!_ is a [Protocol Buffers](https://developers.google.com/protocol-buffers/) implementation for the [Rust Language](https://www.rust-lang.org/). `prost` generates simple, idiomatic Rust code from `proto2` and `proto3` files.
+
+## Bug fixes
+
+* Enum variant named Error causes ambiguous item (#1098)
+
 # PROST version 0.13.0
+
+**note**: this version was yanked in favor of 0.13.1
 
 _PROST!_ is a [Protocol Buffers](https://developers.google.com/protocol-buffers/) implementation for the [Rust Language](https://www.rust-lang.org/). `prost` generates simple, idiomatic Rust code from `proto2` and `proto3` files.
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ exclude = [
 resolver = "2"
 
 [workspace.package]
-version = "0.13.0"
+version = "0.13.1"
 authors = [
   "Dan Burkert <dan@danburkert.com>",
   "Lucio Franco <luciofranco14@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -380,9 +380,9 @@ the `std` features in `prost` and `prost-types`:
 
 ```ignore
 [dependencies]
-prost = { version = "0.13.0", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.13.1", default-features = false, features = ["prost-derive"] }
 # Only necessary if using Protobuf well-known types:
-prost-types = { version = "0.13.0", default-features = false }
+prost-types = { version = "0.13.1", default-features = false }
 ```
 
 Additionally, configure `prost-build` to output `BTreeMap`s instead of `HashMap`s

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -21,8 +21,8 @@ itertools = { version = ">=0.10, <=0.13", default-features = false, features = [
 log = "0.4.4"
 multimap = { version = ">=0.8, <=0.10", default-features = false }
 petgraph = { version = "0.6", default-features = false }
-prost = { version = "0.13.0", path = "../prost", default-features = false }
-prost-types = { version = "0.13.0", path = "../prost-types", default-features = false }
+prost = { version = "0.13.1", path = "../prost", default-features = false }
+prost-types = { version = "0.13.1", path = "../prost-types", default-features = false }
 tempfile = "3"
 once_cell = "1.17.1"
 regex = { version = "1.8.1", default-features = false, features = ["std", "unicode-bool"] }

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-build/0.13.0")]
+#![doc(html_root_url = "https://docs.rs/prost-build/0.13.1")]
 #![allow(clippy::option_as_ref_deref, clippy::format_push_string)]
 
 //! `prost-build` compiles `.proto` files into Rust.

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-derive/0.13.0")]
+#![doc(html_root_url = "https://docs.rs/prost-derive/0.13.1")]
 // The `quote!` macro requires deep recursion.
 #![recursion_limit = "4096"]
 

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -17,7 +17,7 @@ default = ["std"]
 std = ["prost/std"]
 
 [dependencies]
-prost = { version = "0.13.0", path = "../prost", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.13.1", path = "../prost", default-features = false, features = ["prost-derive"] }
 
 [dev-dependencies]
 proptest = "1"

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-types/0.13.0")]
+#![doc(html_root_url = "https://docs.rs/prost-types/0.13.1")]
 
 //! Protocol Buffers well-known types.
 //!

--- a/prost/Cargo.toml
+++ b/prost/Cargo.toml
@@ -24,7 +24,7 @@ std = []
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-prost-derive = { version = "0.13.0", path = "../prost-derive", optional = true }
+prost-derive = { version = "0.13.1", path = "../prost-derive", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false }

--- a/prost/README.md
+++ b/prost/README.md
@@ -380,9 +380,9 @@ the `std` features in `prost` and `prost-types`:
 
 ```ignore
 [dependencies]
-prost = { version = "0.13.0", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.13.1", default-features = false, features = ["prost-derive"] }
 # Only necessary if using Protobuf well-known types:
-prost-types = { version = "0.13.0", default-features = false }
+prost-types = { version = "0.13.1", default-features = false }
 ```
 
 Additionally, configure `prost-build` to output `BTreeMap`s instead of `HashMap`s

--- a/prost/src/lib.rs
+++ b/prost/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost/0.13.0")]
+#![doc(html_root_url = "https://docs.rs/prost/0.13.1")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![doc = include_str!("../README.md")]
 


### PR DESCRIPTION
# Prost version 0.13.1

_PROST!_ is a [Protocol Buffers](https://developers.google.com/protocol-buffers/) implementation for the [Rust Language](https://www.rust-lang.org/). `prost` generates simple, idiomatic Rust code from `proto2` and `proto3` files.

## Bug fixes

* Enum variant named Error causes ambiguous item (#1098)