### PR TITLE
feat: Relax Message Debug trait bound

### DIFF
--- a/prost/src/message.rs
+++ b/prost/src/message.rs
@@ -3,8 +3,6 @@ use alloc::boxed::Box;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
-use core::fmt::Debug;
-
 use bytes::{Buf, BufMut};
 
 use crate::encoding::varint::{encode_varint, encoded_len_varint};
@@ -14,7 +12,7 @@ use crate::DecodeError;
 use crate::EncodeError;
 
 /// A Protocol Buffers message.
-pub trait Message: Debug + Send + Sync {
+pub trait Message: Send + Sync {
     /// Encodes the message to a buffer.
     ///
     /// This method will panic if the buffer has insufficient capacity.

--- a/tests/src/generic_derive.rs
+++ b/tests/src/generic_derive.rs
@@ -1,4 +1,4 @@
-pub trait CustomType: prost::Message + Default {}
+pub trait CustomType: prost::Message + Default + core::fmt::Debug {}
 
 impl CustomType for u64 {}
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -118,6 +118,8 @@ pub mod proto3 {
     }
 }
 
+use core::fmt::Debug;
+
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
@@ -224,7 +226,7 @@ where
 /// Generic roundtrip serialization check for messages.
 pub fn check_message<M>(msg: &M)
 where
-    M: Message + Default + PartialEq,
+    M: Debug + Message + Default + PartialEq,
 {
     let expected_len = msg.encoded_len();
 


### PR DESCRIPTION
Relaxes `Message`'s `Debug` trait bound.

BREAKING CHANGE: `trait Debug` was a supertrait of `trait Message`. This is no longer required by `prost`. If your code relies on `trait Debug` being implemented for every `impl Message`, you must now explicitly state that you require both Debug and Message. For example: `where M: Debug + Message`