### PR TITLE
style: Remove allocation in tests

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -10,6 +10,7 @@ cfg_if! {
 
 use std::env;
 use std::fs;
+use std::path::Path;
 use std::path::PathBuf;
 
 fn main() {
@@ -17,8 +18,8 @@ fn main() {
 
     // The source directory. The indirection is necessary in order to support the tests-2015 crate,
     // which sets the current directory to tests-2015 during build script evaluation.
-    let src = PathBuf::from("../tests/src");
-    let includes = &[src.clone()];
+    let src = Path::new("../tests/src");
+    let includes = &[src];
 
     // Generate BTreeMap fields for all messages. This forces encoded output to be consistent, so
     // that encode/decode roundtrips can use encoded output for comparison. Otherwise trying to


### PR DESCRIPTION
Prevent memory allocation in PathBuf and cloning directly after it.

Prevents this clippy warning:
```
warning: this call to `clone` can be replaced with `std::slice::from_ref`
  --> tests-2018/../tests/build.rs:21:20
   |
21 |     let includes = &[src.clone()];
   |                    ^^^^^^^^^^^^^^ help: try: `std::slice::from_ref(&src)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#cloned_ref_to_slice_refs
   = note: `#[warn(clippy::cloned_ref_to_slice_refs)]` on by default
```