### PR TITLE
build(fuzz): Add fuzz targets to workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,6 @@ members = [
   "tests-2015",
   "tests-no-std",
   "tests/single-include",
-]
-
-exclude = [
-  # The fuzz crate can't be compiled or tested without the 'cargo fuzz' command,
-  # so exclude it from normal builds.
   "fuzz",
 ]
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -2,13 +2,8 @@
 name = "fuzz"
 version = "0.0.0"
 publish = false
-edition = "2021"
-authors = [
-  "Dan Burkert <dan@danburkert.com>",
-  "Lucio Franco <luciofranco14@gmail.com>",
-  "Casper Meijn <casper@meijn.net>",
-  "Tokio Contributors <team@tokio.rs>",
-]
+edition.workspace = true
+authors.workspace = true
 
 [package.metadata]
 cargo-fuzz = true
@@ -21,7 +16,13 @@ protobuf = { path = "../protobuf" }
 [[bin]]
 name = "proto3"
 path = "fuzzers/proto3.rs"
+test = false
+doc = false
+bench = false
 
 [[bin]]
 name = "proto2"
 path = "fuzzers/proto2.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzzers/proto2.rs
+++ b/fuzz/fuzzers/proto2.rs
@@ -7,4 +7,3 @@ use tests::roundtrip;
 fuzz_target!(|data: &[u8]| {
     let _ = roundtrip::<TestAllTypesProto2>(data).unwrap_error();
 });
-


### PR DESCRIPTION
`cargo-fuzz` recommends adding the `fuzz` crate to the workspace. It seems the problem of not compiling is fixed with recent dependencies.

source: https://github.com/rust-fuzz/cargo-fuzz?tab=readme-ov-file#usage