### PR TITLE
docs: Update protobuf-src example to avoid unsafe set_var

### DIFF
--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -125,11 +125,12 @@
 //! ### Compiling `protoc` from source
 //!
 //! To compile `protoc` from source you can use the `protobuf-src` crate and
-//! set the correct environment variables.
+//! set the path to `protoc`.
 //! ```no_run,ignore, rust
-//! std::env::set_var("PROTOC", protobuf_src::protoc());
+//! let mut prost_build = prost_build::Config::new();
+//! prost_build.protoc_executable(protobuf_src::protoc());
 //!
-//! // Now compile your proto files via prost-build
+//! // Now compile your proto files with the configuration
 //! ```
 //!
 //! [`protobuf-src`]: https://docs.rs/protobuf-src


### PR DESCRIPTION
This PR updates the documentation under "Compiling `protoc` from source" to avoid using unsafe `std::env::set_var`.

[`std::env::set_var`](https://doc.rust-lang.org/src/std/env.rs.html#366-371) becomes unsafe in Rust 2024 unless certain strict single-threaded conditions are met. While we could wrap the call in an `unsafe` block, introducing `unsafe` just for setting an environment variable isn't worth the added complexity. Instead, the example now uses the `prost_build::Config::protoc_executable` method to directly set the path to the `protoc` binary.