### PR TITLE
harden `ref mut` according to edition 2024

### DIFF
--- a/prost-build/src/message_graph.rs
+++ b/prost-build/src/message_graph.rs
@@ -41,15 +41,11 @@ impl MessageGraph {
     }
 
     fn get_or_insert_index(&mut self, msg_name: String) -> NodeIndex {
-        let MessageGraph {
-            ref mut index,
-            ref mut graph,
-            ..
-        } = *self;
         assert_eq!(b'.', msg_name.as_bytes()[0]);
-        *index
+        *self
+            .index
             .entry(msg_name.clone())
-            .or_insert_with(|| graph.add_node(msg_name))
+            .or_insert_with(|| self.graph.add_node(msg_name))
     }
 
     /// Adds message to graph IFF it contains a non-repeated field containing another message.

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -441,7 +441,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
         quote! {
             #tag => {
                 match field {
-                    ::core::option::Option::Some(#ident::#variant_ident(ref mut value)) => {
+                    &mut ::core::option::Option::Some(#ident::#variant_ident(ref mut value)) => {
                         #merge
                     },
                     _ => {

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -439,17 +439,12 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
         let tag = field.tags()[0];
         let merge = field.merge(quote!(value));
         quote! {
-            #tag => {
-                match field {
-                    &mut ::core::option::Option::Some(#ident::#variant_ident(ref mut value)) => {
-                        #merge
-                    },
-                    _ => {
-                        let mut owned_value = ::core::default::Default::default();
-                        let value = &mut owned_value;
-                        #merge.map(|_| *field = ::core::option::Option::Some(#ident::#variant_ident(owned_value)))
-                    },
-                }
+            #tag => if let ::core::option::Option::Some(#ident::#variant_ident(value)) = field {
+                #merge
+            } else {
+                let mut owned_value = ::core::default::Default::default();
+                let value = &mut owned_value;
+                #merge.map(|_| *field = ::core::option::Option::Some(#ident::#variant_ident(owned_value)))
             }
         }
     });


### PR DESCRIPTION
Ref: https://doc.rust-lang.org/edition-guide/rust-2024/match-ergonomics.html

The direct impact of this is, some prost structs are modded in our codebase by (1) use cargo-expand to unfold prost implementation (2) use script to replace certain types. After upgrading to edition-2024 the output from (1) triggers complaint from rust.