### PR TITLE
fix(prost-build): Make `type_name_domain` cumulative

### DIFF
--- a/prost-build/src/config.rs
+++ b/prost-build/src/config.rs
@@ -684,7 +684,6 @@ impl Config {
         S: AsRef<str>,
         D: AsRef<str>,
     {
-        self.type_name_domains.clear();
         for matcher in paths {
             self.type_name_domains
                 .insert(matcher.as_ref().to_string(), domain.as_ref().to_string());

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -165,6 +165,7 @@ fn main() {
     prost_build::Config::new()
         .enable_type_names()
         .type_name_domain([".type_names.Foo"], "tests")
+        .type_name_domain([".type_names.Qux"], "tests-cumulative")
         .compile_protos(&[src.join("type_names.proto")], includes)
         .unwrap();
 

--- a/tests/src/type_names.proto
+++ b/tests/src/type_names.proto
@@ -9,3 +9,6 @@ message Foo {
 
 message Baz {
 }
+
+message Qux {
+}

--- a/tests/src/type_names.rs
+++ b/tests/src/type_names.rs
@@ -18,4 +18,9 @@ fn valid_type_names() {
     assert_eq!("type_names", Baz::PACKAGE);
     assert_eq!("type_names.Baz", Baz::full_name());
     assert_eq!("/type_names.Baz", Baz::type_url());
+
+    assert_eq!("Qux", Qux::NAME);
+    assert_eq!("type_names", Qux::PACKAGE);
+    assert_eq!("type_names.Qux", Qux::full_name());
+    assert_eq!("tests-cumulative/type_names.Qux", Qux::type_url());
 }


### PR DESCRIPTION
Changes the `type_name_domain` config to behave closer to the way `extern_path` does.

This allows setting more than 1 path to domain mappings.

The original behavior of clearing previous mappings didn't make a lot of sense to me, but perhaps it was working as intended. If that's the case, then this would be a feature instead of a fix I guess.

BREAKING CHANGE: The configuration for domain names of messages is now cumulative. All calls to prost_build::Config::type_name_domain are now concatenated. The previous behavior was that only the arguments of the last call were used. If you do multiple calls to type_name_domain, you need to remove all but the last call to maintain the same behavior.