### PR TITLE
Revert "[decode_length_delimiter] document behavior for error with 10 bytes buffer"

### DIFF
--- a/prost/src/encoding/length_delimiter.rs
+++ b/prost/src/encoding/length_delimiter.rs
@@ -40,7 +40,7 @@ pub fn length_delimiter_len(length: usize) -> usize {
 ///
 ///  * If the supplied buffer contains fewer than 10 bytes, then an error indicates that more
 ///    input is required to decode the full delimiter.
-///  * If the supplied buffer contains 10 bytes or more, then the buffer contains an invalid
+///  * If the supplied buffer contains more than 10 bytes, then the buffer contains an invalid
 ///    delimiter, and typically the buffer should be considered corrupt.
 pub fn decode_length_delimiter(mut buf: impl Buf) -> Result<usize, DecodeError> {
     let length = decode_varint(&mut buf)?;


### PR DESCRIPTION
Reverts tokio-rs/prost#1208

Varints can, and very often are, ten bytes in length. In fact it often causes great pain that types like `int32` encode ten whole bytes for literally any negative value.

https://protobuf.dev/programming-guides/encoding/#varints