### PR TITLE
style: Replace unnecessary `map_or`

### DIFF
--- a/prost-build/src/ast.rs
+++ b/prost-build/src/ast.rs
@@ -103,7 +103,7 @@ impl Comments {
         let mut chars = sanitized_line.chars();
         chars
             .next()
-            .map_or(false, |c| c != ' ' || chars.next() == Some(' '))
+            .is_some_and(|c| c != ' ' || chars.next() == Some(' '))
     }
 
     /// Sanitizes the line for rustdoc by performing the following operations:

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -986,7 +986,7 @@ impl CodeGenerator<'_> {
         // If no package is specified the start of the package name will be '.'
         // and split will return an empty string ("") which breaks resolution
         // The fix to this is to ignore the first item if it is empty.
-        if local_path.peek().map_or(false, |s| s.is_empty()) {
+        if local_path.peek().is_some_and(|s| s.is_empty()) {
             local_path.next();
         }
 
@@ -1103,10 +1103,7 @@ impl CodeGenerator<'_> {
 
     /// Returns `true` if the field options includes the `deprecated` option.
     fn deprecated(&self, field: &FieldDescriptorProto) -> bool {
-        field
-            .options
-            .as_ref()
-            .map_or(false, FieldOptions::deprecated)
+        field.options.as_ref().is_some_and(FieldOptions::deprecated)
     }
 
     /// Returns the fully-qualified name, starting with a dot


### PR DESCRIPTION
Fixes clippy lints like this:
```
warning: this `map_or` is redundant
   --> prost-build/src/ast.rs:104:9
    |
104 | /         chars
105 | |             .next()
106 | |             .map_or(false, |c| c != ' ' || chars.next() == Some(' '))
    | |_____________________________________________________________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or
    = note: `#[warn(clippy::unnecessary_map_or)]` on by default
```