### PR TITLE
fix(prost-build): Prevent repeated fields to be boxed

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -172,6 +172,7 @@ fn main() {
     prost_build::Config::new()
         .boxed("Foo.bar")
         .boxed("Foo.oneof_field.box_qux")
+        .boxed("Foo.boxed_bar_list")
         .compile_protos(&[src.join("boxed_field.proto")], includes)
         .unwrap();
 

--- a/tests/src/boxed_field.proto
+++ b/tests/src/boxed_field.proto
@@ -8,6 +8,7 @@ message Foo {
     string baz = 2;
     Bar box_qux = 3;
   }
+  repeated Bar boxed_bar_list = 4;
 }
 
 message Bar {

--- a/tests/src/boxed_field.rs
+++ b/tests/src/boxed_field.rs
@@ -3,15 +3,18 @@ include!(concat!(env!("OUT_DIR"), "/boxed_field.rs"));
 use self::foo::OneofField;
 
 #[test]
-/// Confirm `Foo::bar` and `OneofField::BoxQux` is boxed by creating an instance
+/// - Confirm `Foo::bar` and `OneofField::BoxQux` is boxed by creating an instance
+/// - `Foo::boxed_bar_list` should not be boxed as it is a `Vec`, therefore it is already heap allocated
 fn test_boxed_field() {
     use alloc::boxed::Box;
-    let _ = Foo {
+    use alloc::vec::Vec;
+    let foo = Foo {
         bar: Some(Box::new(Bar {})),
         oneof_field: Some(OneofField::BoxQux(Box::new(Bar {}))),
+        boxed_bar_list: Vec::from([Bar {}]),
     };
     let _ = Foo {
-        bar: Some(Box::new(Bar {})),
         oneof_field: Some(OneofField::Baz("hello".into())),
+        ..foo
     };
 }


### PR DESCRIPTION
Repeated fields are stored in a `Vec`, and therefore they are already heap allocated.

BREAKING CHANGE: A repeated field that is manually marked as boxed was typed as `Vec<Box<T>>`. Those fields are now simply typed as `Vec<T>` to prevent double indirection. The `boxed` configuration is effectively ignored for repeated fields.