### PR TITLE
Implement PartialOrd on Duration

### DIFF
--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -1815,7 +1815,7 @@ pub struct Mixin {
 /// encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
 /// be expressed in JSON format as "3.000000001s", and 3 seconds and 1
 /// microsecond should be expressed in JSON format as "3.000001s".
-#[derive(Clone, Copy, PartialEq, ::prost::Message)]
+#[derive(Clone, Copy, PartialEq, PartialOrd, ::prost::Message)]
 pub struct Duration {
     /// Signed seconds of the span of time. Must be from -315,576,000,000
     /// to +315,576,000,000 inclusive. Note: these bounds are computed from:


### PR DESCRIPTION
allow duration comparisons (similar to chrono::TimeDelta, which has the same structure)

https://docs.rs/chrono/latest/src/chrono/time_delta.rs.html#52