### PR TITLE
test(groups): Actually construct `NestedGroup`

### DIFF
--- a/tests/src/groups.proto
+++ b/tests/src/groups.proto
@@ -36,7 +36,7 @@ message NestedGroup {
     }
 
     required group RequiredGroup = 2 {
-        required NestedGroup nested_group = 1;
+        optional NestedGroup nested_group = 1;
     }
 
     repeated group RepeatedGroup = 3 {
@@ -47,11 +47,5 @@ message NestedGroup {
         group G = 4 {
             optional NestedGroup nested_group = 1;
         }
-    }
-}
-
-message NestedGroup2 {
-    optional group OptionalGroup = 1 {
-        optional NestedGroup2 nested_group = 1;
     }
 }

--- a/tests/src/groups.rs
+++ b/tests/src/groups.rs
@@ -85,22 +85,109 @@ fn test_group_oneof() {
 }
 
 #[test]
-fn test_deep_nesting_group() {
+fn test_deep_nesting_group_1() {
     fn build_and_roundtrip(depth: usize) -> Result<(), prost::DecodeError> {
-        let mut a = NestedGroup2::default();
+        let mut a = NestedGroup::default();
         for _ in 0..depth {
-            a = NestedGroup2 {
-                optionalgroup: Some(Box::new(nested_group2::OptionalGroup {
+            a = NestedGroup {
+                optionalgroup: Some(Box::new(nested_group::OptionalGroup {
                     nested_group: Some(a),
                 })),
+                requiredgroup: Box::new(nested_group::RequiredGroup { nested_group: None }),
+                repeatedgroup: Vec::from([nested_group::RepeatedGroup {
+                    nested_groups: Vec::from([]),
+                }]),
+                o: Some(nested_group::O::G(Box::new(nested_group::G {
+                    nested_group: None,
+                }))),
             };
         }
 
         let mut buf = Vec::new();
         a.encode(&mut buf).unwrap();
-        NestedGroup2::decode(buf.as_slice()).map(|_| ())
+        NestedGroup::decode(buf.as_slice()).map(|_| ())
     }
 
-    assert!(build_and_roundtrip(50).is_ok());
-    assert!(build_and_roundtrip(51).is_err());
+    assert!(build_and_roundtrip(49).is_ok());
+    assert!(build_and_roundtrip(50).is_err());
+}
+
+#[test]
+fn test_deep_nesting_group_2() {
+    fn build_and_roundtrip(depth: usize) -> Result<(), prost::DecodeError> {
+        let mut a = NestedGroup::default();
+        for _ in 0..depth {
+            a = NestedGroup {
+                optionalgroup: Some(Box::new(nested_group::OptionalGroup { nested_group: None })),
+                requiredgroup: Box::new(nested_group::RequiredGroup {
+                    nested_group: Some(a),
+                }),
+                repeatedgroup: Vec::from([nested_group::RepeatedGroup {
+                    nested_groups: Vec::from([]),
+                }]),
+                o: Some(nested_group::O::G(Box::new(nested_group::G {
+                    nested_group: None,
+                }))),
+            };
+        }
+
+        let mut buf = Vec::new();
+        a.encode(&mut buf).unwrap();
+        NestedGroup::decode(buf.as_slice()).map(|_| ())
+    }
+
+    assert!(build_and_roundtrip(49).is_ok());
+    assert!(build_and_roundtrip(50).is_err());
+}
+
+#[test]
+fn test_deep_nesting_group_3() {
+    fn build_and_roundtrip(depth: usize) -> Result<(), prost::DecodeError> {
+        let mut a = NestedGroup::default();
+        for _ in 0..depth {
+            a = NestedGroup {
+                optionalgroup: Some(Box::new(nested_group::OptionalGroup { nested_group: None })),
+                requiredgroup: Box::new(nested_group::RequiredGroup { nested_group: None }),
+                repeatedgroup: Vec::from([nested_group::RepeatedGroup {
+                    nested_groups: Vec::from([a]),
+                }]),
+                o: Some(nested_group::O::G(Box::new(nested_group::G {
+                    nested_group: None,
+                }))),
+            };
+        }
+
+        let mut buf = Vec::new();
+        a.encode(&mut buf).unwrap();
+        NestedGroup::decode(buf.as_slice()).map(|_| ())
+    }
+
+    assert!(build_and_roundtrip(49).is_ok());
+    assert!(build_and_roundtrip(50).is_err());
+}
+
+#[test]
+fn test_deep_nesting_group_4() {
+    fn build_and_roundtrip(depth: usize) -> Result<(), prost::DecodeError> {
+        let mut a = NestedGroup::default();
+        for _ in 0..depth {
+            a = NestedGroup {
+                optionalgroup: Some(Box::new(nested_group::OptionalGroup { nested_group: None })),
+                requiredgroup: Box::new(nested_group::RequiredGroup { nested_group: None }),
+                repeatedgroup: Vec::from([nested_group::RepeatedGroup {
+                    nested_groups: Vec::from([]),
+                }]),
+                o: Some(nested_group::O::G(Box::new(nested_group::G {
+                    nested_group: Some(a),
+                }))),
+            };
+        }
+
+        let mut buf = Vec::new();
+        a.encode(&mut buf).unwrap();
+        NestedGroup::decode(buf.as_slice()).map(|_| ())
+    }
+
+    assert!(build_and_roundtrip(49).is_ok());
+    assert!(build_and_roundtrip(50).is_err());
 }


### PR DESCRIPTION
- `NestedGroup2` was a duplicate of `NestedGroup`. Simplify by combining them
- A required group with an required recursive field is not constructible. It will always produce a stack overflow. Replace the field with an optional one.
- Construct all four variants of the nested groups. Each in a separate tests. Combining it into a single test will produce an out of memory error, as it is exponentially growing
