### PR TITLE
style: Prepare for 2024 keyword `gen`

### DIFF
--- a/prost-build/src/ident.rs
+++ b/prost-build/src/ident.rs
@@ -18,7 +18,9 @@ pub fn sanitize_identifier(s: impl AsRef<str>) -> String {
         | "abstract" | "become" | "box" | "do" | "final" | "macro" | "override" | "priv" | "typeof"
         | "unsized" | "virtual" | "yield"
         // 2018 reserved keywords.
-        | "async" | "await" | "try" => format!("r#{}", ident),
+        | "async" | "await" | "try"
+        // 2024 reserved keywords.
+        | "gen" => format!("r#{}", ident),
         // the following keywords are not supported as raw identifiers and are therefore suffixed with an underscore.
         "_" | "super" | "self" | "Self" | "extern" | "crate" => format!("{}_", ident),
         // the following keywords begin with a number and are therefore prefixed with an underscore.
@@ -118,6 +120,7 @@ mod tests {
         assert_eq!(sanitize_identifier("async"), "r#async");
         assert_eq!(sanitize_identifier("await"), "r#await");
         assert_eq!(sanitize_identifier("try"), "r#try");
+        assert_eq!(sanitize_identifier("gen"), "r#gen");
         assert_eq!(sanitize_identifier("self"), "self_");
         assert_eq!(sanitize_identifier("super"), "super_");
         assert_eq!(sanitize_identifier("extern"), "extern_");
@@ -219,6 +222,7 @@ mod tests {
         assert_eq!("r#async", &to_snake("async"));
         assert_eq!("r#await", &to_snake("await"));
         assert_eq!("r#try", &to_snake("try"));
+        assert_eq!("r#gen", &to_snake("gen"));
     }
 
     #[test]

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -397,10 +397,10 @@ mod tests {
         let tempdir = tempfile::tempdir().unwrap();
 
         let state = Rc::new(RefCell::new(MockState::default()));
-        let gen = MockServiceGenerator::new(Rc::clone(&state));
+        let generator = MockServiceGenerator::new(Rc::clone(&state));
 
         Config::new()
-            .service_generator(Box::new(gen))
+            .service_generator(Box::new(generator))
             .include_file("_protos.rs")
             .out_dir(tempdir.path())
             .compile_protos(
@@ -467,13 +467,13 @@ mod tests {
     fn test_generate_no_empty_outputs() {
         let _ = env_logger::try_init();
         let state = Rc::new(RefCell::new(MockState::default()));
-        let gen = MockServiceGenerator::new(Rc::clone(&state));
+        let generator = MockServiceGenerator::new(Rc::clone(&state));
         let include_file = "_include.rs";
         let tempdir = tempfile::tempdir().unwrap();
         let previously_empty_proto_path = tempdir.path().join(Path::new("google.protobuf.rs"));
 
         Config::new()
-            .service_generator(Box::new(gen))
+            .service_generator(Box::new(generator))
             .include_file(include_file)
             .out_dir(tempdir.path())
             .compile_protos(
@@ -529,12 +529,12 @@ mod tests {
 
         for _ in 1..10 {
             let state = Rc::new(RefCell::new(MockState::default()));
-            let gen = MockServiceGenerator::new(Rc::clone(&state));
+            let generator = MockServiceGenerator::new(Rc::clone(&state));
             let include_file = "_include.rs";
             let tempdir = tempfile::tempdir().unwrap();
 
             Config::new()
-                .service_generator(Box::new(gen))
+                .service_generator(Box::new(generator))
                 .include_file(include_file)
                 .out_dir(tempdir.path())
                 .compile_protos(

--- a/tests/src/enum_keyword_variant.proto
+++ b/tests/src/enum_keyword_variant.proto
@@ -9,6 +9,7 @@ enum Feeding {
   FEEDING_SELF = 2;
   FEEDING_ELSE = 3;
   FEEDING_ERROR = 4;
+  FEEDING_GEN = 5;
 }
 
 enum Grooming {

--- a/tests/src/enum_keyword_variant.rs
+++ b/tests/src/enum_keyword_variant.rs
@@ -1,6 +1,16 @@
-mod enum_keyword_variant {
-    include!(concat!(env!("OUT_DIR"), "/enum_keyword_variant.rs"));
-}
+include!(concat!(env!("OUT_DIR"), "/enum_keyword_variant.rs"));
 
 #[test]
-fn dummy() {}
+fn test_usage() {
+    let _ = Feeding::Assisted;
+    let _ = Feeding::Self_;
+    let _ = Feeding::Else;
+    let _ = Feeding::Error;
+    let _ = Feeding::Gen;
+
+    let _ = Grooming::Assisted;
+    let _ = Grooming::Self_;
+    let _ = Grooming::Else;
+
+    let _ = Number::Number1;
+}

--- a/tests/src/ident_conversion.proto
+++ b/tests/src/ident_conversion.proto
@@ -62,6 +62,7 @@ message Foo_barBaz {
   int32 super = 51;
   int32 extern = 52;
   int32 crate = 53;
+  int32 gen = 54;
 
   message Self {
   }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -356,6 +356,7 @@ mod tests {
             super_: 51,
             extern_: 52,
             crate_: 53,
+            r#gen: 54,
         };
 
         let _ = foo::bar_baz::foo_bar_baz::Self_ {};


### PR DESCRIPTION
In rust edition 2024 `gen` is a keyword.

- Prefix protobuf field name `r#gen`
- Rename variable names in our code