### PR TITLE
build: Use `trait Error` from core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ authors = [
 ]
 license = "Apache-2.0"
 repository = "https://github.com/tokio-rs/prost"
-rust-version = "1.71.1"
+rust-version = "1.81"
 edition = "2021"
 
 [profile.bench]

--- a/benchmarks/benches/dataset.rs
+++ b/benchmarks/benches/dataset.rs
@@ -1,6 +1,6 @@
 use criterion::{criterion_group, criterion_main, Criterion};
 use prost::Message;
-use std::error::Error;
+use core::error::Error;
 
 pub mod benchmarks {
     include!(concat!(env!("OUT_DIR"), "/benchmarks.rs"));

--- a/prost-types/src/duration.rs
+++ b/prost-types/src/duration.rs
@@ -172,8 +172,7 @@ impl fmt::Display for DurationError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for DurationError {}
+impl core::error::Error for DurationError {}
 
 impl FromStr for Duration {
     type Err = DurationError;

--- a/prost-types/src/timestamp.rs
+++ b/prost-types/src/timestamp.rs
@@ -199,8 +199,7 @@ impl fmt::Display for TimestampError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for TimestampError {}
+impl core::error::Error for TimestampError {}
 
 #[cfg(feature = "std")]
 impl TryFrom<Timestamp> for std::time::SystemTime {

--- a/prost/src/error.rs
+++ b/prost/src/error.rs
@@ -71,8 +71,7 @@ impl fmt::Display for DecodeError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for DecodeError {}
+impl core::error::Error for DecodeError {}
 
 #[cfg(feature = "std")]
 impl From<DecodeError> for std::io::Error {
@@ -122,8 +121,7 @@ impl fmt::Display for EncodeError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for EncodeError {}
+impl core::error::Error for EncodeError {}
 
 #[cfg(feature = "std")]
 impl From<EncodeError> for std::io::Error {
@@ -146,5 +144,4 @@ impl fmt::Display for UnknownEnumValue {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for UnknownEnumValue {}
+impl core::error::Error for UnknownEnumValue {}


### PR DESCRIPTION
Since Rust 1.81, the `trait Error` is available in core. Therefore `std` is no longer needed for error types