### PR TITLE
style: Use variables directly in the `format!` string

### DIFF
--- a/conformance/src/main.rs
+++ b/conformance/src/main.rs
@@ -29,7 +29,7 @@ fn main() -> io::Result<()> {
 
         let result = match ConformanceRequest::decode(bytes.as_slice()) {
             Ok(request) => handle_request(request),
-            Err(error) => conformance_response::Result::ParseError(format!("{:?}", error)),
+            Err(error) => conformance_response::Result::ParseError(format!("{error:?}")),
         };
 
         let response = ConformanceResponse {

--- a/prost-build/src/ast.rs
+++ b/prost-build/src/ast.rs
@@ -193,7 +193,7 @@ where
                             if s.as_ref() == "rust" {
                                 CodeBlockKind::Fenced("compile_fail".into())
                             } else {
-                                CodeBlockKind::Fenced(format!("text,{}", s).into())
+                                CodeBlockKind::Fenced(format!("text,{s}").into())
                             }
                         }
                         CodeBlockKind::Indented => CodeBlockKind::Fenced("text".into()),

--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -310,10 +310,8 @@ impl<'b> CodeGenerator<'_, 'b> {
         ));
         self.depth += 1;
 
-        self.buf.push_str(&format!(
-            "const NAME: &'static str = \"{}\";\n",
-            message_name,
-        ));
+        self.buf
+            .push_str(&format!("const NAME: &'static str = \"{message_name}\";\n"));
         self.buf.push_str(&format!(
             "const PACKAGE: &'static str = \"{}\";\n",
             self.package,
@@ -492,13 +490,13 @@ impl<'b> CodeGenerator<'_, 'b> {
 
         if repeated {
             self.buf
-                .push_str(&format!("{}::alloc::vec::Vec<", prost_path));
+                .push_str(&format!("{prost_path}::alloc::vec::Vec<"));
         } else if optional {
             self.buf.push_str("::core::option::Option<");
         }
         if boxed {
             self.buf
-                .push_str(&format!("{}::alloc::boxed::Box<", prost_path));
+                .push_str(&format!("{prost_path}::alloc::boxed::Box<"));
         }
         self.buf.push_str(&ty);
         if boxed {

--- a/prost-build/src/code_generator/c_escaping.rs
+++ b/prost-build/src/code_generator/c_escaping.rs
@@ -17,10 +17,7 @@ pub(super) fn unescape_c_escape_string(s: &str) -> Vec<u8> {
         } else {
             p += 1;
             if p == len {
-                panic!(
-                    "invalid c-escaped default binary value ({}): ends with '\'",
-                    s
-                )
+                panic!("invalid c-escaped default binary value ({s}): ends with '\'")
             }
             match src[p] {
                 b'a' => {
@@ -83,10 +80,7 @@ pub(super) fn unescape_c_escape_string(s: &str) -> Vec<u8> {
                 }
                 b'x' | b'X' => {
                     if p + 3 > len {
-                        panic!(
-                            "invalid c-escaped default binary value ({}): incomplete hex value",
-                            s
-                        )
+                        panic!("invalid c-escaped default binary value ({s}): incomplete hex value")
                     }
                     match u8::from_str_radix(&s[p + 1..p + 3], 16) {
                         Ok(b) => dst.push(b),
@@ -97,10 +91,7 @@ pub(super) fn unescape_c_escape_string(s: &str) -> Vec<u8> {
                     }
                     p += 3;
                 }
-                _ => panic!(
-                    "invalid c-escaped default binary value ({}): invalid escape",
-                    s
-                ),
+                _ => panic!("invalid c-escaped default binary value ({s}): invalid escape"),
             }
         }
     }

--- a/prost-build/src/code_generator/syntax.rs
+++ b/prost-build/src/code_generator/syntax.rs
@@ -8,7 +8,7 @@ impl From<Option<&str>> for Syntax {
         match optional_str {
             None | Some("proto2") => Syntax::Proto2,
             Some("proto3") => Syntax::Proto3,
-            Some(s) => panic!("unknown syntax: {}", s),
+            Some(s) => panic!("unknown syntax: {s}"),
         }
     }
 }

--- a/prost-build/src/config.rs
+++ b/prost-build/src/config.rs
@@ -993,7 +993,7 @@ impl Config {
         let file_descriptor_set = FileDescriptorSet::decode(buf.as_slice()).map_err(|error| {
             Error::new(
                 ErrorKind::InvalidInput,
-                format!("invalid FileDescriptorSet: {}", error),
+                format!("invalid FileDescriptorSet: {error}"),
             )
         })?;
 
@@ -1060,16 +1060,12 @@ impl Config {
                 .expect("every module should have a filename");
 
             if basepath.is_some() {
-                self.write_line(
-                    outfile,
-                    stack.len(),
-                    &format!("include!(\"{}\");", file_name),
-                )?;
+                self.write_line(outfile, stack.len(), &format!("include!(\"{file_name}\");"))?;
             } else {
                 self.write_line(
                     outfile,
                     stack.len(),
-                    &format!("include!(concat!(env!(\"OUT_DIR\"), \"/{}\"));", file_name),
+                    &format!("include!(concat!(env!(\"OUT_DIR\"), \"/{file_name}\"));"),
                 )?;
             }
         }
@@ -1238,8 +1234,7 @@ pub fn error_message_protoc_not_found() -> String {
         "It is also available at https://github.com/protocolbuffers/protobuf/releases";
 
     format!(
-        "{} {} {}  For more information: https://docs.rs/prost-build/#sourcing-protoc",
-        error_msg, os_specific_hint, download_msg
+        "{error_msg} {os_specific_hint} {download_msg}  For more information: https://docs.rs/prost-build/#sourcing-protoc"
     )
 }
 

--- a/prost-build/src/extern_paths.rs
+++ b/prost-build/src/extern_paths.rs
@@ -7,12 +7,11 @@ use crate::ident::{to_snake, to_upper_camel};
 fn validate_proto_path(path: &str) -> Result<(), String> {
     if path.chars().next().map(|c| c != '.').unwrap_or(true) {
         return Err(format!(
-            "Protobuf paths must be fully qualified (begin with a leading '.'): {}",
-            path
+            "Protobuf paths must be fully qualified (begin with a leading '.'): {path}",
         ));
     }
     if path.split('.').skip(1).any(str::is_empty) {
-        return Err(format!("invalid fully-qualified Protobuf path: {}", path));
+        return Err(format!("invalid fully-qualified Protobuf path: {path}"));
     }
     Ok(())
 }

--- a/prost-build/src/ident.rs
+++ b/prost-build/src/ident.rs
@@ -20,11 +20,11 @@ pub fn sanitize_identifier(s: impl AsRef<str>) -> String {
         // 2018 reserved keywords.
         | "async" | "await" | "try"
         // 2024 reserved keywords.
-        | "gen" => format!("r#{}", ident),
+        | "gen" => format!("r#{ident}"),
         // the following keywords are not supported as raw identifiers and are therefore suffixed with an underscore.
-        "_" | "super" | "self" | "Self" | "extern" | "crate" => format!("{}_", ident),
+        "_" | "super" | "self" | "Self" | "extern" | "crate" => format!("{ident}_"),
         // the following keywords begin with a number and are therefore prefixed with an underscore.
-        s if s.starts_with(|c: char| c.is_numeric()) => format!("_{}", ident),
+        s if s.starts_with(|c: char| c.is_numeric()) => format!("_{ident}"),
         _ => ident.to_string(),
     }
 }

--- a/prost-build/src/path.rs
+++ b/prost-build/src/path.rs
@@ -23,7 +23,7 @@ impl<T> PathMap<T> {
 
     /// Returns a iterator over all the value matching the path `fq_path.field` and associated suffix/prefix path
     pub(crate) fn get_field(&self, fq_path: &str, field: &str) -> Iter<'_, T> {
-        Iter::new(self, format!("{}.{}", fq_path, field))
+        Iter::new(self, format!("{fq_path}.{field}"))
     }
 
     /// Returns the first value found matching the given path
@@ -36,7 +36,7 @@ impl<T> PathMap<T> {
     /// Returns the first value found matching the path `fq_path.field`
     /// If nothing matches the path, suffix paths will be tried, then prefix paths, then the global path
     pub(crate) fn get_first_field<'a>(&'a self, fq_path: &'_ str, field: &'_ str) -> Option<&'a T> {
-        self.find_best_matching(&format!("{}.{}", fq_path, field))
+        self.find_best_matching(&format!("{fq_path}.{field}"))
     }
 
     /// Removes all matchers from the path map.

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -258,8 +258,8 @@ impl Field {
             let key_ty = self.key_ty.rust_type();
             let key_ref_ty = self.key_ty.rust_ref_type();
 
-            let get = Ident::new(&format!("get_{}", ident), Span::call_site());
-            let insert = Ident::new(&format!("insert_{}", ident), Span::call_site());
+            let get = Ident::new(&format!("get_{ident}"), Span::call_site());
+            let insert = Ident::new(&format!("insert_{ident}"), Span::call_site());
             let take_ref = if self.key_ty.is_numeric() {
                 quote!(&)
             } else {
@@ -267,11 +267,10 @@ impl Field {
             };
 
             let get_doc = format!(
-                "Returns the enum value for the corresponding key in `{}`, \
-                 or `None` if the entry does not exist or it is not a valid enum value.",
-                ident,
+                "Returns the enum value for the corresponding key in `{ident}`, \
+                 or `None` if the entry does not exist or it is not a valid enum value."
             );
-            let insert_doc = format!("Inserts a key value pair into `{}`.", ident);
+            let insert_doc = format!("Inserts a key value pair into `{ident}`.");
             Some(quote! {
                 #[doc=#get_doc]
                 pub fn #get(&self, key: #key_ref_ty) -> ::core::option::Option<#ty> {

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -285,14 +285,13 @@ impl Field {
         };
 
         if let Ty::Enumeration(ref ty) = self.ty {
-            let set = Ident::new(&format!("set_{}", ident_str), Span::call_site());
-            let set_doc = format!("Sets `{}` to the provided enum value.", ident_str);
+            let set = Ident::new(&format!("set_{ident_str}"), Span::call_site());
+            let set_doc = format!("Sets `{ident_str}` to the provided enum value.");
             Some(match self.kind {
                 Kind::Plain(ref default) | Kind::Required(ref default) => {
                     let get_doc = format!(
-                        "Returns the enum value of `{}`, \
-                         or the default if the field is set to an invalid enum value.",
-                        ident_str,
+                        "Returns the enum value of `{ident_str}`, \
+                         or the default if the field is set to an invalid enum value."
                     );
                     quote! {
                         #[doc=#get_doc]
@@ -308,9 +307,8 @@ impl Field {
                 }
                 Kind::Optional(ref default) => {
                     let get_doc = format!(
-                        "Returns the enum value of `{}`, \
-                         or the default if the field is unset or set to an invalid enum value.",
-                        ident_str,
+                        "Returns the enum value of `{ident_str}`, \
+                         or the default if the field is unset or set to an invalid enum value."
                     );
                     quote! {
                         #[doc=#get_doc]
@@ -329,11 +327,10 @@ impl Field {
                 }
                 Kind::Repeated | Kind::Packed => {
                     let iter_doc = format!(
-                        "Returns an iterator which yields the valid enum values contained in `{}`.",
-                        ident_str,
+                        "Returns an iterator which yields the valid enum values contained in `{ident_str}`."
                     );
-                    let push = Ident::new(&format!("push_{}", ident_str), Span::call_site());
-                    let push_doc = format!("Appends the provided enum value to `{}`.", ident_str);
+                    let push = Ident::new(&format!("push_{ident_str}"), Span::call_site());
+                    let push_doc = format!("Appends the provided enum value to `{ident_str}`.");
                     quote! {
                         #[doc=#iter_doc]
                         pub fn #get(&self) -> ::core::iter::FilterMap<
@@ -362,8 +359,7 @@ impl Field {
             };
 
             let get_doc = format!(
-                "Returns the value of `{0}`, or the default value if `{0}` is unset.",
-                ident_str,
+                "Returns the value of `{ident_str}`, or the default value if `{ident_str}` is unset."
             );
 
             Some(quote! {

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -74,7 +74,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
                 }
                 Ok(None) => None,
                 Err(err) => Some(Err(
-                    err.context(format!("invalid message field {}.{}", ident, field_ident))
+                    err.context(format!("invalid message field {ident}.{field_ident}"))
                 )),
             }
         })
@@ -310,11 +310,9 @@ fn try_enumeration(input: TokenStream) -> Result<TokenStream, Error> {
         .iter()
         .map(|(variant, value)| quote!(#value => ::core::result::Result::Ok(#ident::#variant)));
 
-    let is_valid_doc = format!("Returns `true` if `value` is a variant of `{}`.", ident);
-    let from_i32_doc = format!(
-        "Converts an `i32` to a `{}`, or `None` if `value` is not a valid variant.",
-        ident
-    );
+    let is_valid_doc = format!("Returns `true` if `value` is a variant of `{ident}`.");
+    let from_i32_doc =
+        format!("Converts an `i32` to a `{ident}`, or `None` if `value` is not a valid variant.");
 
     let expanded = quote! {
         impl #impl_generics #ident #ty_generics #where_clause {

--- a/prost-types/src/datetime.rs
+++ b/prost-types/src/datetime.rs
@@ -90,7 +90,7 @@ impl fmt::Display for DateTime {
         } else if nanos % 1_000 == 0 {
             write!(f, ".{:06}Z", nanos / 1_000)
         } else {
-            write!(f, ".{:09}Z", nanos)
+            write!(f, ".{nanos:09}Z")
         }
     }
 }
@@ -808,8 +808,7 @@ mod tests {
             assert_eq!(
                 s.parse::<Duration>().unwrap(),
                 Duration { seconds, nanos },
-                "duration: {}",
-                s
+                "duration: {s}"
             );
         };
 

--- a/prost-types/src/duration.rs
+++ b/prost-types/src/duration.rs
@@ -122,7 +122,7 @@ impl fmt::Display for Duration {
         } else if nanos % 1_000 == 0 {
             write!(f, ".{:06}s", nanos / 1_000)
         } else {
-            write!(f, ".{:09}s", nanos)
+            write!(f, ".{nanos:09}s")
         }
     }
 }
@@ -155,7 +155,7 @@ impl fmt::Display for DurationError {
         match self {
             DurationError::ParseFailure => write!(f, "failed to parse duration"),
             DurationError::NegativeDuration(duration) => {
-                write!(f, "failed to convert negative duration: {:?}", duration)
+                write!(f, "failed to convert negative duration: {duration:?}")
             }
             DurationError::OutOfRange => {
                 write!(f, "failed to convert duration out of range")

--- a/prost-types/src/timestamp.rs
+++ b/prost-types/src/timestamp.rs
@@ -172,8 +172,7 @@ impl fmt::Display for TimestampError {
             TimestampError::OutOfSystemRange(timestamp) => {
                 write!(
                     f,
-                    "{} is not representable as a `SystemTime` because it is out of range",
-                    timestamp
+                    "{timestamp} is not representable as a `SystemTime` because it is out of range",
                 )
             }
             TimestampError::ParseFailure => {

--- a/prost/src/encoding.rs
+++ b/prost/src/encoding.rs
@@ -115,7 +115,7 @@ pub fn encode_key(tag: u32, wire_type: WireType, buf: &mut impl BufMut) {
 pub fn decode_key(buf: &mut impl Buf) -> Result<(u32, WireType), DecodeError> {
     let key = decode_varint(buf)?;
     if key > u64::from(u32::MAX) {
-        return Err(DecodeError::new(format!("invalid key value: {}", key)));
+        return Err(DecodeError::new(format!("invalid key value: {key}")));
     }
     let wire_type = WireType::try_from(key & 0x07)?;
     let tag = key as u32 >> 3;

--- a/prost/src/encoding/wire_type.rs
+++ b/prost/src/encoding/wire_type.rs
@@ -28,8 +28,7 @@ impl TryFrom<u64> for WireType {
             4 => Ok(WireType::EndGroup),
             5 => Ok(WireType::ThirtyTwoBit),
             _ => Err(DecodeError::new(format!(
-                "invalid wire type value: {}",
-                value
+                "invalid wire type value: {value}"
             ))),
         }
     }
@@ -41,8 +40,7 @@ impl TryFrom<u64> for WireType {
 pub fn check_wire_type(expected: WireType, actual: WireType) -> Result<(), DecodeError> {
     if expected != actual {
         return Err(DecodeError::new(format!(
-            "invalid wire type: {:?} (expected {:?})",
-            actual, expected
+            "invalid wire type: {actual:?} (expected {expected:?})"
         )));
     }
     Ok(())

--- a/prost/src/error.rs
+++ b/prost/src/error.rs
@@ -65,7 +65,7 @@ impl fmt::Display for DecodeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("failed to decode Protobuf message: ")?;
         for &(message, field) in &self.inner.stack {
-            write!(f, "{}.{}: ", message, field)?;
+            write!(f, "{message}.{field}: ")?;
         }
         f.write_str(&self.inner.description)
     }

--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -17,10 +17,10 @@ fn main() -> Result<()> {
     }
 
     let version = git_describe(&src_dir)?;
-    let protobuf_dir = &out_dir.join(format!("protobuf-{}", version));
+    let protobuf_dir = &out_dir.join(format!("protobuf-{version}"));
 
     if !protobuf_dir.exists() {
-        let build_dir = &out_dir.join(format!("build-protobuf-{}", version));
+        let build_dir = &out_dir.join(format!("build-protobuf-{version}"));
         fs::create_dir_all(build_dir).expect("failed to create build directory");
 
         let tempdir = tempfile::Builder::new()

--- a/tests/src/custom_debug.rs
+++ b/tests/src/custom_debug.rs
@@ -64,9 +64,9 @@ impl fmt::Debug for MessageWithOneofCustomDebug {
 #[test]
 fn oneof_with_enum_custom_debug() {
     let of = OneofWithEnumCustomDebug::Enumeration(AnEnum::B as i32);
-    assert_eq!(format!("{:?}", of), "OneofWithEnumCustomDebug {..}");
+    assert_eq!(format!("{of:?}"), "OneofWithEnumCustomDebug {..}");
     let msg = MessageWithOneofCustomDebug { of: Some(of) };
-    assert_eq!(format!("{:?}", msg), "MessageWithOneofCustomDebug {..}");
+    assert_eq!(format!("{msg:?}"), "MessageWithOneofCustomDebug {..}");
 }
 
 /// Generated protobufs
@@ -77,5 +77,5 @@ fn test_proto_msg_custom_debug() {
         b: "".to_string(),
         c: Some(msg::C::D(AnEnum::A as i32)),
     };
-    assert_eq!(format!("{:?}", msg), "Msg {..}");
+    assert_eq!(format!("{msg:?}"), "Msg {..}");
 }

--- a/tests/src/debug.rs
+++ b/tests/src/debug.rs
@@ -18,7 +18,7 @@ use crate::message_encoding::BasicEnumeration;
 fn basic() {
     let mut basic = Basic::default();
     assert_eq!(
-        format!("{:?}", basic),
+        format!("{basic:?}"),
         "Basic { \
          int32: 0, \
          bools: [], \
@@ -41,7 +41,7 @@ fn basic() {
         .bytes_map
         .insert("hello".to_string(), "world".as_bytes().into());
     assert_eq!(
-        format!("{:?}", basic),
+        format!("{basic:?}"),
         "Basic { \
          int32: 0, \
          bools: [], \
@@ -93,7 +93,7 @@ fn oneof_with_enum() {
         of: Some(OneofWithEnum::Enumeration(BasicEnumeration::TWO as i32)),
     };
     assert_eq!(
-        format!("{:?}", msg),
+        format!("{msg:?}"),
         "MessageWithOneof { of: Some(Enumeration(TWO)) }"
     );
 }

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -138,6 +138,7 @@ pub enum RoundtripResult {
     Error(anyhow::Error),
 }
 
+#[allow(clippy::uninlined_format_args)]
 impl RoundtripResult {
     /// Unwrap the roundtrip result.
     pub fn unwrap(self) -> Vec<u8> {


### PR DESCRIPTION
Prevents clippy warnings like:
```
error: variables can be used directly in the `format!` string
   --> prost-derive/src/field/map.rs:261:35
    |
261 |             let get = Ident::new(&format!("get_{}", ident), Span::call_site());
    |                                   ^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
    = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::uninlined_format_args)]`
help: change this to
    |
261 -             let get = Ident::new(&format!("get_{}", ident), Span::call_site());
261 +             let get = Ident::new(&format!("get_{ident}"), Span::call_site());
    |
```