### PR TITLE
feat: Support for marking setter and accessor methods with deprecated…

### DIFF
--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -42,6 +42,7 @@ fn fake_scalar(ty: scalar::Ty) -> scalar::Field {
         ty,
         kind,
         tag: 0, // Not used here
+        deprecated: false,
     }
 }
 

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -34,11 +34,12 @@ impl Field {
     /// If the meta items are invalid, an error will be returned.
     /// If the field should be ignored, `None` is returned.
     pub fn new(attrs: Vec<Attribute>, inferred_tag: Option<u32>) -> Result<Option<Field>, Error> {
+        let deprecated = attrs.iter().any(|v| v.path().is_ident("deprecated"));
         let attrs = prost_attrs(attrs)?;
 
         // TODO: check for ignore attribute.
 
-        let field = if let Some(field) = scalar::Field::new(&attrs, inferred_tag)? {
+        let field = if let Some(field) = scalar::Field::new(&attrs, inferred_tag, deprecated)? {
             Field::Scalar(field)
         } else if let Some(field) = message::Field::new(&attrs, inferred_tag)? {
             Field::Message(field)


### PR DESCRIPTION
If a field is marked as deprecated, the setter and accessor methods should be as well.

Fixes: https://github.com/tokio-rs/prost/issues/985