### PR TITLE
build(protobuf): Use crate `cmake`

### DIFF
--- a/.github/actions/setup-ninja/action.yml
+++ b/.github/actions/setup-ninja/action.yml
@@ -3,15 +3,21 @@ runs:
   steps:
     - name: install ninja
       if: runner.os == 'macOS'
-      run: brew install ninja
+      run: |
+        brew install ninja
+        echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
       shell: bash
 
     - name: install ninja
       if: runner.os == 'Windows'
-      run: choco install ninja
+      run: |
+        choco install ninja
+        echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
       shell: bash
 
     - name: install ninja
       if: runner.os == 'Linux'
-      run: sudo apt-get install ninja-build
+      run: |
+        sudo apt-get install ninja-build
+        echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
       shell: bash

--- a/protobuf/Cargo.toml
+++ b/protobuf/Cargo.toml
@@ -13,6 +13,7 @@ prost-types = { path = "../prost-types" }
 anyhow = "1.0.1"
 prost-build = { path = "../prost-build" }
 tempfile = "3"
+cmake = "0.1.51"
 
 [package.metadata.cargo-machete]
 ignored = ["prost", "prost-types"]


### PR DESCRIPTION
Let the crate `cmake` handle the interaction with CMake executable. This simplifies our codebase and improves compatibility with other platforms.

`CMAKE_BUILD_TYPE` is handle automatically based on `opt-level`.

Set `CMAKE_GENERATOR` environment variable in CI instead of hardcoded dependency on `ninja-build`.