### PR TITLE
test(result_enum): Move test to separate module

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -109,7 +109,7 @@ fn main() {
         .compile_protos(&[src.join("custom_debug.proto")], includes)
         .unwrap();
 
-    config
+    prost_build::Config::new()
         .compile_protos(&[src.join("result_enum.proto")], includes)
         .unwrap();
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -87,9 +87,8 @@ mod test_enum_named_option_value {
     include!(concat!(env!("OUT_DIR"), "/myenum.optionn.rs"));
 }
 
-mod test_enum_named_result_value {
-    include!(concat!(env!("OUT_DIR"), "/myenum.result.rs"));
-}
+#[cfg(test)]
+mod result_enum;
 
 mod test_result_named_option_value {
     include!(concat!(env!("OUT_DIR"), "/mystruct.optionn.rs"));

--- a/tests/src/result_enum.proto
+++ b/tests/src/result_enum.proto
@@ -1,6 +1,5 @@
 syntax = "proto3";
-package myenum.result;
-
+package result_enum;
 
 enum Result {
   HELLO = 0;

--- a/tests/src/result_enum.rs
+++ b/tests/src/result_enum.rs
@@ -1,0 +1,8 @@
+include!(concat!(env!("OUT_DIR"), "/result_enum.rs"));
+
+#[test]
+fn test_enum_named_result_value() {
+    let _ = FailMessage {
+        result: Result::Hello.into(),
+    };
+}


### PR DESCRIPTION
- Create a explicit test in separate module
- Rename package to match the filename
- Make config dependency explicit in `build.rs`