### PR TITLE
Chrono interoperability and Ops for Timestamp, update Nix and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -459,9 +459,21 @@ pub enum Gender {
 
 ## Nix
 
-The prost project maintains flakes support for local development. Once you have
-nix and nix flakes setup you can just run `nix develop` to get a shell
-configured with the required dependencies to compile the whole project.
+The prost project supports development using Nix flakes. Once you have Nix and flakes enabled, you can simply run:
+
+```
+nix develop
+```
+
+This will drop you into a shell with all dependencies configured to build the entire project.
+
+If you want to use the minimum supported Rust version as required by Tokio [see MSRV](#msrv), run:
+
+```
+nix develop .#rust_minimum_version
+```
+
+This ensures compatibility testing and development with the oldest supported toolchain version.
 
 ## Feature Flags
 - `std`: Enable integration with standard library. Disable this feature for `no_std` support. This feature is enabled by default.

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,24 @@
 {
   "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1752129689,
+        "narHash": "sha256-0Xq5tZbvgZvxbbxv6kRHFuZE4Tq2za016NXh32nX0+Q=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "70bb04a7de606a75ba0a2ee9d47b99802780b35d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -20,6 +39,22 @@
     },
     "nixpkgs": {
       "locked": {
+        "lastModified": 1751984180,
+        "narHash": "sha256-LwWRsENAZJKUdD3SpLluwDmdXY9F45ZEgCb0X+xgOL0=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "9807714d6944a957c2e036f84b0ff8caf9930bc0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
         "lastModified": 1735648875,
         "narHash": "sha256-fQ4k/hyQiH9RRPznztsA9kbcDajvwV1sRm01el6Sr3c=",
         "owner": "NixOS",
@@ -36,8 +71,26 @@
     },
     "root": {
       "inputs": {
+        "fenix": "fenix",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs_2"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1752086493,
+        "narHash": "sha256-USpVUdiWXDfPoh+agbvoBQaBhg3ZdKZgHXo/HikMfVo=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "6e3abe164b9036048dce1a3aa65a7e7e5200c0d3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.lock
+++ b/flake.lock
@@ -73,7 +73,8 @@
       "inputs": {
         "fenix": "fenix",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "rust_manifest": "rust_manifest"
       }
     },
     "rust-analyzer-src": {
@@ -91,6 +92,18 @@
         "ref": "nightly",
         "repo": "rust-analyzer",
         "type": "github"
+      }
+    },
+    "rust_manifest": {
+      "flake": false,
+      "locked": {
+        "narHash": "sha256-+luyleoaReh01qcOghMXEz+t3Lm700Z0cS4Hm61pVCE=",
+        "type": "file",
+        "url": "https://static.rust-lang.org/dist/2023-08-03/channel-rust-1.71.1.toml"
+      },
+      "original": {
+        "type": "file",
+        "url": "https://static.rust-lang.org/dist/2023-08-03/channel-rust-1.71.1.toml"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,17 +4,52 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    fenix.url = "github:nix-community/fenix";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      fenix,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = import nixpkgs { inherit system; };
+        default_pkgs = with pkgs; [
+          protobuf
+          cmake
+          pkg-config
+          protobuf
+          curl
+          ninja
+        ];
       in
       {
-        devShells.default = pkgs.mkShell {
-          packages = with pkgs; [ cargo rustc ];
-          buildInputs = with pkgs; [ pkg-config protobuf curl cmake ninja ];
-        };
-      });
+        devShells.default =
+          let
+            rustpkgs = fenix.packages.${system}.stable.defaultToolchain;
+          in
+          pkgs.mkShell {
+            packages = [
+              rustpkgs
+            ] ++ default_pkgs;
+          };
+        devShells."rust_minimum_version" =
+          let
+            rust_manifest = {
+              url = "https://static.rust-lang.org/dist/2023-08-03/channel-rust-1.71.1.toml";
+              flake = false;
+            };
+            rustpkgs = (fenix.packages.${system}.fromManifestFile rust_manifest).defaultToolchain;
+          in
+          pkgs.mkShell {
+            packages = [
+              rustpkgs
+            ] ++ default_pkgs;
+          };
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,10 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     fenix.url = "github:nix-community/fenix";
+    rust_manifest = {
+      url = "https://static.rust-lang.org/dist/2023-08-03/channel-rust-1.71.1.toml";
+      flake = false;
+    };
   };
 
   outputs =
@@ -13,6 +17,7 @@
       nixpkgs,
       flake-utils,
       fenix,
+      rust_manifest,
     }:
     flake-utils.lib.eachDefaultSystem (
       system:
@@ -30,7 +35,7 @@
       {
         devShells.default =
           let
-            rustpkgs = fenix.packages.${system}.stable.defaultToolchain;
+            rustpkgs = fenix.packages.${system}.stable.completeToolchain;
           in
           pkgs.mkShell {
             packages = [
@@ -39,11 +44,7 @@
           };
         devShells."rust_minimum_version" =
           let
-            rust_manifest = {
-              url = "https://static.rust-lang.org/dist/2023-08-03/channel-rust-1.71.1.toml";
-              flake = false;
-            };
-            rustpkgs = (fenix.packages.${system}.fromManifestFile rust_manifest).defaultToolchain;
+            rustpkgs = (fenix.packages.${system}.fromManifestFile rust_manifest).completeToolchain;
           in
           pkgs.mkShell {
             packages = [

--- a/prost-types/src/timestamp.rs
+++ b/prost-types/src/timestamp.rs
@@ -113,6 +113,16 @@ impl Timestamp {
 
         Timestamp::try_from(date_time)
     }
+
+    pub const MAX: Timestamp = Timestamp {
+        seconds: i64::MAX,
+        nanos: NANOS_PER_SECOND - 1,
+    };
+
+    pub const MIN: Timestamp = Timestamp {
+        seconds: i64::MIN,
+        nanos: 0,
+    };
 }
 
 impl Add<Duration> for Timestamp {


### PR DESCRIPTION
First of all, a huge thanks to all the contributors for this great library!

## Changes:
### Arithmetic Operations for Timestamp
 - Implemented the Add<Duration>, Sub<Duration>, and Div traits for the Timestamp type.
 - Added comprehensive unit tests and formal verification tests using the Kani verifier to ensure correctness
 
### Enhanced chrono Interoperability, with chrono feature
* Added support for into() and try_into() to enable lossless, round-trip conversions between Timestamp and the following chrono types:
  * DateTime<Utc>;
  * NaiveDateTime;
  * NaiveDate;
* Full test coverage is provided for these conversions, including both automated unit tests and Kani verification.

### Nix Development Environment Update
* The Nix configuration has been updated. Running `nix develop .#rust_minimum_version` now correctly sets up a development shell with the appropriate Minimum Supported Rust Version (MSRV) required by Tokio. 
 
## A Note on the README
I have updated the README.md to include documentation for the new Nix command. However, I noticed that the `check-readme` CI job is configured to fail automatically on any modification to the README.

This pull request introduces **no breaking changes**.