### PR TITLE
chore(build): Remove unnecessary empty line after document

### DIFF
--- a/prost-build/src/config.rs
+++ b/prost-build/src/config.rs
@@ -881,7 +881,6 @@ impl Config {
     ///   config.compile_fds(file_descriptor_set)
     /// }
     /// ```
-
     pub fn load_fds(
         &mut self,
         protos: &[impl AsRef<Path>],


### PR DESCRIPTION
Removes the unnecessary empty line after the document.