### PR TITLE
Remove unnecessary unsafe

### DIFF
--- a/prost/src/encoding/varint.rs
+++ b/prost/src/encoding/varint.rs
@@ -27,8 +27,8 @@ pub fn encode_varint(mut value: u64, buf: &mut impl BufMut) {
 pub const fn encoded_len_varint(value: u64) -> usize {
     // Based on [VarintSize64][1].
     // [1]: https://github.com/protocolbuffers/protobuf/blob/v28.3/src/google/protobuf/io/coded_stream.h#L1744-L1756
-    // Safety: value | 1 is non-zero.
-    let log2value = unsafe { NonZeroU64::new_unchecked(value | 1) }.ilog2();
+    // Telease optimizations will eliminate the unwrap from generated code.
+    let log2value = NonZeroU64::new(value | 1).unwrap().ilog2();
     ((log2value * 9 + (64 + 9)) / 64) as usize
 }
 


### PR DESCRIPTION
As suggested by @anforowicz in [1], this `new_unchecked` is unnecessary, as the value can be trivially determined to be nonzero.

See [compiler explorer](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:rust,selection:(endColumn:49,endLineNumber:20,positionColumn:49,positionLineNumber:20,selectionStartColumn:49,selectionStartLineNumber:20,startColumn:49,startLineNumber:20),source:'//+Type+your+code+here,+or+load+an+example.%0Ause+std::num::NonZeroU64%3B%0Ause+std::hint::black_box%3B%0A%0A%23%5Bno_mangle%5D%0Apub+fn+foo(value:+u64)+%7B%0A++++black_box(checked(value))%3B%0A++++black_box(unchecked(value))%3B%0A%7D%0A%0A%23%5Bno_mangle%5D%0A%23%5Binline(never)%5D%0Apub+fn+checked(value:+u64)+-%3E+NonZeroU64+%7B%0A++++NonZeroU64::new(value+%7C+1).unwrap()%0A%7D%0A%0A%23%5Bno_mangle%5D%0A%23%5Binline(never)%5D%0Apub+fn+unchecked(value:+u64)+-%3E+NonZeroU64+%7B%0A++++unsafe+%7B+NonZeroU64::new_unchecked(value+%7C+2)+%7D%0A%7D%0A%0A//+If+you+use+%60main()%60,+declare+it+as+%60pub%60+to+see+it+in+the+output:%0A//+pub+fn+main()+%7B+...+%7D%0A'),l:'5',n:'0',o:'Rust+source+%231',t:'0')),k:50,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:output,i:(compilerName:'rustc+1.83.0',editorid:1,fontScale:14,fontUsePx:'0',j:1,wrap:'1'),l:'5',n:'0',o:'Output+of+rustc+1.83.0+(Compiler+%231)',t:'0')),header:(),k:25,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:r1830,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:rust,libs:!(),options:'-O',overrides:!(),selection:(endColumn:1,endLineNumber:1,positionColumn:1,positionLineNumber:1,selectionStartColumn:1,selectionStartLineNumber:1,startColumn:1,startLineNumber:1),source:1),l:'5',n:'0',o:'+rustc+1.83.0+(Editor+%231)',t:'0')),k:25,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4) to validate that this is correctly optimized (with `-O`).

[1] https://chromium-review.googlesource.com/c/chromium/src/+/6099062?tab=comments

cc: @mzabaluev per https://github.com/tokio-rs/prost/commit/5ae30c5fd2725132c4daa0ef9f6d2f14f1308bd5