### PR TITLE
build: Use `proc-macro` in Cargo.toml

### DIFF
--- a/prost-derive/Cargo.toml
+++ b/prost-derive/Cargo.toml
@@ -10,7 +10,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [lib]
-proc_macro = true
+proc-macro = true
 
 [dependencies]
 anyhow = "1.0.1"


### PR DESCRIPTION
The nightly compiler warns about a incompatibility of the Cargo.toml for the next edition. Use the backwards compatible `proc-macro` in the Cargo.toml.

Compiler reports:
```
warning: prost/prost-derive/Cargo.toml: `proc_macro` is deprecated in favor of `proc-macro` and will not work in the 2024 edition
```