### PR TITLE
docs: update dead link LICENSE in `prost-types/README.md`

### DIFF
--- a/prost-types/README.md
+++ b/prost-types/README.md
@@ -16,6 +16,6 @@ included under its original ([BSD][2]) license.
 
 [2]: https://github.com/google/protobuf/blob/master/LICENSE
 
-See [LICENSE](../LICENSE) for details.
+See [LICENSE](./LICENSE) for details.
 
 Copyright 2017 Dan Burkert

--- a/prost-types/README.md
+++ b/prost-types/README.md
@@ -16,6 +16,6 @@ included under its original ([BSD][2]) license.
 
 [2]: https://github.com/google/protobuf/blob/master/LICENSE
 
-See [LICENSE](..LICENSE) for details.
+See [LICENSE](../LICENSE) for details.
 
 Copyright 2017 Dan Burkert


### PR DESCRIPTION
Hi! I fixed a broken relative link to the project LICENSE file in `prost-types/README.md`. The previous link had incorrect path syntax.