### PR TITLE
test(result_struct): Move tests to separate module

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -116,7 +116,7 @@ fn main() {
         .compile_protos(&[src.join("result_enum.proto")], includes)
         .unwrap();
 
-    config
+    prost_build::Config::new()
         .compile_protos(&[src.join("result_struct.proto")], includes)
         .unwrap();
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -97,9 +97,8 @@ mod test_result_named_option_value {
     include!(concat!(env!("OUT_DIR"), "/mystruct.optionn.rs"));
 }
 
-mod test_result_named_result_value {
-    include!(concat!(env!("OUT_DIR"), "/mystruct.result.rs"));
-}
+#[cfg(test)]
+mod result_struct;
 
 /// Also for testing custom attributes, but on oneofs.
 ///

--- a/tests/src/result_struct.proto
+++ b/tests/src/result_struct.proto
@@ -1,6 +1,5 @@
 syntax = "proto3";
-package mystruct.result;
-
+package result_struct;
 
 message Result {
   string msg = 1;

--- a/tests/src/result_struct.rs
+++ b/tests/src/result_struct.rs
@@ -1,0 +1,8 @@
+include!(concat!(env!("OUT_DIR"), "/result_struct.rs"));
+
+#[test]
+fn test_result_named_result_value() {
+    let _ = Result {
+        msg: "Can I create?".into(),
+    };
+}


### PR DESCRIPTION
- Create a explicit test in separate module
- Rename package to match the filename
- Make config dependency explicit in `build.rs`