### PR TITLE
Skip fields

### DIFF
--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -3,6 +3,7 @@ mod map;
 mod message;
 mod oneof;
 mod scalar;
+mod skip;
 
 use std::fmt;
 use std::slice;
@@ -26,6 +27,8 @@ pub enum Field {
     Oneof(oneof::Field),
     /// A group field.
     Group(group::Field),
+    /// An ignored field.
+    Skip(skip::Field),
 }
 
 impl Field {
@@ -36,9 +39,9 @@ impl Field {
     pub fn new(attrs: Vec<Attribute>, inferred_tag: Option<u32>) -> Result<Option<Field>, Error> {
         let attrs = prost_attrs(attrs)?;
 
-        // TODO: check for ignore attribute.
-
-        let field = if let Some(field) = scalar::Field::new(&attrs, inferred_tag)? {
+        let field = if let Some(field) = skip::Field::new(&attrs)? {
+            Field::Skip(field)
+        } else if let Some(field) = scalar::Field::new(&attrs, inferred_tag)? {
             Field::Scalar(field)
         } else if let Some(field) = message::Field::new(&attrs, inferred_tag)? {
             Field::Message(field)
@@ -62,8 +65,6 @@ impl Field {
     pub fn new_oneof(attrs: Vec<Attribute>) -> Result<Option<Field>, Error> {
         let attrs = prost_attrs(attrs)?;
 
-        // TODO: check for ignore attribute.
-
         let field = if let Some(field) = scalar::Field::new_oneof(&attrs)? {
             Field::Scalar(field)
         } else if let Some(field) = message::Field::new_oneof(&attrs)? {
@@ -81,6 +82,7 @@ impl Field {
 
     pub fn tags(&self) -> Vec<u32> {
         match *self {
+            Field::Skip(_) => vec![],
             Field::Scalar(ref scalar) => vec![scalar.tag],
             Field::Message(ref message) => vec![message.tag],
             Field::Map(ref map) => vec![map.tag],
@@ -92,6 +94,7 @@ impl Field {
     /// Returns a statement which encodes the field.
     pub fn encode(&self, prost_path: &Path, ident: TokenStream) -> TokenStream {
         match *self {
+            Field::Skip(ref ignore) => ignore.encode(ident),
             Field::Scalar(ref scalar) => scalar.encode(prost_path, ident),
             Field::Message(ref message) => message.encode(prost_path, ident),
             Field::Map(ref map) => map.encode(prost_path, ident),
@@ -104,6 +107,7 @@ impl Field {
     /// value into the field.
     pub fn merge(&self, prost_path: &Path, ident: TokenStream) -> TokenStream {
         match *self {
+            Field::Skip(ref ignore) => ignore.merge(ident),
             Field::Scalar(ref scalar) => scalar.merge(prost_path, ident),
             Field::Message(ref message) => message.merge(prost_path, ident),
             Field::Map(ref map) => map.merge(prost_path, ident),
@@ -115,6 +119,7 @@ impl Field {
     /// Returns an expression which evaluates to the encoded length of the field.
     pub fn encoded_len(&self, prost_path: &Path, ident: TokenStream) -> TokenStream {
         match *self {
+            Field::Skip(ref ignore) => ignore.encoded_len(ident),
             Field::Scalar(ref scalar) => scalar.encoded_len(prost_path, ident),
             Field::Map(ref map) => map.encoded_len(prost_path, ident),
             Field::Message(ref msg) => msg.encoded_len(prost_path, ident),
@@ -126,6 +131,7 @@ impl Field {
     /// Returns a statement which clears the field.
     pub fn clear(&self, ident: TokenStream) -> TokenStream {
         match *self {
+            Field::Skip(ref ignore) => ignore.clear(ident),
             Field::Scalar(ref scalar) => scalar.clear(ident),
             Field::Message(ref message) => message.clear(ident),
             Field::Map(ref map) => map.clear(ident),

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -94,7 +94,7 @@ impl Field {
     /// Returns a statement which encodes the field.
     pub fn encode(&self, prost_path: &Path, ident: TokenStream) -> TokenStream {
         match *self {
-            Field::Skip(ref ignore) => ignore.encode(ident),
+            Field::Skip(_) => TokenStream::default(),
             Field::Scalar(ref scalar) => scalar.encode(prost_path, ident),
             Field::Message(ref message) => message.encode(prost_path, ident),
             Field::Map(ref map) => map.encode(prost_path, ident),
@@ -107,7 +107,7 @@ impl Field {
     /// value into the field.
     pub fn merge(&self, prost_path: &Path, ident: TokenStream) -> TokenStream {
         match *self {
-            Field::Skip(ref ignore) => ignore.merge(ident),
+            Field::Skip(_) => TokenStream::default(),
             Field::Scalar(ref scalar) => scalar.merge(prost_path, ident),
             Field::Message(ref message) => message.merge(prost_path, ident),
             Field::Map(ref map) => map.merge(prost_path, ident),
@@ -119,7 +119,7 @@ impl Field {
     /// Returns an expression which evaluates to the encoded length of the field.
     pub fn encoded_len(&self, prost_path: &Path, ident: TokenStream) -> TokenStream {
         match *self {
-            Field::Skip(ref ignore) => ignore.encoded_len(ident),
+            Field::Skip(_) => quote!(0),
             Field::Scalar(ref scalar) => scalar.encoded_len(prost_path, ident),
             Field::Map(ref map) => map.encoded_len(prost_path, ident),
             Field::Message(ref msg) => msg.encoded_len(prost_path, ident),
@@ -131,7 +131,7 @@ impl Field {
     /// Returns a statement which clears the field.
     pub fn clear(&self, ident: TokenStream) -> TokenStream {
         match *self {
-            Field::Skip(ref ignore) => ignore.clear(ident),
+            Field::Skip(ref skip) => skip.clear(ident),
             Field::Scalar(ref scalar) => scalar.clear(ident),
             Field::Message(ref message) => message.clear(ident),
             Field::Map(ref map) => map.clear(ident),

--- a/prost-derive/src/field/skip.rs
+++ b/prost-derive/src/field/skip.rs
@@ -1,0 +1,56 @@
+﻿use anyhow::{bail, Error};
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{Meta};
+
+use crate::field::{set_bool, word_attr};
+
+#[derive(Clone)]
+pub struct Field;
+
+impl Field {
+    pub fn new(attrs: &[Meta]) -> Result<Option<Field>, Error> {
+        let mut skip = false;
+        let mut unknown_attrs = Vec::new();
+
+        for attr in attrs {
+            if word_attr("skip", attr) {
+                set_bool(&mut skip, "duplicate ignore attribute")?;
+            } else {
+                unknown_attrs.push(attr);
+            }
+        }
+
+        if !skip {
+            return Ok(None);
+        }
+
+        if !unknown_attrs.is_empty() {
+            bail!(
+                "unknown attribute(s) for ignored field: #[prost({})]",
+                quote!(#(#unknown_attrs),*)
+            );
+        }
+
+        Ok(Some(Field))
+    }
+
+    /// Returns a statement which non-ops, since the field is ignored.
+    pub fn encode(&self, _: TokenStream) -> TokenStream {
+        quote!()
+    }
+
+    /// Returns an expression which evaluates to the default value of the ignored field.
+    pub fn merge(&self, ident: TokenStream) -> TokenStream {
+        quote!(#ident.get_or_insert_with(::core::default::Default::default))
+    }
+
+    /// Returns an expression which evaluates to 0
+    pub fn encoded_len(&self, _: TokenStream) -> TokenStream {
+        quote!(0)
+    }
+
+    pub fn clear(&self, ident: TokenStream) -> TokenStream {
+        quote!(#ident = ::core::default::Default::default)
+    }
+}

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -84,6 +84,9 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     // We want Debug to be in declaration order
     let unsorted_fields = fields.clone();
 
+    // Filter out ignored fields
+    fields.retain(|(_, field)| matches!(field, Field::Skip(..)));
+
     // Sort the fields by tag number so that fields will be encoded in tag order.
     // TODO: This encodes oneof fields in the position of their lowest tag,
     // regardless of the currently occupied variant, is that consequential?

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -85,14 +85,19 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
     let unsorted_fields = fields.clone();
 
     // Filter out ignored fields
-    fields.retain(|(_, field)| matches!(field, Field::Skip(..)));
+    fields.retain(|(_, field)| !matches!(field, Field::Skip(..)));
 
     // Sort the fields by tag number so that fields will be encoded in tag order.
     // TODO: This encodes oneof fields in the position of their lowest tag,
     // regardless of the currently occupied variant, is that consequential?
     // See: https://developers.google.com/protocol-buffers/docs/encoding#order
-    fields.sort_by_key(|(_, field)| field.tags().into_iter().min().unwrap());
-    let fields = fields;
+    let all_fields = unsorted_fields.clone();
+    let mut active_fields = all_fields.clone();
+    // Filter out skipped fields for encoding/decoding/length
+    active_fields.retain(|(_, field)| !matches!(field, Field::Skip(_)));
+    // Sort the active fields by tag number so that fields will be encoded in tag order.
+    active_fields.sort_by_key(|(_, field)| field.tags().into_iter().min().unwrap());
+    let fields = active_fields;
 
     if let Some(duplicate_tag) = fields
         .iter()
@@ -131,7 +136,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
         }
     });
 
-    let struct_name = if fields.is_empty() {
+    let struct_name = if all_fields.is_empty() {
         quote!()
     } else {
         quote!(
@@ -139,21 +144,28 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
         )
     };
 
-    let clear = fields
+    let clear = all_fields
         .iter()
         .map(|(field_ident, field)| field.clear(quote!(self.#field_ident)));
 
+    // For Default implementation, use all_fields (including skipped)
     let default = if is_struct {
-        let default = fields.iter().map(|(field_ident, field)| {
-            let value = field.default(&prost_path);
+        let default = all_fields.iter().map(|(field_ident, field)| {
+            let value = match field {
+                Field::Skip(skip_field) => skip_field.default_value(),
+                _ => field.default(&prost_path),
+            };
             quote!(#field_ident: #value,)
         });
         quote! {#ident {
             #(#default)*
         }}
     } else {
-        let default = fields.iter().map(|(_, field)| {
-            let value = field.default(&prost_path);
+        let default = all_fields.iter().map(|(_, field)| {
+            let value = match field {
+                Field::Skip(skip_field) => skip_field.default_value(),
+                _ => field.default(&prost_path),
+            };
             quote!(#value,)
         });
         quote! {#ident (


### PR DESCRIPTION
This change will allow Prost users to skip a field during serialization and deserialization. It also provides an optional `default` attribute for these fields, in the event the underlying object does not implement the `Default` trait.

My motivation for this is some reverse engineering effort, in which the existing datastructures are serialized in both protobuf and xml formats. I can use `quick_xml`/`serde` and ignore protobuf-only fields, but I can't ignore xml-only fields using `prost`, which results in duplicate data structures and more boilerplate to convert between the two types.

Usage:

```rs
#[derive(::prost::Message)]
struct Test {
    #[prost(int32, tag = "1")]
    a: i32,
    #[prost(skip)]
    b: i32,
    #[prost(skip, default = "create_foo")]
    c: Foo,
}

#[derive(Debug)]
struct Foo(i32);

pub fn create_foo() -> Foo {
    Foo(12)
}
```

Related: https://github.com/tokio-rs/prost/issues/174

---

This appears to work locally, but I can't get the full test suite to run (even with clean main branch). I'd like to add some integration tests for this, but it seems the only tests for derive currently are the existing Protobuf known-types (where this wouldn't really make sense), and a few negative test cases in the derive package.