### PR TITLE
Fix typo: "unparseable" instead of "unparseble" in docs and proto

### DIFF
--- a/prost-types/src/compiler.rs
+++ b/prost-types/src/compiler.rs
@@ -56,7 +56,7 @@ pub struct CodeGeneratorResponse {
     /// This should be used to indicate errors in .proto files which prevent the
     /// code generator from generating correct code.  Errors which indicate a
     /// problem in protoc itself -- such as the input CodeGeneratorRequest being
-    /// unparseable -- should be reported by writing a message to stderr and
+    /// unparsable -- should be reported by writing a message to stderr and
     /// exiting with a non-zero status code.
     #[prost(string, optional, tag = "1")]
     pub error: ::core::option::Option<::prost::alloc::string::String>,

--- a/tests/src/include/google/protobuf/compiler/plugin.proto
+++ b/tests/src/include/google/protobuf/compiler/plugin.proto
@@ -103,7 +103,7 @@ message CodeGeneratorResponse {
   // This should be used to indicate errors in .proto files which prevent the
   // code generator from generating correct code.  Errors which indicate a
   // problem in protoc itself -- such as the input CodeGeneratorRequest being
-  // unparseable -- should be reported by writing a message to stderr and
+  // unparsable -- should be reported by writing a message to stderr and
   // exiting with a non-zero status code.
   optional string error = 1;
 


### PR DESCRIPTION


Description:
Corrects a typo in documentation and proto comments, changing "unparseble" to the correct "unparseable" for clarity and consistency. 