### PR TITLE
test(custom_attributes): Move module to separate file

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -32,18 +32,10 @@ fn main() {
         "Foo.Bar_Baz.Foo_barBaz.fuzz_buster",
         "#[derive(Eq, PartialOrd, Ord)]",
     );
-    config.type_attribute("Foo.Custom.Attrs.Msg", "#[allow(missing_docs)]");
-    config.type_attribute("Foo.Custom.Attrs.Msg.field", "/// Oneof docs");
-    config.type_attribute("Foo.Custom.Attrs.AnEnum", "#[allow(missing_docs)]");
-    config.type_attribute("Foo.Custom.Attrs.AnotherEnum", "/// Oneof docs");
     config.type_attribute(
         "Foo.Custom.OneOfAttrs.Msg.field",
         "#[derive(Eq, PartialOrd, Ord)]",
     );
-    config.field_attribute("Foo.Custom.Attrs.AnotherEnum.C", "/// The C docs");
-    config.field_attribute("Foo.Custom.Attrs.AnotherEnum.D", "/// The D docs");
-    config.field_attribute("Foo.Custom.Attrs.Msg.field.a", "/// Oneof A docs");
-    config.field_attribute("Foo.Custom.Attrs.Msg.field.b", "/// Oneof B docs");
 
     config.file_descriptor_set_path(
         PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR environment variable not set"))
@@ -62,7 +54,15 @@ fn main() {
         .compile_protos(&[src.join("recursive_oneof.proto")], includes)
         .unwrap();
 
-    config
+    prost_build::Config::new()
+        .type_attribute("custom_attributes.Msg", "#[allow(missing_docs)]")
+        .type_attribute("custom_attributes.Msg.field", "/// Oneof docs")
+        .type_attribute("custom_attributes.AnEnum", "#[allow(missing_docs)]")
+        .type_attribute("custom_attributes.AnotherEnum", "/// Oneof docs")
+        .field_attribute("custom_attributes.AnotherEnum.C", "/// The C docs")
+        .field_attribute("custom_attributes.AnotherEnum.D", "/// The D docs")
+        .field_attribute("custom_attributes.Msg.field.a", "/// Oneof A docs")
+        .field_attribute("custom_attributes.Msg.field.b", "/// Oneof B docs")
         .compile_protos(&[src.join("custom_attributes.proto")], includes)
         .unwrap();
 

--- a/tests/src/custom_attributes.proto
+++ b/tests/src/custom_attributes.proto
@@ -1,8 +1,12 @@
 syntax = "proto3";
 
-package Foo.Custom.Attrs;
+package custom_attributes;
 
 message Msg {
+	oneof field {
+        string a = 1;
+        bytes b = 2;
+    }
 }
 
 enum AnEnum {

--- a/tests/src/custom_attributes.rs
+++ b/tests/src/custom_attributes.rs
@@ -1,0 +1,8 @@
+//! This tests the custom attributes support by abusing docs.
+//!
+//! Docs really are full-blown attributes. So we use them to ensure we can place them on everything
+//! we need. If they aren't put onto something or allowed not to be there (by the generator),
+//! compilation fails.
+#![deny(missing_docs)]
+
+include!(concat!(env!("OUT_DIR"), "/custom_attributes.rs"));

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -62,6 +62,10 @@ mod custom_debug;
 // Must be `pub` as doc tests are only executed on public types.
 pub mod disable_comments;
 
+#[cfg(test)]
+// Must be `pub` as `missing_docs` lint is only executed on public types.
+pub mod custom_attributes;
+
 mod test_enum_named_option_value {
     include!(concat!(env!("OUT_DIR"), "/myenum.optionn.rs"));
 }
@@ -90,16 +94,6 @@ pub mod nesting {
 
 pub mod recursive_oneof {
     include!(concat!(env!("OUT_DIR"), "/recursive_oneof.rs"));
-}
-
-/// This tests the custom attributes support by abusing docs.
-///
-/// Docs really are full-blown attributes. So we use them to ensure we can place them on everything
-/// we need. If they aren't put onto something or allowed not to be there (by the generator),
-/// compilation fails.
-#[deny(missing_docs)]
-pub mod custom_attributes {
-    include!(concat!(env!("OUT_DIR"), "/foo.custom.attrs.rs"));
 }
 
 /// Also for testing custom attributes, but on oneofs.


### PR DESCRIPTION
- Use package name `custom_attributes` to ease finding related files
- Make config dependency explicit in `build.rs`
- Add oneof fields to make every `field_attribute` part of the test