### PR TITLE
feat: Remove prost-derive feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ the `std` features in `prost` and `prost-types`:
 
 ```ignore
 [dependencies]
-prost = { version = "0.13.5", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.13.5", default-features = false, features = ["derive"] }
 # Only necessary if using Protobuf well-known types:
 prost-types = { version = "0.13.5", default-features = false }
 ```

--- a/prost-types/Cargo.toml
+++ b/prost-types/Cargo.toml
@@ -18,7 +18,7 @@ std = ["prost/std"]
 arbitrary = ["dep:arbitrary"]
 
 [dependencies]
-prost = { version = "0.13.5", path = "../prost", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.13.5", path = "../prost", default-features = false, features = ["derive"] }
 arbitrary = { version = "1.4", features = ["derive"], optional = true }
 chrono = { version = "0.4.34", default-features = false, optional = true }
 

--- a/prost/Cargo.toml
+++ b/prost/Cargo.toml
@@ -18,7 +18,6 @@ bench = false
 [features]
 default = ["derive", "std"]
 derive = ["dep:prost-derive"]
-prost-derive = ["derive"]     # deprecated, please use derive feature instead
 no-recursion-limit = []
 std = []
 

--- a/prost/README.md
+++ b/prost/README.md
@@ -380,7 +380,7 @@ the `std` features in `prost` and `prost-types`:
 
 ```ignore
 [dependencies]
-prost = { version = "0.13.5", default-features = false, features = ["prost-derive"] }
+prost = { version = "0.13.5", default-features = false, features = ["derive"] }
 # Only necessary if using Protobuf well-known types:
 prost-types = { version = "0.13.5", default-features = false }
 ```


### PR DESCRIPTION
Removes the deprecated prost-derive feature.

BREAKING CHANGE: Feature flag `prost-derive` is renamed to `derive`. Please rename any usage of `prost-derive` feature in your `Cargo.toml`.