### PR TITLE
test: Rename `invalid_doctest` to `disable_comments`

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -132,14 +132,10 @@ fn main() {
         .compile_protos(&[src.join("proto3_presence.proto")], includes)
         .unwrap();
 
-    {
-        let mut config = prost_build::Config::new();
-        config.disable_comments(["."]);
-
-        config
-            .compile_protos(&[src.join("invalid_doctest.proto")], includes)
-            .unwrap();
-    }
+    prost_build::Config::new()
+        .disable_comments(["."])
+        .compile_protos(&[src.join("disable_comments.proto")], includes)
+        .unwrap();
 
     config
         .bytes(["."])

--- a/tests/src/disable_comments.proto
+++ b/tests/src/disable_comments.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package invalid.doctest;
+package disable_comments;
 
 // ```
 // invalid

--- a/tests/src/disable_comments.rs
+++ b/tests/src/disable_comments.rs
@@ -1,0 +1,3 @@
+//! MessageWithInvalidDoctest would generate a invalid doc test if
+//! `Config::disable_comments` doesn't work correctly.
+include!(concat!(env!("OUT_DIR"), "/disable_comments.rs"));

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -59,6 +59,9 @@ mod boxed_field;
 #[cfg(test)]
 mod custom_debug;
 
+// Must be `pub` as doc tests are only executed on public types.
+pub mod disable_comments;
+
 mod test_enum_named_option_value {
     include!(concat!(env!("OUT_DIR"), "/myenum.optionn.rs"));
 }
@@ -123,12 +126,6 @@ pub mod groups {
 pub mod proto3 {
     pub mod presence {
         include!(concat!(env!("OUT_DIR"), "/proto3.presence.rs"));
-    }
-}
-
-pub mod invalid {
-    pub mod doctest {
-        include!(concat!(env!("OUT_DIR"), "/invalid.doctest.rs"));
     }
 }
 


### PR DESCRIPTION
This test uses a invalid doctest to confirm `disable_comments` works as expected. Rename the test to what is tested.