### PR TITLE
feat(prost-build): Add protoc executable path to Config

### DIFF
--- a/prost-build/README.md
+++ b/prost-build/README.md
@@ -7,17 +7,6 @@
 a Cargo build. See the crate [documentation](https://docs.rs/prost-build/) for examples
 of how to integrate `prost-build` into a Cargo project.
 
-## `protoc`
-
-`prost-build` uses `protoc` to parse the proto files. There are two ways to make `protoc`
-available for `prost-build`:
-
-* Include `protoc` in your `PATH`. This can be done by following the [`protoc` install instructions].
-* Pass the `PROTOC=<my/path/to/protoc>` environment variable with the path to
-  `protoc`.
-
-[`protoc` install instructions]: https://github.com/protocolbuffers/protobuf#protocol-compiler-installation
-
 ## License
 
 `prost-build` is distributed under the terms of the Apache License (Version 2.0).

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -101,7 +101,14 @@
 //! ## Sourcing `protoc`
 //!
 //! `prost-build` depends on the Protocol Buffers compiler, `protoc`, to parse `.proto` files into
-//! a representation that can be transformed into Rust. If set, `prost-build` uses the `PROTOC`
+//! a representation that can be transformed into Rust.
+//!
+//! The easiest way for `prost-build` to find `protoc` is to install it in your `PATH`.
+//! This can be done by following the [`protoc` install instructions]. `prost-build` will search
+//! the current path for `protoc` or `protoc.exe`.
+//!
+//! When `protoc` is installed in a different location, set `PROTOC` to the path of the executable.
+//! If set, `prost-build` uses the `PROTOC`
 //! for locating `protoc`. For example, on a macOS system where Protobuf is installed
 //! with Homebrew, set the environment variables to:
 //!
@@ -109,15 +116,13 @@
 //! PROTOC=/usr/local/bin/protoc
 //! ```
 //!
-//! and in a typical Linux installation:
+//! Alternatively, the path to `protoc` execuatable can be explicitly set
+//! via [`Config::protoc_executable()`].
 //!
-//! ```bash
-//! PROTOC=/usr/bin/protoc
-//! ```
-//!
-//! If no `PROTOC` environment variable is set then `prost-build` will search the
-//! current path for `protoc` or `protoc.exe`. If `prost-build` can not find `protoc`
+//! If `prost-build` can not find `protoc`
 //! via these methods the `compile_protos` method will fail.
+//!
+//! [`protoc` install instructions]: https://github.com/protocolbuffers/protobuf#protocol-compiler-installation
 //!
 //! ### Compiling `protoc` from source
 //!


### PR DESCRIPTION
Set the path to `protoc` executable to be used by `prost-build`

Use the provided path to find `protoc`. This can either be a file name which is searched for in the `PATH` or an aboslute path to use a specific executable.

This API is needed during `prost` development to use the repo compiled `protoc` on the `.proto`-files in the same repo: https://github.com/caspermeijn/prost/commit/1e4f390d699cbd7b36fcdd3a53dc63a2e2debbc6