### PR TITLE
test(proto3_presence): Move test to separate module

### DIFF
--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -110,11 +110,8 @@ pub mod oneof_attributes {
     include!(concat!(env!("OUT_DIR"), "/foo.custom.one_of_attrs.rs"));
 }
 
-pub mod proto3 {
-    pub mod presence {
-        include!(concat!(env!("OUT_DIR"), "/proto3.presence.rs"));
-    }
-}
+#[cfg(test)]
+mod proto3_presence;
 
 use core::fmt::Debug;
 
@@ -316,16 +313,6 @@ mod tests {
         // https://github.com/tokio-rs/prost/issues/267
         let buf = vec![b'C'; 1 << 20];
         <() as Message>::decode(&buf[..]).err().unwrap();
-    }
-
-    #[test]
-    fn test_proto3_presence() {
-        let msg = proto3::presence::A {
-            b: Some(42),
-            foo: Some(proto3::presence::a::Foo::C(13)),
-        };
-
-        check_message(&msg);
     }
 
     #[test]

--- a/tests/src/proto3_presence.proto
+++ b/tests/src/proto3_presence.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package proto3.presence;
+package proto3_presence;
 
 message A {
   optional int32 b = 1;

--- a/tests/src/proto3_presence.rs
+++ b/tests/src/proto3_presence.rs
@@ -1,0 +1,11 @@
+include!(concat!(env!("OUT_DIR"), "/proto3_presence.rs"));
+
+#[test]
+fn test_proto3_presence() {
+    let msg = A {
+        b: Some(42),
+        foo: Some(a::Foo::C(13)),
+    };
+
+    crate::check_message(&msg);
+}


### PR DESCRIPTION
- Move a test to a separate module
- Rename package to match the filename