### PR TITLE
Add a config option to avoid passing include_source_info

### DIFF
--- a/prost-build/src/config.rs
+++ b/prost-build/src/config.rs
@@ -614,7 +614,6 @@ impl Config {
     ///     .skip_source_info()
     ///     .compile_protos(&["src/items.proto"], &["src/"]);
     /// ```
-    ///
     pub fn skip_source_info(&mut self) -> &mut Self {
         self.skip_source_info = true;
         self

--- a/prost-build/src/config.rs
+++ b/prost-build/src/config.rs
@@ -599,7 +599,7 @@ impl Config {
     }
 
     /// Configures the code generator to remove surrounding comments and documentation.
-    /// 
+    ///
     /// If enabled, this will cause `protoc` to not be passed the `--include_source_info` argument.
     /// Typically, `--include_source_info` is passed by default, but it results in larger
     /// [`FileDescriptorSet`s](https://github.com/protocolbuffers/protobuf/blob/cff254d32f850ba8186227ce6775b3f01a1f8cf8/src/google/protobuf/descriptor.proto#L54-L66) that include information about the

--- a/prost-build/src/config.rs
+++ b/prost-build/src/config.rs
@@ -598,11 +598,13 @@ impl Config {
         self
     }
 
-    /// This can be used to avoid passing ``--include_source_info`` argument when the `protoc`
-    /// command is invoked to generate the `FileDescriptorSet`. The ``--include_source_info``
-    /// flag is passed by default, however it results in vastly larger descriptors that
-    /// include information about the original location of each decl in the source file as
-    /// well as surrounding comments.
+    /// Configures the code generator to remove surrounding comments and documentation.
+    /// 
+    /// If enabled, this will cause `protoc` to not be passed the `--include_source_info` argument.
+    /// Typically, `--include_source_info` is passed by default, but it results in larger
+    /// [`FileDescriptorSet`s](https://github.com/protocolbuffers/protobuf/blob/cff254d32f850ba8186227ce6775b3f01a1f8cf8/src/google/protobuf/descriptor.proto#L54-L66) that include information about the
+    /// original location of each declaration in the source file as well as surrounding
+    /// comments and documentation.
     ///
     /// In `build.rs`:
     ///


### PR DESCRIPTION
Fixes #1213

We already support passing ``disable_comments`` to disable comment processing during the code generation.

However, when we compile FileDescriptorSet, we always pass ``--include_source_info``. These might cause a problem, especially when the file is later included into the final binary using ``include_bytes!`` e.g. because of the following:
- The comments might contain sensitive private information (comments + file location) which we don't want to be visible in the binary (e.g. when  someone disassemble it).
- It increases the size of the binary

Therefore, adding the ``skip_source_info`` argument allowing to disable it.  Altnerative fix could be to add it ``protoc_args`` by default, but this is not backwards compatible, because ``protoc_args`` are currently additive only.