### PR TITLE
Allow encoding/decoding strings as `Arc<str>`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ authors = [
 ]
 license = "Apache-2.0"
 repository = "https://github.com/tokio-rs/prost"
-rust-version = "1.71.1"
+rust-version = "1.82.0"
 edition = "2021"
 
 [profile.bench]

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See the [snazzy repository][snazzy] for a simple start-to-finish example.
 
 ### MSRV
 
-`prost` follows the `tokio-rs` project's MSRV model and supports 1.71.1. For more
+`prost` follows the `tokio-rs` project's MSRV model and supports 1.82.0. For more
 information on the tokio msrv policy you can check it out [here][tokio msrv]
 
 [tokio msrv]: https://github.com/tokio-rs/tokio/#supported-rust-versions
@@ -467,7 +467,7 @@ configured with the required dependencies to compile the whole project.
 - `std`: Enable integration with standard library. Disable this feature for `no_std` support. This feature is enabled by default.
 - `derive`: Enable integration with `prost-derive`. Disable this feature to reduce compile times. This feature is enabled by default.
 - `prost-derive`: Deprecated. Alias for `derive` feature.
-- `no-recursion-limit`: Disable the recursion limit. The recursion limit is 100 and cannot be customized. 
+- `no-recursion-limit`: Disable the recursion limit. The recursion limit is 100 and cannot be customized.
 
 ## FAQ
 

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -366,7 +366,7 @@ fn key_ty_from_str(s: &str) -> Result<scalar::Ty, Error> {
         | scalar::Ty::Sfixed32
         | scalar::Ty::Sfixed64
         | scalar::Ty::Bool
-        | scalar::Ty::String => Ok(ty),
+        | scalar::Ty::String(_) => Ok(ty),
         _ => bail!("invalid map key type: {}", s),
     }
 }

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -124,9 +124,9 @@ impl Field {
     }
 
     /// Returns a statement which clears the field.
-    pub fn clear(&self, ident: TokenStream) -> TokenStream {
+    pub fn clear(&self, prost_path: &Path, ident: TokenStream) -> TokenStream {
         match *self {
-            Field::Scalar(ref scalar) => scalar.clear(ident),
+            Field::Scalar(ref scalar) => scalar.clear(prost_path, ident),
             Field::Message(ref message) => message.clear(ident),
             Field::Map(ref map) => map.clear(ident),
             Field::Oneof(ref oneof) => oneof.clear(ident),

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -138,7 +138,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
 
     let clear = fields
         .iter()
-        .map(|(field_ident, field)| field.clear(quote!(self.#field_ident)));
+        .map(|(field_ident, field)| field.clear(&prost_path, quote!(self.#field_ident)));
 
     let default = if is_struct {
         let default = fields.iter().map(|(field_ident, field)| {

--- a/tests/src/message_encoding.rs
+++ b/tests/src/message_encoding.rs
@@ -1,3 +1,4 @@
+use prost::alloc::sync::Arc;
 use prost::alloc::vec;
 #[cfg(not(feature = "std"))]
 use prost::alloc::{borrow::ToOwned, string::String, vec::Vec};
@@ -64,9 +65,11 @@ pub struct ScalarTypes {
     pub _bool: bool,
     #[prost(string, tag = "014")]
     pub string: String,
-    #[prost(bytes = "vec", tag = "015")]
+    #[prost(string = "arc", tag = "015")]
+    pub string_arc: Arc<str>,
+    #[prost(bytes = "vec", tag = "016")]
     pub bytes_vec: Vec<u8>,
-    #[prost(bytes = "bytes", tag = "016")]
+    #[prost(bytes = "bytes", tag = "017")]
     pub bytes_buf: Bytes,
 
     #[prost(int32, required, tag = "101")]


### PR DESCRIPTION
This raises the MSRV for some of the `MaybeUninit` APIs. This is acceptable under the tokio MSRV policy.