### PR TITLE
let Message inherit AsAny

### DIFF
--- a/prost/Cargo.toml
+++ b/prost/Cargo.toml
@@ -24,6 +24,7 @@ std = []
 
 [dependencies]
 bytes = { version = "1", default-features = false }
+as-any = "0.3"
 prost-derive = { version = "0.13.4", path = "../prost-derive", optional = true }
 
 [dev-dependencies]

--- a/prost/src/message.rs
+++ b/prost/src/message.rs
@@ -14,7 +14,7 @@ use crate::DecodeError;
 use crate::EncodeError;
 
 /// A Protocol Buffers message.
-pub trait Message: Debug + Send + Sync {
+pub trait Message: as_any::AsAny + Debug + Send + Sync {
     /// Encodes the message to a buffer.
     ///
     /// This method will panic if the buffer has insufficient capacity.


### PR DESCRIPTION
introduce crate as `as_any`, and let `Message` inherits `AsAny`, then `dyn Message` can downcast to a concrete type easier. 
Here is a example,
```
    fn encode(&self, msg: &dyn Message, buf: &mut Vec<u8>) -> Result<(), TcpTransportError> {
        let msg = msg
            .downcast_ref::<T>()
            .ok_or(TcpTransportError::Infallible)?;

        // println!("type name: {}", msg.type_name());
        msg.encode(buf)?;
        Ok(())
    }
```