### PR TITLE
build(protobuf): Use same `protoc` from same repo as .proto-files

### DIFF
--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -36,12 +36,16 @@ fn main() -> Result<()> {
         fs::rename(prefix_dir, protobuf_dir).context("failed to move protobuf dir")?;
     }
 
+    let protoc_executable = protobuf_dir.join("bin").join("protoc");
+
     let conformance_proto_dir = src_dir.join("conformance");
-    prost_build::compile_protos(
-        &[conformance_proto_dir.join("conformance.proto")],
-        &[conformance_proto_dir],
-    )
-    .unwrap();
+    prost_build::Config::new()
+        .protoc_executable(&protoc_executable)
+        .compile_protos(
+            &[conformance_proto_dir.join("conformance.proto")],
+            &[conformance_proto_dir],
+        )
+        .unwrap();
 
     let proto_dir = src_dir.join("src");
 
@@ -50,6 +54,7 @@ fn main() -> Result<()> {
     // compare based on the Rust PartialEq implementations is difficult, due to presence of NaN
     // values.
     prost_build::Config::new()
+        .protoc_executable(&protoc_executable)
         .btree_map(["."])
         .compile_protos(
             &[


### PR DESCRIPTION
Crate `protobuf` compiles some .proto-files from the checked out repo in `third_party/protobuf`. Those files can use newest features from `protoc`. Therefore during development the `protoc` in `PATH` must be the same version or newer than in `third_party/protobuf`.

The crate already builds a `protoc` compiler from the checked out repo to be used in conformance executable. Use that specific `protoc` for compiling the .proto-files in the crate.

This doesn't influence the `protoc` used in crate `tests` nor published crates.