### PR TITLE
test(default_string_escape): Move tests to separate module

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -99,7 +99,7 @@ fn main() {
         .compile_protos(&[src.join("derive_copy.proto")], includes)
         .unwrap();
 
-    config
+    prost_build::Config::new()
         .compile_protos(&[src.join("default_string_escape.proto")], includes)
         .unwrap();
 

--- a/tests/src/default_string_escape.rs
+++ b/tests/src/default_string_escape.rs
@@ -1,0 +1,7 @@
+include!(concat!(env!("OUT_DIR"), "/default_string_escape.rs"));
+
+#[test]
+fn test_default_string_escape() {
+    let msg = Person::default();
+    assert_eq!(msg.name, r#"["unknown"]"#);
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -78,6 +78,9 @@ mod recursive_oneof;
 #[cfg(test)]
 mod groups;
 
+#[cfg(test)]
+mod default_string_escape;
+
 mod test_enum_named_option_value {
     include!(concat!(env!("OUT_DIR"), "/myenum.optionn.rs"));
 }
@@ -113,10 +116,6 @@ pub mod proto3 {
     pub mod presence {
         include!(concat!(env!("OUT_DIR"), "/proto3.presence.rs"));
     }
-}
-
-pub mod default_string_escape {
-    include!(concat!(env!("OUT_DIR"), "/default_string_escape.rs"));
 }
 
 #[cfg(not(feature = "std"))]
@@ -392,12 +391,6 @@ mod tests {
         // https://github.com/tokio-rs/prost/issues/267
         let buf = vec![b'C'; 1 << 20];
         <() as Message>::decode(&buf[..]).err().unwrap();
-    }
-
-    #[test]
-    fn test_default_string_escape() {
-        let msg = default_string_escape::Person::default();
-        assert_eq!(msg.name, r#"["unknown"]"#);
     }
 
     #[test]


### PR DESCRIPTION
- Move related tests to separate module
- Make config dependency explicit in `build.rs`