### PR TITLE
test(derive_copy): Allow dead code

### DIFF
--- a/tests/src/derive_copy.rs
+++ b/tests/src/derive_copy.rs
@@ -1,6 +1,7 @@
+#![allow(dead_code)]
+
 include!(concat!(env!("OUT_DIR"), "/derive_copy.rs"));
 
-#[allow(dead_code)]
 trait TestCopyIsImplemented: Copy {}
 
 impl TestCopyIsImplemented for EmptyMsg {}


### PR DESCRIPTION
This test uses a trait to assert each message implements `Copy`, therefore non of the messages are actually used.