### PR TITLE
build: Increase MSRV to 1.82

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ authors = [
 ]
 license = "Apache-2.0"
 repository = "https://github.com/tokio-rs/prost"
-rust-version = "1.71.1"
+rust-version = "1.82"
 edition = "2021"
 
 [profile.bench]

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See the [snazzy repository][snazzy] for a simple start-to-finish example.
 
 ### MSRV
 
-`prost` follows the `tokio-rs` project's MSRV model and supports 1.71.1. For more
+`prost` follows the `tokio-rs` project's MSRV model and supports 1.82. For more
 information on the tokio msrv policy you can check it out [here][tokio msrv]
 
 [tokio msrv]: https://github.com/tokio-rs/tokio/#supported-rust-versions


### PR DESCRIPTION
Rust 1.82 was released on 17 October, 2024 (1 year ago at this time). Our transitive dependency `indexmap` has recently increased their MSRV. The path of least resistance is to follow this decision.