### PR TITLE
ci: Run `cargo test` without `all-targets`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,14 +146,9 @@ jobs:
         uses: ./.github/actions/setup-ninja
       - uses: Swatinem/rust-cache@v2
       - name: test
-        run: cargo test --all-targets
+        run: cargo test
       - name: test no-default-features
-        run: cargo test -p prost-build -p prost-derive -p prost-types --all-targets --no-default-features
-      # Run doc tests separately: https://github.com/rust-lang/cargo/issues/6669
-      - name: test doc
-        run: cargo test --doc
-      - name: test doc no-default-features
-        run: cargo test -p prost-build -p prost-derive -p prost-types --doc --no-default-features
+        run: cargo test -p prost-build -p prost-derive -p prost-types --no-default-features
 
   msrv:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Running `cargo test --all-targets` will not run doctests, as noted in the removed comments.

Another effect is that Cargo.toml instructions for not running a test are ignored. For example, benchmarks are tested, but no unit tests are inside and bins marked with `test = false` are run.

I diffed the text output of running `cargo test` and `cargo test --all-targets` and concluded that no useful test will be skipped when running just `cargo test`.