### PR TITLE
build: Ignore missing features in `tests` crates

### DIFF
--- a/tests-2018/Cargo.toml
+++ b/tests-2018/Cargo.toml
@@ -18,6 +18,9 @@ path = "../tests/src/lib.rs"
 default = ["std"]
 std = []
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("edition-2015"))'] }
+
 [dependencies]
 anyhow = "1.0.1"
 bytes = "1"

--- a/tests-no-std/Cargo.toml
+++ b/tests-no-std/Cargo.toml
@@ -11,6 +11,9 @@ build = "../tests/src/build.rs"
 doctest = false
 path = "../tests/src/lib.rs"
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("edition-2015", "std"))'] }
+
 # Compile the `tests` crate *without* the std feature, which is implicitly
 # omitted from the default crate features. It would be easier to do something
 # like `cargo test -p tests --no-default-features`, but that currently does not

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -11,6 +11,9 @@ build = "src/build.rs"
 default = ["std"]
 std = []
 
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("edition-2015"))'] }
+
 [dependencies]
 anyhow = "1.0.1"
 cfg-if = "1"


### PR DESCRIPTION
Only the crate `tests-2015` uses the feature `edition-2015`, but the code is shared with the `tests` crate.

Same for `tests-no-std` which disables feature `std`, but reuses the code with the `tests` crate.

Therefore the `tests`, `tests-2018` and `tests-no-std` crates should be configured to ignore the lint about missing features.

Cargo clippy reports:
```
warning: unexpected `cfg` condition value: `edition-2015`
 --> tests-no-std/../tests/src/build.rs:5:14
  |
5 |     if #[cfg(feature = "edition-2015")] {
  |              ^^^^^^^-----------------
  |              |
  |              help: remove the condition
  |
  = note: no expected values for `feature`
  = help: consider adding `edition-2015` as a feature in `Cargo.toml`
  = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
  = note: `#[warn(unexpected_cfgs)]` on by default
```