### PR TITLE
style: Remove needless borrow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ on:
 
 
 env:
-  PROTOC_VERSION: 3.20.3
-  clippy_rust_version: 1.79
+  PROTOC_VERSION: '3.20.3'
+  clippy_rust_version: '1.79'
 
 jobs:
   # Depends on all actions that are required for a "successful" CI run.

--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -122,7 +122,7 @@ fn install_conformance_test_runner(
         .arg("-GNinja")
         .arg(src_dir.join("cmake"))
         .arg("-DCMAKE_BUILD_TYPE=DEBUG")
-        .arg(&format!("-DCMAKE_INSTALL_PREFIX={}", prefix_dir.display()))
+        .arg(format!("-DCMAKE_INSTALL_PREFIX={}", prefix_dir.display()))
         .arg("-Dprotobuf_BUILD_CONFORMANCE=ON")
         .arg("-Dprotobuf_BUILD_TESTS=OFF")
         .current_dir(build_dir)


### PR DESCRIPTION
```
warning: the borrowed expression implements the required traits
   --> protobuf/build.rs:143:14
    |
143 | ...rg(&format!("-DCMAKE_INSTALL_PREFIX={}", prefix_dir.display(...
    |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `format!("-DCMAKE_INSTALL_PREFIX={}", prefix_dir.display())`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args
    = note: `#[warn(clippy::needless_borrows_for_generic_args)]` on by default
```