### PR TITLE
Revert "feat(prost-build): emit `rerun` commands (#1140)"

### DIFF
--- a/prost-build/src/config.rs
+++ b/prost-build/src/config.rs
@@ -910,7 +910,6 @@ impl Config {
     ) -> Result<FileDescriptorSet> {
         let tmp;
         let file_descriptor_set_path = if let Some(path) = &self.file_descriptor_set_path {
-            println!("cargo:rerun-if-changed={}", path.display());
             path.clone()
         } else {
             if self.skip_protoc_run {
@@ -932,7 +931,6 @@ impl Config {
             cmd.arg("-o").arg(&file_descriptor_set_path);
 
             for include in includes {
-                println!("cargo:rerun-if-changed={}", include.as_ref().display());
                 if include.as_ref().exists() {
                     cmd.arg("-I").arg(include.as_ref());
                 } else {
@@ -954,7 +952,6 @@ impl Config {
             }
 
             for proto in protos {
-                println!("cargo:rerun-if-changed={}", proto.as_ref().display());
                 cmd.arg(proto.as_ref());
             }
 
@@ -1025,6 +1022,12 @@ impl Config {
         protos: &[impl AsRef<Path>],
         includes: &[impl AsRef<Path>],
     ) -> Result<()> {
+        // TODO: This should probably emit 'rerun-if-changed=PATH' directives for cargo, however
+        // according to [1] if any are output then those paths replace the default crate root,
+        // which is undesirable. Figure out how to do it in an additive way; perhaps gcc-rs has
+        // this figured out.
+        // [1]: http://doc.crates.io/build-script.html#outputs-of-the-build-script
+
         let file_descriptor_set = self.load_fds(protos, includes)?;
 
         self.compile_fds(file_descriptor_set)
@@ -1245,7 +1248,6 @@ pub fn error_message_protoc_not_found() -> String {
 
 /// Returns the path to the `protoc` binary.
 pub fn protoc_from_env() -> PathBuf {
-    println!("cargo:rerun-if-env-changed=PROTOC");
     env::var_os("PROTOC")
         .map(PathBuf::from)
         .unwrap_or(PathBuf::from("protoc"))
@@ -1253,7 +1255,6 @@ pub fn protoc_from_env() -> PathBuf {
 
 /// Returns the path to the Protobuf include directory.
 pub fn protoc_include_from_env() -> Option<PathBuf> {
-    println!("cargo:rerun-if-env-changed=PROTOC_INCLUDE");
     let protoc_include: PathBuf = env::var_os("PROTOC_INCLUDE")?.into();
 
     if !protoc_include.exists() {


### PR DESCRIPTION
This reverts commit 7c16959496b99157e53d59323c7b46470c95137e.

In version 0.14.0, `prost-build` began emitting `rerun` commands. This change introduced regressions for some users—for example, those generating `protos` from an `includes` directory. These edge cases are non-trivial to address comprehensively, so version 0.14.1 reverts the emission of `rerun` commands. For more details, see issue #1296.