### PR TITLE
Make `key_len` and `encoding_len_varint` const

### DIFF
--- a/prost/src/encoding.rs
+++ b/prost/src/encoding.rs
@@ -130,8 +130,8 @@ pub fn decode_key(buf: &mut impl Buf) -> Result<(u32, WireType), DecodeError> {
 /// Returns the width of an encoded Protobuf field key with the given tag.
 /// The returned width will be between 1 and 5 bytes (inclusive).
 #[inline]
-pub fn key_len(tag: u32) -> usize {
-    encoded_len_varint(u64::from(tag << 3))
+pub const fn key_len(tag: u32) -> usize {
+    encoded_len_varint((tag << 3) as u64)
 }
 
 /// Helper function which abstracts reading a length delimiter prefix followed

--- a/prost/src/encoding/varint.rs
+++ b/prost/src/encoding/varint.rs
@@ -24,7 +24,7 @@ pub fn encode_varint(mut value: u64, buf: &mut impl BufMut) {
 /// Returns the encoded length of the value in LEB128 variable length format.
 /// The returned value will be between 1 and 10, inclusive.
 #[inline]
-pub fn encoded_len_varint(value: u64) -> usize {
+pub const fn encoded_len_varint(value: u64) -> usize {
     // Based on [VarintSize64][1].
     // [1]: https://github.com/protocolbuffers/protobuf/blob/v28.3/src/google/protobuf/io/coded_stream.h#L1744-L1756
     // Safety: value | 1 is non-zero.


### PR DESCRIPTION
The constness is not really needed anywhere in prost crates, but it won't hurt either.