### PR TITLE
tests: Fix build without std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,8 @@ jobs:
       # prost's default features to compile.
       - name: prost-build check
         run: cargo check --manifest-path prost-build/Cargo.toml
+      - name: tests-no-std cargo-no-std-check
+        run: cargo no-std-check --manifest-path tests-no-std/Cargo.toml
 
   check-readme:
     name: Check README

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -204,7 +204,7 @@ where
 
     let mut buf1 = Vec::new();
     if let Err(error) = all_types.encode(&mut buf1) {
-        return RoundtripResult::Error(error.into());
+        return RoundtripResult::Error(anyhow!(error));
     }
     let buf1 = buf1;
     if encoded_len != buf1.len() {
@@ -217,12 +217,12 @@ where
 
     let roundtrip = match M::decode(buf1.as_slice()) {
         Ok(roundtrip) => roundtrip,
-        Err(error) => return RoundtripResult::Error(anyhow::Error::new(error)),
+        Err(error) => return RoundtripResult::Error(anyhow!(error)),
     };
 
     let mut buf2 = Vec::new();
     if let Err(error) = roundtrip.encode(&mut buf2) {
-        return RoundtripResult::Error(error.into());
+        return RoundtripResult::Error(anyhow!(error));
     }
     let buf2 = buf2;
     let buf3 = roundtrip.encode_to_vec();


### PR DESCRIPTION
The crate `tests-no-std` was never build without std in CI. Therefore the build was broken.

Use the `no_std` compatible `anyhow` calls and run `no-std-check` on the crate.