### PR TITLE
style: `MessageGraph::new()` can't actually fail

### DIFF
--- a/prost-build/src/config.rs
+++ b/prost-build/src/config.rs
@@ -1079,8 +1079,7 @@ impl Config {
         let mut modules = HashMap::new();
         let mut packages = HashMap::new();
 
-        let message_graph = MessageGraph::new(requests.iter().map(|x| &x.1))
-            .map_err(|error| Error::new(ErrorKind::InvalidInput, error))?;
+        let message_graph = MessageGraph::new(requests.iter().map(|x| &x.1));
         let extern_paths = ExternPaths::new(&self.extern_paths, self.prost_types)
             .map_err(|error| Error::new(ErrorKind::InvalidInput, error))?;
 

--- a/prost-build/src/message_graph.rs
+++ b/prost-build/src/message_graph.rs
@@ -19,9 +19,7 @@ pub struct MessageGraph {
 }
 
 impl MessageGraph {
-    pub fn new<'a>(
-        files: impl Iterator<Item = &'a FileDescriptorProto>,
-    ) -> Result<MessageGraph, String> {
+    pub fn new<'a>(files: impl Iterator<Item = &'a FileDescriptorProto>) -> MessageGraph {
         let mut msg_graph = MessageGraph {
             index: HashMap::new(),
             graph: Graph::new(),
@@ -39,7 +37,7 @@ impl MessageGraph {
             }
         }
 
-        Ok(msg_graph)
+        msg_graph
     }
 
     fn get_or_insert_index(&mut self, msg_name: String) -> NodeIndex {


### PR DESCRIPTION
`MessageGraph` is an internal type. The currenly implementation can't fail, so it doesn't have to return a `Result`