### PR TITLE
ci: Always choose macOS 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,7 +136,7 @@ jobs:
           - stable
         os:
           - ubuntu-latest
-          - macos-latest
+          - macos-14
           - windows-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
The build fails on macOS 15 due to wrong defaults in CMake/Abseil.