### PR TITLE
style: Remove explicit lifetimes

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -87,7 +87,7 @@ impl OneofField {
     }
 }
 
-impl<'a> CodeGenerator<'a> {
+impl CodeGenerator<'_> {
     pub fn generate(
         config: &mut Config,
         message_graph: &MessageGraph,

--- a/prost-build/src/path.rs
+++ b/prost-build/src/path.rs
@@ -92,7 +92,7 @@ impl<'a, T> std::iter::Iterator for Iter<'a, T> {
     }
 }
 
-impl<'a, T> std::iter::FusedIterator for Iter<'a, T> {}
+impl<T> std::iter::FusedIterator for Iter<'_, T> {}
 
 /// Given a fully-qualified path, returns a sequence of paths:
 /// - the path itself

--- a/prost-types/src/conversions.rs
+++ b/prost-types/src/conversions.rs
@@ -43,7 +43,7 @@ impl From<String> for Value {
     }
 }
 
-impl<'a> From<&'a str> for Value {
+impl From<&str> for Value {
     fn from(value: &str) -> Self {
         value::Kind::StringValue(value.into()).into()
     }

--- a/prost/src/encoding.rs
+++ b/prost/src/encoding.rs
@@ -583,7 +583,7 @@ pub mod string {
         // in the buf implementation, a drop guard is used.
         unsafe {
             struct DropGuard<'a>(&'a mut Vec<u8>);
-            impl<'a> Drop for DropGuard<'a> {
+            impl Drop for DropGuard<'_> {
                 #[inline]
                 fn drop(&mut self) {
                     self.0.clear();


### PR DESCRIPTION
`cargo clippy` reports:
```
error: the following explicit lifetimes could be elided: 'a
  --> prost-types/src/conversions.rs:46:6
   |
46 | impl<'a> From<&'a str> for Value {
   |      ^^        ^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_lifetimes
   = note: `-D clippy::needless-lifetimes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_lifetimes)]`
help: elide the lifetimes
   |
46 - impl<'a> From<&'a str> for Value {
46 + impl From<&str> for Value {
```