### PR TITLE
build(fuzz): Fix building of fuzzing targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,6 @@ exclude = [
   # The fuzz crate can't be compiled or tested without the 'cargo fuzz' command,
   # so exclude it from normal builds.
   "fuzz",
-  # Same counts for the afl fuzz targets
-  "afl",
 ]
 
 resolver = "2"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,8 +2,13 @@
 name = "fuzz"
 version = "0.0.0"
 publish = false
-edition.workspace = true
-authors.workspace = true
+edition = "2021"
+authors = [
+  "Dan Burkert <dan@danburkert.com>",
+  "Lucio Franco <luciofranco14@gmail.com>",
+  "Casper Meijn <casper@meijn.net>",
+  "Tokio Contributors <team@tokio.rs>",
+]
 
 [package.metadata]
 cargo-fuzz = true

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -14,7 +14,7 @@ authors = [
 cargo-fuzz = true
 
 [dependencies]
-libfuzzer-sys = { git = "https://github.com/rust-fuzz/libfuzzer-sys.git" }
+libfuzzer-sys = "0.4"
 tests = { path = "../tests" }
 
 [[bin]]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -16,6 +16,7 @@ cargo-fuzz = true
 [dependencies]
 libfuzzer-sys = "0.4"
 tests = { path = "../tests" }
+protobuf = { path = "../protobuf" }
 
 [[bin]]
 name = "proto3"


### PR DESCRIPTION
The fuzzing targets need some love. I got them working again with these changes:
- build(fuzz): Add missing dependency
- build(fuzz): Use released version of `libfizzer-sys`
- build(fuzz): create `fuzz` is not part of workspace
- build(fuzz): afl is not in root directory
