### PR TITLE
ci(clippy): Update to cargo clippy version 1.80

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   PROTOC_VERSION: '3.20.3'
-  clippy_rust_version: '1.79'
+  clippy_rust_version: '1.80'
 
 jobs:
   # Depends on all actions that are required for a "successful" CI run.

--- a/tests/src/decode_error.rs
+++ b/tests/src/decode_error.rs
@@ -56,7 +56,6 @@ fn test_decode_error_length_delimiter_too_large() {
     );
 }
 
-#[cfg(not(feature = "no-recursion-limit"))]
 #[test]
 fn test_decode_error_recursion_limit_reached() {
     let recursve_message = {


### PR DESCRIPTION
Remove feature check for a feature that doesn't exist in the `tests` crate. This allows clippy to be updated.