### PR TITLE
Optional Enum Getters

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -406,8 +406,8 @@ impl<'b> CodeGenerator<'_, 'b> {
     }
 
     fn append_field(&mut self, fq_message_name: &str, field: &Field) {
-        let type_ = field.descriptor.r#type();
-        let repeated = field.descriptor.label() == Label::Repeated;
+        let type_ = field.descriptor.type_or_default();
+        let repeated = field.descriptor.label_or_default() == Label::Repeated;
         let deprecated = self.deprecated(&field.descriptor);
         let optional = self.optional(&field.descriptor);
         let boxed = self
@@ -442,7 +442,7 @@ impl<'b> CodeGenerator<'_, 'b> {
                 .push_str(&format!(" = {:?}", bytes_type.annotation()));
         }
 
-        match field.descriptor.label() {
+        match field.descriptor.label_or_default() {
             Label::Optional => {
                 if optional {
                     self.buf.push_str(", optional");
@@ -946,7 +946,7 @@ impl<'b> CodeGenerator<'_, 'b> {
     }
 
     fn resolve_type(&self, field: &FieldDescriptorProto, fq_message_name: &str) -> String {
-        match field.r#type() {
+        match field.type_or_default() {
             Type::Float => String::from("f32"),
             Type::Double => String::from("f64"),
             Type::Uint32 | Type::Fixed32 => String::from("u32"),
@@ -1003,7 +1003,7 @@ impl<'b> CodeGenerator<'_, 'b> {
     }
 
     fn field_type_tag(&self, field: &FieldDescriptorProto) -> Cow<'static, str> {
-        match field.r#type() {
+        match field.type_or_default() {
             Type::Float => Cow::Borrowed("float"),
             Type::Double => Cow::Borrowed("double"),
             Type::Int32 => Cow::Borrowed("int32"),
@@ -1029,7 +1029,7 @@ impl<'b> CodeGenerator<'_, 'b> {
     }
 
     fn map_value_type_tag(&self, field: &FieldDescriptorProto) -> Cow<'static, str> {
-        match field.r#type() {
+        match field.type_or_default() {
             Type::Enum => Cow::Owned(format!(
                 "enumeration({})",
                 self.resolve_ident(field.type_name())
@@ -1043,11 +1043,11 @@ impl<'b> CodeGenerator<'_, 'b> {
             return true;
         }
 
-        if field.label() != Label::Optional {
+        if field.label_or_default() != Label::Optional {
             return false;
         }
 
-        match field.r#type() {
+        match field.type_or_default() {
             Type::Message => true,
             _ => self.syntax == Syntax::Proto2,
         }
@@ -1074,7 +1074,7 @@ impl<'b> CodeGenerator<'_, 'b> {
 /// Returns `true` if the repeated field type can be packed.
 fn can_pack(field: &FieldDescriptorProto) -> bool {
     matches!(
-        field.r#type(),
+        field.type_or_default(),
         Type::Float
             | Type::Double
             | Type::Int32

--- a/prost-build/src/context.rs
+++ b/prost-build/src/context.rs
@@ -141,11 +141,11 @@ impl<'a> Context<'a> {
         oneof: Option<&str>,
         field: &FieldDescriptorProto,
     ) -> bool {
-        if field.label() == Label::Repeated {
+        if field.label_or_default() == Label::Repeated {
             // Repeated field are stored in Vec, therefore it is already heap allocated
             return false;
         }
-        let fd_type = field.r#type();
+        let fd_type = field.type_or_default();
         if (fd_type == Type::Message || fd_type == Type::Group)
             && self
                 .message_graph
@@ -188,9 +188,9 @@ impl<'a> Context<'a> {
         assert_eq!(".", &fq_message_name[..1]);
 
         // repeated field cannot derive Copy
-        if field.label() == Label::Repeated {
+        if field.label_or_default() == Label::Repeated {
             false
-        } else if field.r#type() == Type::Message {
+        } else if field.type_or_default() == Type::Message {
             // nested and boxed messages cannot derive Copy
             if self
                 .message_graph
@@ -210,7 +210,7 @@ impl<'a> Context<'a> {
             }
         } else {
             matches!(
-                field.r#type(),
+                field.type_or_default(),
                 Type::Float
                     | Type::Double
                     | Type::Int32
@@ -243,8 +243,8 @@ impl<'a> Context<'a> {
     pub fn can_field_derive_eq(&self, fq_message_name: &str, field: &FieldDescriptorProto) -> bool {
         assert_eq!(".", &fq_message_name[..1]);
 
-        if field.r#type() == Type::Message {
-            if field.label() == Label::Repeated
+        if field.type_or_default() == Type::Message {
+            if field.label_or_default() == Label::Repeated
                 || self
                     .message_graph
                     .is_nested(field.type_name(), fq_message_name)
@@ -255,7 +255,7 @@ impl<'a> Context<'a> {
             }
         } else {
             matches!(
-                field.r#type(),
+                field.type_or_default(),
                 Type::Int32
                     | Type::Int64
                     | Type::Uint32

--- a/prost-build/src/message_graph.rs
+++ b/prost-build/src/message_graph.rs
@@ -58,7 +58,9 @@ impl MessageGraph {
         let msg_index = self.get_or_insert_index(msg_name.clone());
 
         for field in &msg.field {
-            if field.r#type() == Type::Message && field.label() != Label::Repeated {
+            if field.type_or_default() == Type::Message
+                && field.label_or_default() != Label::Repeated
+            {
                 let field_index = self.get_or_insert_index(field.type_name.clone().unwrap());
                 self.graph.add_edge(msg_index, field_index, ());
             }

--- a/tests/src/default_enum_value.rs
+++ b/tests/src/default_enum_value.rs
@@ -9,16 +9,19 @@ include!(concat!(env!("OUT_DIR"), "/default_enum_value.rs"));
 #[test]
 fn test_default_enum() {
     let msg = Test::default();
-    assert_eq!(msg.privacy_level_1(), PrivacyLevel::One);
-    assert_eq!(msg.privacy_level_3(), PrivacyLevel::PrivacyLevelThree);
+    assert_eq!(msg.privacy_level_1_or_default(), PrivacyLevel::One);
     assert_eq!(
-        msg.privacy_level_4(),
+        msg.privacy_level_3_or_default(),
+        PrivacyLevel::PrivacyLevelThree
+    );
+    assert_eq!(
+        msg.privacy_level_4_or_default(),
         PrivacyLevel::PrivacyLevelprivacyLevelFour
     );
 
     let msg = CMsgRemoteClientBroadcastHeader::default();
     assert_eq!(
-        msg.msg_type(),
+        msg.msg_type_or_default(),
         ERemoteClientBroadcastMsg::KERemoteClientBroadcastMsgDiscovery
     );
 }


### PR DESCRIPTION
Currently, generated getters for optional enums emit the default enum variant if the field is not present in the message. This PR renames this behavior to "_or_default" and changes the getter behavior to return an `Option`.

*Note: This is a breaking change, I can refactor this to be non-breaking, but it would not be idiomatic Rust.*

Thanks!