### PR TITLE
build: Increase MSRV to 1.71.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = [
 ]
 license = "Apache-2.0"
 repository = "https://github.com/tokio-rs/prost"
-rust-version = "1.70"
+rust-version = "1.71.1"
 edition = "2021"
 
 [profile.bench]


### PR DESCRIPTION
Rust 1.71.1 was released on Aug. 3, 2023 (1 year ago at this time). This allows to bump `pulldown-cmark` dependency to the latest version.