### PR TITLE
fix(prost-build): Resolve OneOf type name conflict with embedded message

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -180,6 +180,10 @@ fn main() {
         .compile_protos(&[src.join("boxed_field.proto")], includes)
         .unwrap();
 
+    prost_build::Config::new()
+        .compile_protos(&[src.join("oneof_name_conflict.proto")], includes)
+        .unwrap();
+
     // Check that attempting to compile a .proto without a package declaration does not result in an error.
     config
         .compile_protos(&[src.join("no_package.proto")], includes)

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -84,6 +84,9 @@ mod default_string_escape;
 #[cfg(test)]
 mod ident_conversion;
 
+#[cfg(test)]
+mod oneof_name_conflict;
+
 mod test_enum_named_option_value {
     include!(concat!(env!("OUT_DIR"), "/myenum.optionn.rs"));
 }

--- a/tests/src/oneof_name_conflict.proto
+++ b/tests/src/oneof_name_conflict.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+package oneof_name_conflict;
+
+message Bakery {
+  message Bread {
+    int32 weight = 3;
+  }
+
+  oneof bread {
+    string a = 1;
+    Bread b = 2;
+  }
+}

--- a/tests/src/oneof_name_conflict.rs
+++ b/tests/src/oneof_name_conflict.rs
@@ -1,0 +1,13 @@
+mod oneof_name_conflict {
+    include!(concat!(env!("OUT_DIR"), "/oneof_name_conflict.rs"));
+}
+
+#[test]
+/// Check naming convention by creating an instance
+fn test_creation() {
+    let _ = oneof_name_conflict::Bakery {
+        bread: Some(oneof_name_conflict::bakery::BreadOneOf::B(
+            oneof_name_conflict::bakery::Bread { weight: 12 },
+        )),
+    };
+}


### PR DESCRIPTION
When a oneof field and a message have the same name, then `prost-build` will generate invalid code. The generated types have the same name. With this change the oneof enum is renamed to resolve the conflict. This is not a breaking change, because the old code didn't compile.

Example of generated code for `oneof_name_conflict.proto`:
```rust
// This file is @generated by prost-build.
#[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
pub struct Bakery {
    #[prost(oneof = "bakery::BreadOneOf", tags = "1, 2")]
    pub bread: ::core::option::Option<bakery::BreadOneOf>,
}
/// Nested message and enum types in `Bakery`.
pub mod bakery {
    #[derive(Clone, Copy, PartialEq, Eq, Hash, ::prost::Message)]
    pub struct Bread {
        #[prost(int32, tag = "3")]
        pub weight: i32,
    }
    #[derive(Clone, PartialEq, Eq, Hash, ::prost::Oneof)]
    pub enum BreadOneOf {
        #[prost(string, tag = "1")]
        A(::prost::alloc::string::String),
        #[prost(message, tag = "2")]
        B(Bread),
    }
}
```