### PR TITLE
docs: add example for `decode_length_delimiter`

### DIFF
--- a/prost/src/encoding/length_delimiter.rs
+++ b/prost/src/encoding/length_delimiter.rs
@@ -9,7 +9,7 @@ use crate::encoding::varint::{decode_varint, encode_varint, encoded_len_varint};
 
 /// Encodes a length delimiter to the buffer.
 ///
-/// See [Message.encode_length_delimited] for more info.
+/// See [Message::encode_length_delimited] for more info.
 ///
 /// An error will be returned if the buffer does not have sufficient capacity to encode the
 /// delimiter.
@@ -35,7 +35,7 @@ pub fn length_delimiter_len(length: usize) -> usize {
 /// Decodes a length delimiter from the buffer.
 ///
 /// This method allows the length delimiter to be decoded independently of the message, when the
-/// message is encoded with [Message.encode_length_delimited].
+/// message is encoded with [Message::encode_length_delimited].
 ///
 /// An error may be returned in two cases:
 ///


### PR DESCRIPTION
From [documentation](https://docs.rs/prost/0.14.1/prost/fn.decode_length_delimiter.html), it's not obvious how to decode the delimiter given the larger buffer. I think it would be helpful if there was an example.

Looking through the issues (e.g. #285), I found out that using `Bytes` or `BytesMut` instead of `&[u8]` makes everything work. 

I pieced this example from what I could find in the issues, so let me know if this is not the most idiomatic way and I will update the PR.