### PR TITLE
fix(protobuf): `protobuf/build.rs` get stuck when patch is already applied

### DIFF
--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -97,6 +97,7 @@ fn apply_patches(src_dir: &Path) -> Result<()> {
     patch_src.push("fix-conformance_test_runner-cmake-build.patch");
 
     let rc = Command::new("patch")
+        .arg("-f")
         .arg("-p1")
         .arg("-i")
         .arg(patch_src)


### PR DESCRIPTION
`protobuf/build.rs` is occasionally stucked. The reason is that `patch` requires user input if the patch has already been applied:

```shell
$ patch -p1 -i "../../protobuf/src/fix-conformance_test_runner-cmake-build.patch"
patching file 'cmake/conformance.cmake'
Reversed (or previously applied) patch detected!  Assume -R? [y] 
```

Adding the `-f` flag solves the issue.