### PR TITLE
fix(prost-build): Remove `derived(Copy)` on boxed fields

### DIFF
--- a/prost-build/src/config.rs
+++ b/prost-build/src/config.rs
@@ -1080,7 +1080,7 @@ impl Config {
         let mut modules = HashMap::new();
         let mut packages = HashMap::new();
 
-        let message_graph = MessageGraph::new(requests.iter().map(|x| &x.1));
+        let message_graph = MessageGraph::new(requests.iter().map(|x| &x.1), self.boxed.clone());
         let extern_paths = ExternPaths::new(&self.extern_paths, self.prost_types)
             .map_err(|error| Error::new(ErrorKind::InvalidInput, error))?;
 

--- a/prost-build/src/fixtures/field_attributes/_expected_field_attributes.rs
+++ b/prost-build/src/fixtures/field_attributes/_expected_field_attributes.rs
@@ -19,7 +19,7 @@ pub struct Foo {
     #[prost(string, tag="1")]
     pub foo: ::prost::alloc::string::String,
 }
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Bar {
     #[prost(message, optional, boxed, tag="1")]
     pub qux: ::core::option::Option<::prost::alloc::boxed::Box<Qux>>,

--- a/prost-build/src/fixtures/field_attributes/_expected_field_attributes_formatted.rs
+++ b/prost-build/src/fixtures/field_attributes/_expected_field_attributes_formatted.rs
@@ -19,7 +19,7 @@ pub struct Foo {
     #[prost(string, tag = "1")]
     pub foo: ::prost::alloc::string::String,
 }
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Bar {
     #[prost(message, optional, boxed, tag = "1")]
     pub qux: ::core::option::Option<::prost::alloc::boxed::Box<Qux>>,

--- a/prost-build/src/path.rs
+++ b/prost-build/src/path.rs
@@ -3,7 +3,7 @@
 use std::iter;
 
 /// Maps a fully-qualified Protobuf path to a value using path matchers.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub(crate) struct PathMap<T> {
     // insertion order might actually matter (to avoid warning about legacy-derive-helpers)
     // see: https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#legacy-derive-helpers

--- a/tests/src/boxed_field.proto
+++ b/tests/src/boxed_field.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package boxed_field;
+
+message Foo {
+  Bar bar = 1;
+}
+
+message Bar {
+}

--- a/tests/src/build.rs
+++ b/tests/src/build.rs
@@ -171,6 +171,11 @@ fn main() {
         .compile_protos(&[src.join("type_names.proto")], includes)
         .unwrap();
 
+    prost_build::Config::new()
+        .boxed("Foo.bar")
+        .compile_protos(&[src.join("boxed_field.proto")], includes)
+        .unwrap();
+
     // Check that attempting to compile a .proto without a package declaration does not result in an error.
     config
         .compile_protos(&[src.join("no_package.proto")], includes)

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -140,6 +140,10 @@ pub mod invalid {
     }
 }
 
+pub mod boxed_field {
+    include!(concat!(env!("OUT_DIR"), "/boxed_field.rs"));
+}
+
 pub mod default_string_escape {
     include!(concat!(env!("OUT_DIR"), "/default_string_escape.rs"));
 }


### PR DESCRIPTION
Fix one of the problems I found while rebasing #705: boxed fields are not `Copy`