### PR TITLE
chore: Release version 0.13.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,42 @@
+# Prost version 0.13.3
+
+_PROST!_ is a [Protocol Buffers](https://developers.google.com/protocol-buffers/) implementation for the [Rust Language](https://www.rust-lang.org/). `prost` generates simple, idiomatic Rust code from `proto2` and `proto3` files.
+
+
+### Features
+
+- *(prost-types)* Add `normalized` functions (#1158)
+
+### Bug Fixes
+
+- *(prost-build)* Remove `derived(Copy)` on boxed fields (#1157)
+
+### Documentation
+
+- *(prost-types)* Add description of using Any (#1141)
+- *(prost-build)* Use `cargo add` in example (#1149)
+
+### Styling
+
+- Use `Path::display()` when printing a path (#1150)
+- `MessageGraph::new()` can't actually fail (#1151)
+- *(generated-code)* Use `Self` in `as_str_name` (#1154)
+
+### Testing
+
+- Actually test `skip_debug` for `prost::Oneof` (#1148)
+- *(prost-build)* Validate error texts (#1152)
+- *(prost-build)* Fix error texts (#1156)
+
+### Build
+
+- Increase MSRV to 1.71.1 (#1135)
+- *(deps)* Update pulldown-cmark to 0.12 and pulldown-cmark-to-cmark to 16 (#1144)
+- *(protobuf)* Compile and install protoc on Windows (#1145)
+- *(protobuf)* Use same `protoc` from same repo as .proto-files (#1136)
+- *(deps)* Update pulldown-cmark-to-cmark from 16 to 17 (#1155)
+- Unify assert on fixtures (#1142)
+
 # Prost version 0.13.2
 
 _PROST!_ is a [Protocol Buffers](https://developers.google.com/protocol-buffers/) implementation for the [Rust Language](https://www.rust-lang.org/). `prost` generates simple, idiomatic Rust code from `proto2` and `proto3` files.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.13.2"
+version = "0.13.3"
 authors = [
   "Dan Burkert <dan@danburkert.com>",
   "Lucio Franco <luciofranco14@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -380,9 +380,9 @@ the `std` features in `prost` and `prost-types`:
 
 ```ignore
 [dependencies]
-prost = { version = "0.13.2", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.13.3", default-features = false, features = ["prost-derive"] }
 # Only necessary if using Protobuf well-known types:
-prost-types = { version = "0.13.2", default-features = false }
+prost-types = { version = "0.13.3", default-features = false }
 ```
 
 Additionally, configure `prost-build` to output `BTreeMap`s instead of `HashMap`s

--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -21,8 +21,8 @@ itertools = { version = ">=0.10, <=0.13", default-features = false, features = [
 log = "0.4.4"
 multimap = { version = ">=0.8, <=0.10", default-features = false }
 petgraph = { version = "0.6", default-features = false }
-prost = { version = "0.13.2", path = "../prost", default-features = false }
-prost-types = { version = "0.13.2", path = "../prost-types", default-features = false }
+prost = { version = "0.13.3", path = "../prost", default-features = false }
+prost-types = { version = "0.13.3", path = "../prost-types", default-features = false }
 tempfile = "3"
 once_cell = "1.17.1"
 regex = { version = "1.8.1", default-features = false, features = ["std", "unicode-bool"] }

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-build/0.13.2")]
+#![doc(html_root_url = "https://docs.rs/prost-build/0.13.3")]
 #![allow(clippy::option_as_ref_deref, clippy::format_push_string)]
 
 //! `prost-build` compiles `.proto` files into Rust.

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-derive/0.13.2")]
+#![doc(html_root_url = "https://docs.rs/prost-derive/0.13.3")]
 // The `quote!` macro requires deep recursion.
 #![recursion_limit = "4096"]
 

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -17,7 +17,7 @@ default = ["std"]
 std = ["prost/std"]
 
 [dependencies]
-prost = { version = "0.13.2", path = "../prost", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.13.3", path = "../prost", default-features = false, features = ["prost-derive"] }
 
 [dev-dependencies]
 proptest = "1"

--- a/prost-types/src/lib.rs
+++ b/prost-types/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost-types/0.13.2")]
+#![doc(html_root_url = "https://docs.rs/prost-types/0.13.3")]
 
 //! Protocol Buffers well-known types.
 //!

--- a/prost/Cargo.toml
+++ b/prost/Cargo.toml
@@ -24,7 +24,7 @@ std = []
 
 [dependencies]
 bytes = { version = "1", default-features = false }
-prost-derive = { version = "0.13.2", path = "../prost-derive", optional = true }
+prost-derive = { version = "0.13.3", path = "../prost-derive", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", default-features = false }

--- a/prost/README.md
+++ b/prost/README.md
@@ -380,9 +380,9 @@ the `std` features in `prost` and `prost-types`:
 
 ```ignore
 [dependencies]
-prost = { version = "0.13.2", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.13.3", default-features = false, features = ["prost-derive"] }
 # Only necessary if using Protobuf well-known types:
-prost-types = { version = "0.13.2", default-features = false }
+prost-types = { version = "0.13.3", default-features = false }
 ```
 
 Additionally, configure `prost-build` to output `BTreeMap`s instead of `HashMap`s

--- a/prost/src/lib.rs
+++ b/prost/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc(html_root_url = "https://docs.rs/prost/0.13.2")]
+#![doc(html_root_url = "https://docs.rs/prost/0.13.3")]
 #![cfg_attr(not(feature = "std"), no_std)]
 #![doc = include_str!("../README.md")]
 


### PR DESCRIPTION
Apparently, `prost-build::Config::boxed` has been broken since 0.13.0. With that fix (#1157)  in a new release would be nice.