### PR TITLE
style: Use DoubleEndedIterator::next_back

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 
 env:
   PROTOC_VERSION: '3.25.3'
-  clippy_rust_version: '1.83'
+  clippy_rust_version: '1.85'
 
 jobs:
   # Depends on all actions that are required for a "successful" CI run.

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -470,7 +470,7 @@ impl<'b> CodeGenerator<'_, 'b> {
                         .descriptor
                         .type_name
                         .as_ref()
-                        .and_then(|ty| ty.split('.').last())
+                        .and_then(|ty| ty.split('.').next_back())
                         .unwrap();
 
                     enum_value = strip_enum_prefix(&to_upper_camel(enum_type), &enum_value)


### PR DESCRIPTION
Prevents clippy warnings like:
```
warning: called `Iterator::last` on a `DoubleEndedIterator`; this will needlessly iterate the entire iterator
   --> prost-build/src/code_generator.rs:473:54
    |
473 |                         .and_then(|ty| ty.split('.').last())
    |                                                      ^^^^^^ help: try: `next_back()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#double_ended_iterator_last
    = note: `#[warn(clippy::double_ended_iterator_last)]` on by default
```