### PR TITLE
test(option_struct): Move tests to separate module

### DIFF
--- a/tests/build.rs
+++ b/tests/build.rs
@@ -121,7 +121,7 @@ fn main() {
         .compile_protos(&[src.join("option_enum.proto")], includes)
         .unwrap();
 
-    config
+    prost_build::Config::new()
         .compile_protos(&[src.join("option_struct.proto")], includes)
         .unwrap();
 

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -89,9 +89,8 @@ mod option_enum;
 #[cfg(test)]
 mod result_enum;
 
-mod test_result_named_option_value {
-    include!(concat!(env!("OUT_DIR"), "/mystruct.optionn.rs"));
-}
+#[cfg(test)]
+mod option_struct;
 
 #[cfg(test)]
 mod result_struct;

--- a/tests/src/option_struct.proto
+++ b/tests/src/option_struct.proto
@@ -1,6 +1,5 @@
 syntax = "proto3";
-package mystruct.optionn;
-
+package option_struct;
 
 message Option {
   string msg = 1;

--- a/tests/src/option_struct.rs
+++ b/tests/src/option_struct.rs
@@ -1,0 +1,8 @@
+include!(concat!(env!("OUT_DIR"), "/option_struct.rs"));
+
+#[test]
+fn test_struct_named_option_value() {
+    let _ = Option {
+        msg: "Can I create?".into(),
+    };
+}


### PR DESCRIPTION
- Create a explicit test in separate module
- Rename package to match the filename
- Make config dependency explicit in `build.rs`