### PR TITLE
style(prost-build): Use enum getter

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -383,7 +383,7 @@ impl<'b> CodeGenerator<'_, 'b> {
 
     fn append_field(&mut self, fq_message_name: &str, field: &Field) {
         let type_ = field.descriptor.r#type();
-        let repeated = field.descriptor.label == Some(Label::Repeated as i32);
+        let repeated = field.descriptor.label() == Label::Repeated;
         let deprecated = self.deprecated(&field.descriptor);
         let optional = self.optional(&field.descriptor);
         let boxed = self

--- a/prost-build/src/context.rs
+++ b/prost-build/src/context.rs
@@ -141,7 +141,7 @@ impl<'a> Context<'a> {
         oneof: Option<&str>,
         field: &FieldDescriptorProto,
     ) -> bool {
-        let repeated = field.label == Some(Label::Repeated as i32);
+        let repeated = field.label() == Label::Repeated;
         let fd_type = field.r#type();
         if !repeated
             && (fd_type == Type::Message || fd_type == Type::Group)


### PR DESCRIPTION
Use enum getter function to compare enum values instead of `i32` values.