### PR TITLE
style: Use variables directly in the `format!` string

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -883,7 +883,7 @@ impl<'b> CodeGenerator<'_, 'b> {
 
     fn push_service(&mut self, service: ServiceDescriptorProto) {
         let name = service.name().to_owned();
-        debug!("  service: {:?}", name);
+        debug!("  service: {name:?}");
 
         let comments = self
             .location()

--- a/prost-build/src/code_generator/c_escaping.rs
+++ b/prost-build/src/code_generator/c_escaping.rs
@@ -69,7 +69,7 @@ pub(super) fn unescape_c_escape_string(s: &str) -> Vec<u8> {
                     let mut octal = 0;
                     for _ in 0..3 {
                         if p < len && src[p] >= b'0' && src[p] <= b'7' {
-                            debug!("\toctal: {}", octal);
+                            debug!("\toctal: {octal}");
                             octal = octal * 8 + (src[p] - b'0');
                             p += 1;
                         } else {

--- a/prost-build/src/config.rs
+++ b/prost-build/src/config.rs
@@ -967,7 +967,7 @@ impl Config {
                 cmd.arg(proto.as_ref());
             }
 
-            debug!("Running: {:?}", cmd);
+            debug!("Running: {cmd:?}");
 
             let output = match cmd.output() {
             Err(err) if ErrorKind::NotFound == err.kind() => return Err(Error::new(

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -82,7 +82,7 @@ impl Field {
                             None => bail!("invalid map attribute: must have key and value types"),
                         };
                         if items.next().is_some() {
-                            bail!("invalid map attribute: {:?}", attr);
+                            bail!("invalid map attribute: {attr:?}");
                         }
                         (k, v)
                     }
@@ -367,7 +367,7 @@ fn key_ty_from_str(s: &str) -> Result<scalar::Ty, Error> {
         | scalar::Ty::Sfixed64
         | scalar::Ty::Bool
         | scalar::Ty::String => Ok(ty),
-        _ => bail!("invalid map key type: {}", s),
+        _ => bail!("invalid map key type: {s}"),
     }
 }
 
@@ -385,7 +385,7 @@ impl ValueTy {
         } else if s.trim() == "message" {
             Ok(ValueTy::Message)
         } else {
-            bail!("invalid map value type: {}", s);
+            bail!("invalid map value type: {s}");
         }
     }
 

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -247,7 +247,7 @@ where
     T: fmt::Debug,
 {
     if let Some(ref existing) = *option {
-        bail!("{}: {:?} and {:?}", message, existing, value);
+        bail!("{message}: {existing:?} and {value:?}");
     }
     *option = Some(value);
     Ok(())
@@ -255,7 +255,7 @@ where
 
 pub fn set_bool(b: &mut bool, message: &str) -> Result<(), Error> {
     if *b {
-        bail!("{}", message);
+        bail!("{message}");
     } else {
         *b = true;
         Ok(())
@@ -291,7 +291,7 @@ fn bool_attr(key: &str, attr: &Meta) -> Result<Option<bool>, Error> {
                 }),
             ..
         }) => Ok(Some(value)),
-        _ => bail!("invalid {} attribute", key),
+        _ => bail!("invalid {key} attribute"),
     }
 }
 
@@ -320,9 +320,9 @@ pub(super) fn tag_attr(attr: &Meta) -> Result<Option<u32>, Error> {
                 .map_err(Error::from)
                 .map(Option::Some),
             Lit::Int(ref lit) => Ok(Some(lit.base10_parse()?)),
-            _ => bail!("invalid tag attribute: {:?}", attr),
+            _ => bail!("invalid tag attribute: {attr:?}"),
         },
-        _ => bail!("invalid tag attribute: {:?}", attr),
+        _ => bail!("invalid tag attribute: {attr:?}"),
     }
 }
 
@@ -351,6 +351,6 @@ fn tags_attr(attr: &Meta) -> Result<Option<Vec<u32>>, Error> {
             .map(|s| s.trim().parse::<u32>().map_err(Error::from))
             .collect::<Result<Vec<u32>, _>>()
             .map(Some),
-        _ => bail!("invalid tag attribute: {:?}", attr),
+        _ => bail!("invalid tag attribute: {attr:?}"),
     }
 }

--- a/prost-derive/src/field/oneof.rs
+++ b/prost-derive/src/field/oneof.rs
@@ -29,7 +29,7 @@ impl Field {
                         ..
                     }) => parse_str::<Path>(&lit.value())?,
                     Meta::List(ref list) => list.parse_args::<Ident>()?.into(),
-                    _ => bail!("invalid oneof attribute: {:?}", attr),
+                    _ => bail!("invalid oneof attribute: {attr:?}"),
                 };
                 set_option(&mut ty, t, "duplicate oneof attribute")?;
             } else if let Some(t) = tags_attr(attr)? {

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -409,7 +409,7 @@ impl BytesTy {
         match s {
             "vec" => Ok(BytesTy::Vec),
             "bytes" => Ok(BytesTy::Bytes),
-            _ => bail!("Invalid bytes type: {}", s),
+            _ => bail!("Invalid bytes type: {s}"),
         }
     }
 
@@ -467,7 +467,7 @@ impl Ty {
 
     pub fn from_str(s: &str) -> Result<Ty, Error> {
         let enumeration_len = "enumeration".len();
-        let error = Err(anyhow!("invalid type: {}", s));
+        let error = Err(anyhow!("invalid type: {s}"));
         let ty = match s.trim() {
             "float" => Ty::Float,
             "double" => Ty::Double,
@@ -622,7 +622,7 @@ impl DefaultValue {
         {
             Ok(Some(lit.clone()))
         } else {
-            bail!("invalid default value attribute: {:?}", attr)
+            bail!("invalid default value attribute: {attr:?}")
         }
     }
 

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -97,11 +97,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
         .duplicates()
         .next()
     {
-        bail!(
-            "message {} has multiple fields with tag {}",
-            ident,
-            duplicate_tag
-        )
+        bail!("message {ident} has multiple fields with tag {duplicate_tag}",)
     };
 
     let encoded_len = fields
@@ -435,11 +431,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
         .duplicates()
         .next()
     {
-        bail!(
-            "invalid oneof {}: multiple variants have tag {}",
-            ident,
-            duplicate_tag
-        );
+        bail!("invalid oneof {ident}: multiple variants have tag {duplicate_tag}");
     }
 
     let encode = fields.iter().map(|(variant_ident, field, deprecated)| {


### PR DESCRIPTION
Prevent clippy warnings like:
```
error: variables can be used directly in the `format!` string
   --> prost-derive/src/lib.rs:438:9
    |
438 | /         bail!(
439 | |             "invalid oneof {}: multiple variants have tag {}",
440 | |             ident,
441 | |             duplicate_tag
442 | |         );
    | |_________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
```