### PR TITLE
fix(prost-types): Allow unknown local time offset

### DIFF
--- a/prost-types/src/datetime.rs
+++ b/prost-types/src/datetime.rs
@@ -310,9 +310,6 @@ fn parse_offset(s: &str) -> Option<(i8, i8, &str)> {
             (minute, s)
         };
 
-        // '-00:00' indicates an unknown local offset.
-        ensure!(is_positive || hour > 0 || minute > 0);
-
         ensure!(hour < 24 && minute < 60);
 
         let hour = hour as i8;


### PR DESCRIPTION
`chrono` allows a negative zero local offset. I think we should follow their example.

The RFC 3339 spec says this is a special value, but doesn't specify how to handle the situation. https://www.rfc-editor.org/rfc/rfc3339#section-4.3