### PR TITLE
test(option_enum): Move test to separate module

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -117,7 +117,7 @@ fn main() {
         .compile_protos(&[src.join("result_struct.proto")], includes)
         .unwrap();
 
-    config
+    prost_build::Config::new()
         .compile_protos(&[src.join("option_enum.proto")], includes)
         .unwrap();
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -83,9 +83,8 @@ mod ident_conversion;
 #[cfg(test)]
 mod oneof_name_conflict;
 
-mod test_enum_named_option_value {
-    include!(concat!(env!("OUT_DIR"), "/myenum.optionn.rs"));
-}
+#[cfg(test)]
+mod option_enum;
 
 #[cfg(test)]
 mod result_enum;

--- a/tests/src/option_enum.proto
+++ b/tests/src/option_enum.proto
@@ -1,6 +1,5 @@
 syntax = "proto3";
-package myenum.optionn;
-
+package option_enum;
 
 enum Option {
   HELLO = 0;

--- a/tests/src/option_enum.rs
+++ b/tests/src/option_enum.rs
@@ -1,0 +1,8 @@
+include!(concat!(env!("OUT_DIR"), "/option_enum.rs"));
+
+#[test]
+fn test_enum_named_option_value() {
+    let _ = FailMessage {
+        result: Option::Hello.into(),
+    };
+}


### PR DESCRIPTION
- Create a explicit test in separate module
- Rename package to match the filename
- Make config dependency explicit in `build.rs`