### PR TITLE
feature(custom-derive) Adds config options to customize derives in code_generation

### DIFF
--- a/prost-build/Cargo.toml
+++ b/prost-build/Cargo.toml
@@ -10,10 +10,10 @@ edition.workspace = true
 rust-version.workspace = true
 
 [features]
-default = ["format"]
+default = ["format", "custom-derive"]
 format = ["dep:prettyplease", "dep:syn"]
 cleanup-markdown = ["dep:pulldown-cmark", "dep:pulldown-cmark-to-cmark"]
-
+custom-derive = []
 [dependencies]
 heck = { version = ">=0.4, <=0.5" }
 itertools = { version = ">=0.10, <=0.14", default-features = false, features = ["use_alloc"] }

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -238,7 +238,11 @@ impl<'b> CodeGenerator<'_, 'b> {
             {
                 #[cfg(feature = "custom-derive")]
                 {
-                    String::from(", ") + &self.config().custom_message_derives.join(", ")
+                    if self.config().custom_message_derives.len() > 0 {
+                        String::from(", ") + &self.config().custom_message_derives.join(", ")
+                    } else {
+                        String::from("")
+                    }
                 }
                 #[cfg(not(feature = "custom-derive"))]
                 {
@@ -627,7 +631,11 @@ impl<'b> CodeGenerator<'_, 'b> {
             {
                 #[cfg(feature = "custom-derive")]
                 {
-                    String::from(", ") + &self.config().custom_oneof_derives.join(", ")
+                    if self.config().custom_oneof_derives.len() > 0 {
+                        String::from(", ") + &self.config().custom_oneof_derives.join(", ")
+                    } else {
+                        String::from("")
+                    }
                 }
                 #[cfg(not(feature = "custom-derive"))]
                 {
@@ -744,7 +752,11 @@ impl<'b> CodeGenerator<'_, 'b> {
             {
                 #[cfg(feature = "custom-derive")]
                 {
-                    String::from(", ") + &self.config().custom_enum_derives.join(", ")
+                    if self.config().custom_enum_derives.len() > 0 {
+                        String::from(", ") + &self.config().custom_enum_derives.join(", ")
+                    } else {
+                        String::from("")
+                    }
                 }
                 #[cfg(not(feature = "custom-derive"))]
                 {

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -223,7 +223,7 @@ impl<'b> CodeGenerator<'_, 'b> {
         self.append_message_attributes(&fq_message_name);
         self.push_indent();
         self.buf.push_str(&format!(
-            "#[derive(Clone, {}PartialEq, {}{}::Message)]\n",
+            "#[derive(Clone, {}PartialEq, {}{}::Message{})]\n",
             if self.context.can_message_derive_copy(&fq_message_name) {
                 "Copy, "
             } else {
@@ -234,7 +234,17 @@ impl<'b> CodeGenerator<'_, 'b> {
             } else {
                 ""
             },
-            self.context.prost_path()
+            self.context.prost_path(),
+            {
+                #[cfg(feature = "custom-derive")]
+                {
+                    String::from(", ") + &self.config().custom_message_derives.join(", ")
+                }
+                #[cfg(not(feature = "custom-derive"))]
+                {
+                    String::from("")
+                }
+            }
         ));
         self.append_skip_debug(&fq_message_name);
         self.push_indent();
@@ -606,14 +616,24 @@ impl<'b> CodeGenerator<'_, 'b> {
                 .can_field_derive_eq(fq_message_name, &field.descriptor)
         });
         self.buf.push_str(&format!(
-            "#[derive(Clone, {}PartialEq, {}{}::Oneof)]\n",
+            "#[derive(Clone, {}PartialEq, {}{}::Oneof{})]\n",
             if can_oneof_derive_copy { "Copy, " } else { "" },
             if can_oneof_derive_eq {
                 "Eq, Hash, "
             } else {
                 ""
             },
-            self.context.prost_path()
+            self.context.prost_path(),
+            {
+                #[cfg(feature = "custom-derive")]
+                {
+                    String::from(", ") + &self.config().custom_oneof_derives.join(", ")
+                }
+                #[cfg(not(feature = "custom-derive"))]
+                {
+                    String::from("")
+                }
+            }
         ));
         self.append_skip_debug(fq_message_name);
         self.push_indent();
@@ -718,9 +738,19 @@ impl<'b> CodeGenerator<'_, 'b> {
             "Debug, "
         };
         self.buf.push_str(&format!(
-            "#[derive(Clone, Copy, {}PartialEq, Eq, Hash, PartialOrd, Ord, {}::Enumeration)]\n",
+            "#[derive(Clone, Copy, {}PartialEq, Eq, Hash, PartialOrd, Ord, {}::Enumeration{})]\n",
             dbg,
             self.context.prost_path(),
+            {
+                #[cfg(feature = "custom-derive")]
+                {
+                    String::from(", ") + &self.config().custom_enum_derives.join(", ")
+                }
+                #[cfg(not(feature = "custom-derive"))]
+                {
+                    String::from("")
+                }
+            }
         ));
         self.push_indent();
         self.buf.push_str("#[repr(i32)]\n");

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -238,7 +238,7 @@ impl<'b> CodeGenerator<'_, 'b> {
             {
                 #[cfg(feature = "custom-derive")]
                 {
-                    if self.config().custom_message_derives.len() > 0 {
+                    if !self.config().custom_message_derives.is_empty() {
                         String::from(", ") + &self.config().custom_message_derives.join(", ")
                     } else {
                         String::from("")
@@ -631,7 +631,7 @@ impl<'b> CodeGenerator<'_, 'b> {
             {
                 #[cfg(feature = "custom-derive")]
                 {
-                    if self.config().custom_oneof_derives.len() > 0 {
+                    if !self.config().custom_oneof_derives.is_empty() {
                         String::from(", ") + &self.config().custom_oneof_derives.join(", ")
                     } else {
                         String::from("")
@@ -752,7 +752,7 @@ impl<'b> CodeGenerator<'_, 'b> {
             {
                 #[cfg(feature = "custom-derive")]
                 {
-                    if self.config().custom_enum_derives.len() > 0 {
+                    if !self.config().custom_enum_derives.is_empty() {
                         String::from(", ") + &self.config().custom_enum_derives.join(", ")
                     } else {
                         String::from("")

--- a/prost-build/src/config.rs
+++ b/prost-build/src/config.rs
@@ -54,6 +54,12 @@ pub struct Config {
     pub(crate) prost_path: Option<String>,
     #[cfg(feature = "format")]
     pub(crate) fmt: bool,
+    #[cfg(feature = "custom-derive")]
+    pub(crate) custom_message_derives: Vec<String>,
+    #[cfg(feature = "custom-derive")]
+    pub(crate) custom_oneof_derives: Vec<String>,
+    #[cfg(feature = "custom-derive")]
+    pub(crate) custom_enum_derives: Vec<String>,
 }
 
 impl Config {
@@ -1145,6 +1151,17 @@ impl Config {
             *buf = with_generated;
         }
     }
+    #[cfg(feature = "custom-derive")]
+    pub fn with_custom_derives(
+        &mut self,
+        message_derives: Vec<String>,
+        oneof_derives: Vec<String>,
+        enum_derives: Vec<String>,
+    ) {
+        self.custom_message_derives.extend(message_derives);
+        self.custom_oneof_derives.extend(oneof_derives);
+        self.custom_enum_derives.extend(enum_derives);
+    }
 }
 
 /// Write a slice as the entire contents of a file.
@@ -1196,6 +1213,12 @@ impl default::Default for Config {
             prost_path: None,
             #[cfg(feature = "format")]
             fmt: true,
+            #[cfg(feature = "custom-derive")]
+            custom_message_derives: vec![],
+            #[cfg(feature = "custom-derive")]
+            custom_oneof_derives: vec![],
+            #[cfg(feature = "custom-derive")]
+            custom_enum_derives: vec![],
         }
     }
 }


### PR DESCRIPTION
first time making a pr to a decently sized project, but here goes;

I was working on a personal project of mine and found that one of the few things that prost doesn't have compared to the regular rust protobuf crates is custom derives (though in that crate its an entire `Customizer` struct for that stuff), this just kinda adds a few little properties and a `fn` or two to get a similar functionality, based on my usages it seems to work well (I'm using this for `serde::Deserialize` and `serde::Serialize`)

There's almost definitely a better way to implement this but I think if this feature is to be implemented this is a good start