### PR TITLE
feature: expose public error API for decode errors

### DIFF
--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -117,7 +117,9 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
             #(#tags)* => {
                 let mut value = &mut self.#field_ident;
                 #merge.map_err(|mut error| {
-                    error.push(STRUCT_NAME, stringify!(#field_ident));
+                    error.path_mut().push_segment(
+                        #prost_path::ErrorPathSegment::new(STRUCT_NAME, stringify!(#field_ident)),
+                    );
                     error
                 })
             },

--- a/prost/src/encoding.rs
+++ b/prost/src/encoding.rs
@@ -13,8 +13,7 @@ use core::str;
 
 use ::bytes::{Buf, BufMut, Bytes};
 
-use crate::error::DecodeErrorKind;
-use crate::DecodeError;
+use crate::{decode_error_kind, DecodeError};
 use crate::Message;
 
 pub mod varint;
@@ -84,7 +83,7 @@ impl DecodeContext {
     #[inline]
     pub(crate) fn limit_reached(&self) -> Result<(), DecodeError> {
         if self.recurse_count == 0 {
-            Err(DecodeErrorKind::RecursionLimitReached.into())
+            Err(decode_error_kind::RecursionLimitReached::new().into())
         } else {
             Ok(())
         }
@@ -115,13 +114,13 @@ pub fn encode_key(tag: u32, wire_type: WireType, buf: &mut impl BufMut) {
 pub fn decode_key(buf: &mut impl Buf) -> Result<(u32, WireType), DecodeError> {
     let key = decode_varint(buf)?;
     if key > u64::from(u32::MAX) {
-        return Err(DecodeErrorKind::InvalidKey { key }.into());
+        return Err(decode_error_kind::InvalidKey::new(key).into());
     }
     let wire_type = WireType::try_from(key & 0x07)?;
     let tag = key as u32 >> 3;
 
     if tag < MIN_TAG {
-        return Err(DecodeErrorKind::InvalidTag.into());
+        return Err(decode_error_kind::InvalidTag::new().into());
     }
 
     Ok((tag, wire_type))
@@ -149,7 +148,7 @@ where
     let len = decode_varint(buf)?;
     let remaining = buf.remaining();
     if len > remaining as u64 {
-        return Err(DecodeErrorKind::BufferUnderflow.into());
+        return Err(decode_error_kind::BufferUnderflow::new().into());
     }
 
     let limit = remaining - len as usize;
@@ -158,7 +157,7 @@ where
     }
 
     if buf.remaining() != limit {
-        return Err(DecodeErrorKind::DelimitedLengthExceeded.into());
+        return Err(decode_error_kind::BufferUnderflow::new().into());
     }
     Ok(())
 }
@@ -180,18 +179,18 @@ pub fn skip_field(
             match inner_wire_type {
                 WireType::EndGroup => {
                     if inner_tag != tag {
-                        return Err(DecodeErrorKind::UnexpectedEndGroupTag.into());
+                        return Err(decode_error_kind::UnexpectedEndGroupTag::new().into());
                     }
                     break 0;
                 }
                 _ => skip_field(inner_wire_type, inner_tag, buf, ctx.enter_recursion())?,
             }
         },
-        WireType::EndGroup => return Err(DecodeErrorKind::UnexpectedEndGroupTag.into()),
+        WireType::EndGroup => return Err(decode_error_kind::UnexpectedEndGroupTag::new().into()),
     };
 
     if len > buf.remaining() as u64 {
-        return Err(DecodeErrorKind::BufferUnderflow.into());
+        return Err(decode_error_kind::BufferUnderflow::new().into());
     }
 
     buf.advance(len as usize);
@@ -396,7 +395,7 @@ macro_rules! fixed_width {
             ) -> Result<(), DecodeError> {
                 check_wire_type($wire_type, wire_type)?;
                 if buf.remaining() < $width {
-                    return Err(DecodeErrorKind::BufferUnderflow.into());
+                    return Err(decode_error_kind::BufferUnderflow::new().into());
                 }
                 *value = buf.$get();
                 Ok(())
@@ -599,7 +598,7 @@ pub mod string {
                     mem::forget(drop_guard);
                     Ok(())
                 }
-                Err(_) => Err(DecodeErrorKind::InvalidString.into()),
+                Err(_) => Err(decode_error_kind::InvalidString::new().into()),
             }
         }
     }
@@ -684,8 +683,6 @@ impl sealed::BytesAdapter for Vec<u8> {
 }
 
 pub mod bytes {
-    use crate::error::DecodeErrorKind;
-
     use super::*;
 
     pub fn encode(tag: u32, value: &impl BytesAdapter, buf: &mut impl BufMut) {
@@ -703,7 +700,7 @@ pub mod bytes {
         check_wire_type(WireType::LengthDelimited, wire_type)?;
         let len = decode_varint(buf)?;
         if len > buf.remaining() as u64 {
-            return Err(DecodeErrorKind::BufferUnderflow.into());
+            return Err(decode_error_kind::BufferUnderflow::new().into());
         }
         let len = len as usize;
 
@@ -732,7 +729,7 @@ pub mod bytes {
         check_wire_type(WireType::LengthDelimited, wire_type)?;
         let len = decode_varint(buf)?;
         if len > buf.remaining() as u64 {
-            return Err(DecodeErrorKind::BufferUnderflow.into());
+            return Err(decode_error_kind::BufferUnderflow::new().into());
         }
         let len = len as usize;
 
@@ -866,8 +863,6 @@ pub mod message {
 }
 
 pub mod group {
-    use crate::error::DecodeErrorKind;
-
     use super::*;
 
     pub fn encode<M>(tag: u32, msg: &M, buf: &mut impl BufMut)
@@ -896,7 +891,7 @@ pub mod group {
             let (field_tag, field_wire_type) = decode_key(buf)?;
             if field_wire_type == WireType::EndGroup {
                 if field_tag != tag {
-                    return Err(DecodeErrorKind::UnexpectedEndGroupTag.into());
+                    return Err(decode_error_kind::UnexpectedEndGroupTag::new().into());
                 }
                 return Ok(());
             }

--- a/prost/src/encoding/length_delimiter.rs
+++ b/prost/src/encoding/length_delimiter.rs
@@ -1,4 +1,4 @@
-use crate::error::DecodeErrorKind;
+use crate::error::decode_error_kind;
 pub use crate::error::{DecodeError, EncodeError, UnknownEnumValue};
 pub use crate::message::Message;
 pub use crate::name::Name;
@@ -46,7 +46,7 @@ pub fn length_delimiter_len(length: usize) -> usize {
 pub fn decode_length_delimiter(mut buf: impl Buf) -> Result<usize, DecodeError> {
     let length = decode_varint(&mut buf)?;
     if length > usize::MAX as u64 {
-        return Err(DecodeErrorKind::LengthDelimiterTooLarge.into());
+        return Err(decode_error_kind::LengthDelimiterTooLarge::new().into());
     }
     Ok(length as usize)
 }

--- a/prost/src/encoding/varint.rs
+++ b/prost/src/encoding/varint.rs
@@ -3,7 +3,7 @@ use core::num::NonZeroU64;
 
 use ::bytes::{Buf, BufMut};
 
-use crate::{error::DecodeErrorKind, DecodeError};
+use crate::{decode_error_kind, DecodeError};
 
 /// Encodes an integer value into LEB128 variable length format, and writes it to the buffer.
 /// The buffer must have enough remaining space (maximum 10 bytes).
@@ -38,7 +38,7 @@ pub fn decode_varint(buf: &mut impl Buf) -> Result<u64, DecodeError> {
     let bytes = buf.chunk();
     let len = bytes.len();
     if len == 0 {
-        return Err(DecodeErrorKind::InvalidVarint.into());
+        return Err(decode_error_kind::InvalidVarint::new().into());
     }
 
     let byte = bytes[0];
@@ -143,7 +143,7 @@ fn decode_varint_slice(bytes: &[u8]) -> Result<(u64, usize), DecodeError> {
 
     // We have overrun the maximum size of a varint (10 bytes) or the final byte caused an overflow.
     // Assume the data is corrupt.
-    Err(DecodeErrorKind::InvalidVarint.into())
+    Err(decode_error_kind::InvalidVarint::new().into())
 }
 
 /// Decodes a LEB128-encoded variable length integer from the buffer, advancing the buffer as
@@ -163,14 +163,14 @@ fn decode_varint_slow(buf: &mut impl Buf) -> Result<u64, DecodeError> {
             // Check for u64::MAX overflow. See [`ConsumeVarint`][1] for details.
             // [1]: https://github.com/protocolbuffers/protobuf-go/blob/v1.27.1/encoding/protowire/wire.go#L358
             if count == 9 && byte >= 0x02 {
-                return Err(DecodeErrorKind::InvalidVarint.into());
+                return Err(decode_error_kind::InvalidVarint::new().into());
             } else {
                 return Ok(value);
             }
         }
     }
 
-    Err(DecodeErrorKind::InvalidVarint.into())
+    Err(decode_error_kind::InvalidVarint::new().into())
 }
 
 #[cfg(test)]

--- a/prost/src/encoding/wire_type.rs
+++ b/prost/src/encoding/wire_type.rs
@@ -1,4 +1,4 @@
-use crate::{error::DecodeErrorKind, DecodeError};
+use crate::{decode_error_kind, DecodeError};
 
 /// Represent the wire type for protobuf encoding.
 ///
@@ -26,7 +26,7 @@ impl TryFrom<u64> for WireType {
             3 => Ok(WireType::StartGroup),
             4 => Ok(WireType::EndGroup),
             5 => Ok(WireType::ThirtyTwoBit),
-            _ => Err(DecodeErrorKind::InvalidWireType { value }.into()),
+            _ => Err(decode_error_kind::InvalidWireType::new(value).into()),
         }
     }
 }
@@ -36,7 +36,7 @@ impl TryFrom<u64> for WireType {
 #[inline]
 pub fn check_wire_type(expected: WireType, actual: WireType) -> Result<(), DecodeError> {
     if expected != actual {
-        return Err(DecodeErrorKind::UnexpectedWireType { actual, expected }.into());
+        return Err(decode_error_kind::UnexpectedWireType::new(actual, expected).into());
     }
     Ok(())
 }

--- a/prost/src/error.rs
+++ b/prost/src/error.rs
@@ -1,13 +1,15 @@
 //! Protobuf encoding and decoding errors.
 
-use crate::encoding::WireType;
 #[cfg(not(feature = "std"))]
 use alloc::boxed::Box;
 #[cfg(not(feature = "std"))]
 use alloc::string::String;
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
+use core::error::Error;
 use core::fmt;
+
+pub use decode_error_kind::DecodeErrorKind;
 
 /// A Protobuf message decoding error.
 ///
@@ -22,11 +24,11 @@ pub struct DecodeError {
 #[derive(Clone, PartialEq, Eq)]
 struct Inner {
     /// A 'best effort' root cause description.
-    description: DecodeErrorKind,
-    /// A stack of (message, field) name pairs, which identify the specific
-    /// message type and field where decoding failed. The stack contains an
-    /// entry per level of nesting.
-    stack: Vec<(&'static str, &'static str)>,
+    kind: DecodeErrorKind,
+    /// Logical path to where the error occurred.
+    ///
+    /// Internally, this is a stack with an entry per level of nesting.
+    path: ErrorPath,
 }
 
 impl DecodeError {
@@ -35,117 +37,349 @@ impl DecodeError {
     /// Meant to be used only by `prost_types::Any` implementation.
     #[doc(hidden)]
     #[cold]
-    pub fn new_unexpected_type_url(
-        actual: impl Into<String>,
-        expected: impl Into<String>,
-    ) -> DecodeError {
-        DecodeErrorKind::UnexpectedTypeUrl {
-            actual: actual.into(),
-            expected: expected.into(),
-        }
-        .into()
+    pub fn new_unexpected_type_url(actual: impl Into<String>, expected: impl Into<String>) -> Self {
+        decode_error_kind::UnexpectedTypeUrl::new(actual.into(), expected.into())
+            .into()
     }
 
-    /// Pushes a (message, field) name location pair on to the location stack.
+    /// Get the location where the error occurred as a logical path.
     ///
-    /// Meant to be used only by `Message` implementations.
+    /// The error path represents the stack of message fields being
+    /// decoded as the error occurred.
+    pub fn path(&self) -> &ErrorPath {
+        &self.inner.path
+    }
+
+    /// Get a mutable reference to the error path
+    ///
+    /// This API is hidden to prevent accidental misuse. It is still public to
+    /// enable advanced use cases such as creating decode errors from manual
+    /// implementations in third-party crates.
     #[doc(hidden)]
-    pub fn push(&mut self, message: &'static str, field: &'static str) {
-        self.inner.stack.push((message, field));
+    pub fn path_mut(&mut self) -> &mut ErrorPath {
+        &mut self.inner.path
+    }
+}
+
+/// Logical path to the location of an error using Protobuf fields.
+///
+/// This struct provides context for errors such as [`DecodeError`]. It tracks
+/// the logical call-stack of where an error occurred. It stores a path from
+/// the root where decoding started down to some nested field where the error
+/// actually occurred.
+///
+/// Each level is represented by an [`ErrorPathSegment`] value. You can retrieve
+/// segments using the [`iter`] method.
+///
+/// An empty path represents an error that happened "at the root".
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct ErrorPath {
+    segments: Vec<ErrorPathSegment>,
+}
+
+impl ErrorPath {
+    /// Create a new empty error path.
+    pub fn new() -> Self {
+        Self {
+            segments: Vec::new(),
+        }
+    }
+
+    /// Get an iterator for all the segments in this error path.
+    ///
+    /// The segments are iterated in the direction from the root down to the
+    /// nested field.
+    pub fn iter(&self) -> PathSegmentIter<'_> {
+        PathSegmentIter {
+            inner: self.segments.iter(),
+        }
+    }
+
+    pub fn push_segment(&mut self, segment: ErrorPathSegment) {
+        self.segments.push(segment);
+    }
+}
+
+impl<'path> IntoIterator for &'path ErrorPath {
+    type Item = &'path ErrorPathSegment;
+    type IntoIter = PathSegmentIter<'path>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Iterator over all the segments in an [`ErrorPath`] value.
+///
+/// Segments are iterated starting from the root down to the nested field.
+///
+/// This iterator is double-ended. Use the [`rev`](Iterator::rev) method to
+/// iterate from the nested field up to the root.
+pub struct PathSegmentIter<'path> {
+    inner: core::slice::Iter<'path, ErrorPathSegment>,
+}
+
+impl<'path> Iterator for PathSegmentIter<'path> {
+    type Item = &'path ErrorPathSegment;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.inner.next()
+    }
+}
+
+impl<'path> DoubleEndedIterator for PathSegmentIter<'path> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.inner.next_back()
+    }
+}
+
+/// A segment identifying a specific Protobuf message field by name.
+///
+/// This type is usually retrieved from an [`ErrorPath`] value.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[non_exhaustive]
+pub struct ErrorPathSegment {
+    message: &'static str,
+    field: &'static str,
+}
+
+impl ErrorPathSegment {
+    /// Create a new error path segment.
+    ///
+    /// The `message` and `field` parameters may be any string, but it is
+    /// recommended to follow the following format:
+    /// - `message`: dot-separated absolute Protobuf message name (no leading dot); e.g. `com.example.GitRepository`
+    /// - `field`: field name, as found in the Protobuf definition; e.g. `default_branch`
+    ///
+    /// This API is hidden to prevent accidental misuse using invalid message or
+    /// field names. It is still public to enable advanced use cases such as
+    /// creating decode errors from manual implementations in third-party crates.
+    #[doc(hidden)]
+    pub fn new(message: &'static str, field: &'static str) -> Self {
+        Self { message, field }
+    }
+
+    /// Get the protobuf message name
+    pub fn message(&self) -> &'static str {
+        self.message
+    }
+
+    /// Get the protobuf message name
+    pub fn field(&self) -> &'static str {
+        self.field
     }
 }
 
 impl fmt::Debug for DecodeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("DecodeError")
-            .field("description", &self.inner.description)
-            .field("stack", &self.inner.stack)
+            .field("kind", &self.inner.kind)
+            .field("path", &self.path())
             .finish()
     }
 }
 
 impl fmt::Display for DecodeError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str("failed to decode Protobuf message: ")?;
-        for &(message, field) in &self.inner.stack {
-            write!(f, "{message}.{field}: ")?;
+        f.write_str("failed to decode Protobuf message")?;
+        for segment in self.path().iter() {
+            write!(
+                f,
+                ": {message}.{field}",
+                message = segment.message(),
+                field = segment.field()
+            )?;
         }
-        write!(f, "{}", self.inner.description)
+        Ok(())
     }
 }
 
 impl From<DecodeErrorKind> for DecodeError {
-    fn from(description: DecodeErrorKind) -> Self {
+    fn from(kind: DecodeErrorKind) -> Self {
         DecodeError {
             inner: Box::new(Inner {
-                description,
-                stack: Vec::new(),
+                kind,
+                path: ErrorPath::new(),
             }),
         }
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) enum DecodeErrorKind {
-    /// Length delimiter exceeds maximum usize value
-    LengthDelimiterTooLarge,
-    /// Invalid varint
-    InvalidVarint,
-    #[cfg(not(feature = "no-recursion-limit"))]
-    /// Recursion limit reached
-    RecursionLimitReached,
-    /// Invalid wire type value
-    InvalidWireType { value: u64 },
-    /// Invalid key value
-    InvalidKey { key: u64 },
-    /// Invalid tag value: 0
-    InvalidTag,
-    /// Invalid wire type
-    UnexpectedWireType {
-        actual: WireType,
-        expected: WireType,
-    },
-    /// Buffer underflow
-    BufferUnderflow,
-    /// Delimited length exceeded
-    DelimitedLengthExceeded,
-    /// Unexpected end group tag
-    UnexpectedEndGroupTag,
-    /// Invalid string value: data is not UTF-8 encoded
-    InvalidString,
-    /// Unexpected type URL
-    UnexpectedTypeUrl { actual: String, expected: String },
-}
+pub mod decode_error_kind {
+  use super::*;
+  use crate::encoding::WireType;
 
-impl fmt::Display for DecodeErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::LengthDelimiterTooLarge => {
-                write!(f, "length delimiter exceeds maximum usize value")
-            }
-            Self::InvalidVarint => write!(f, "invalid varint"),
-            #[cfg(not(feature = "no-recursion-limit"))]
-            Self::RecursionLimitReached => write!(f, "recursion limit reached"),
-            Self::InvalidWireType { value } => write!(f, "invalid wire type value: {value}"),
-            Self::InvalidKey { key } => write!(f, "invalid key value: {key}"),
-            Self::InvalidTag => write!(f, "invalid tag value: 0"),
-            Self::UnexpectedWireType { actual, expected } => {
-                write!(f, "invalid wire type: {actual:?} (expected {expected:?})")
-            }
-            Self::BufferUnderflow => write!(f, "buffer underflow"),
-            Self::DelimitedLengthExceeded => write!(f, "delimited length exceeded"),
-            Self::UnexpectedEndGroupTag => write!(f, "unexpected end group tag"),
-            Self::InvalidString => {
-                write!(f, "invalid string value: data is not UTF-8 encoded")
-            }
-            Self::UnexpectedTypeUrl { actual, expected } => {
-                write!(f, "unexpected type URL.type_url: expected type URL: \"{expected}\" (got: \"{actual}\")")
-            }
+  macro_rules! impl_decode_error_kind {
+    {
+      $(
+        $(#[doc = $doc:literal])?
+        $(#[cfg($($cfg_value:tt)+)])*
+        #[description($description:literal)]
+        pub struct $name:ident {
+          $(
+            #[get($field_get:ty $(, $get_method:ident)?)]
+            $(#[$field_meta:meta])*
+            $field:ident: $field_type:ty
+          ),*$(,)?
         }
+      )*
+    } => {
+      #[derive(Clone, Debug, PartialEq, Eq)]
+      #[non_exhaustive]
+      pub enum DecodeErrorKind {
+        $(
+          $(#[doc = $doc])?
+          $name($name),
+        )*
+      }
+
+      /// Retrieve the inner error value
+      impl DecodeErrorKind {
+        pub fn inner(&self) -> &(dyn Error + 'static) {
+          match self {
+            $(Self::$name(inner) => inner,)*
+          }
+        }
+      }
+
+      impl fmt::Display for DecodeErrorKind {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+          match self {
+            $(Self::$name(inner) => inner.fmt(f),)*
+          }
+        }
+      }
+
+      $(
+        $(#[doc = $doc])?
+        #[derive(Debug, Clone, PartialEq, Eq)]
+        #[non_exhaustive]
+        pub struct $name {
+          $(
+            $(#[$field_meta])*
+            $field: $field_type,
+          )*
+        }
+
+        impl $name {
+          #[doc(hidden)]
+          pub fn new($($field: $field_type,)*) -> Self {
+            Self {
+              $($field: $field,)*
+            }
+          }
+
+          pub fn into_decode_error_kind(self) -> super::DecodeErrorKind {
+            super::DecodeErrorKind::$name(self)
+          }
+
+          pub fn into_decode_error(self) -> super::DecodeError {
+            super::DecodeError::from(self.into_decode_error_kind())
+          }
+
+          $(
+            pub fn $field(&self) -> $field_get {
+              self.$field $(.$get_method())?
+            }
+          )*
+        }
+
+        impl fmt::Display for $name {
+          fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, $description, $($field = self.$field,)*)
+          }
+        }
+
+        impl Error for $name {}
+
+        impl From<$name> for DecodeErrorKind {
+          fn from(value: $name) -> Self {
+            value.into_decode_error_kind()
+          }
+        }
+
+        impl From<$name> for DecodeError {
+          fn from(value: $name) -> Self {
+            value.into_decode_error()
+          }
+        }
+      )*
+    };
+  }
+
+    impl_decode_error_kind! {
+      /// Length delimiter exceeds maximum usize value
+      #[description("length delimiter exceeds maximum usize value")]
+      pub struct LengthDelimiterTooLarge {}
+
+      /// Invalid varint
+      #[description("invalid varint")]
+      pub struct InvalidVarint {}
+
+      /// Recursion limit reached
+      #[cfg(not(feature = "no-recursion-limit"))]
+      #[description("recursion limit reached")]
+      pub struct RecursionLimitReached {}
+
+      /// Invalid wire type value
+      #[description("invalid wire type value: {value}")]
+      pub struct InvalidWireType {
+        #[get(u64)]
+        value: u64,
+      }
+
+      /// Invalid key value
+      #[description("invalid key value: {key}")]
+      pub struct InvalidKey { #[get(u64)]
+      key: u64,
+      }
+
+      /// Invalid tag value: 0
+      #[description("invalid tag value: 0")]
+      pub struct InvalidTag {}
+
+      /// Invalid wire type
+      #[description("invalid wire type: {actual:?} (expected {expected:?})")]
+      pub struct UnexpectedWireType {
+        #[get(WireType)]
+        actual: WireType,
+        #[get(WireType)]
+        expected: WireType,
+      }
+
+      /// Buffer underflow
+      #[description("buffer underflow")]
+      pub struct BufferUnderflow {}
+
+      /// Delimited length exceeded
+      #[description("delimited length exceeded")]
+      pub struct DelimitedLengthExceeded{}
+
+      /// Unexpected end group tag
+      #[description("unexpected end group tag")]
+      pub struct UnexpectedEndGroupTag{}
+
+      /// Invalid string value: data is not UTF-8 encoded
+      #[description("invalid string value: data is not UTF-8 encoded")]
+      pub struct InvalidString{}
+
+      /// Unexpected type URL
+      #[description("unexpected type URL.type_url: expected type URL: \"{expected}\" (got: \"{actual}\")")]
+      pub struct UnexpectedTypeUrl {
+        #[get(&str, as_str)]
+        actual: String,
+        #[get(&str, as_str)]
+        expected: String
+      }
     }
 }
 
-impl core::error::Error for DecodeError {}
+impl Error for DecodeError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        Some(self.inner.kind.inner())
+    }
+}
 
 #[cfg(feature = "std")]
 impl From<DecodeError> for std::io::Error {
@@ -222,30 +456,38 @@ impl core::error::Error for UnknownEnumValue {}
 
 #[cfg(test)]
 mod test {
-    use super::*;
+  use super::*;
 
-    #[test]
+  #[test]
     fn test_push() {
-        let mut decode_error = DecodeError::from(DecodeErrorKind::InvalidVarint);
-        decode_error.push("Foo bad", "bar.foo");
-        decode_error.push("Baz bad", "bar.baz");
+        let mut decode_error = decode_error_kind::InvalidVarint::new().into_decode_error();
+        decode_error.path_mut().push_segment(ErrorPathSegment::new("Foo bad", "bar.foo"));
+        decode_error.path_mut().push_segment(ErrorPathSegment::new("Baz bad", "bar.baz"));
 
         assert_eq!(
             decode_error.to_string(),
-            "failed to decode Protobuf message: Foo bad.bar.foo: Baz bad.bar.baz: invalid varint"
+            "failed to decode Protobuf message: Foo bad.bar.foo: Baz bad.bar.baz"
+        );
+        assert_eq!(
+            decode_error.source().unwrap().to_string(),
+            "invalid varint"
         );
     }
 
     #[cfg(feature = "std")]
     #[test]
     fn test_into_std_io_error() {
-        let decode_error = DecodeError::from(DecodeErrorKind::InvalidVarint);
+      let decode_error = decode_error_kind::InvalidVarint::new().into_decode_error();
         let std_io_error = std::io::Error::from(decode_error);
 
         assert_eq!(std_io_error.kind(), std::io::ErrorKind::InvalidData);
         assert_eq!(
             std_io_error.to_string(),
-            "failed to decode Protobuf message: invalid varint"
+            "failed to decode Protobuf message"
+        );
+        assert_eq!(
+            std_io_error.source().unwrap().to_string(),
+            "invalid varint"
         );
     }
 }

--- a/prost/src/lib.rs
+++ b/prost/src/lib.rs
@@ -4,7 +4,14 @@
 
 // Re-export the alloc crate for use within derived code.
 #[doc(hidden)]
-pub extern crate alloc;
+pub extern crate alloc; // Re-export #[derive(Message, Enumeration, Oneof)].
+// Based on serde's equivalent re-export [1], but enabled by default.
+//
+// [1]: https://github.com/serde-rs/serde/blob/v1.0.89/serde/src/lib.rs#L245-L256
+#[cfg(feature = "derive")]
+#[allow(unused_imports)]
+#[macro_use]
+extern crate prost_derive;
 
 // Re-export the bytes crate for use within derived code.
 pub use bytes;
@@ -18,9 +25,12 @@ mod types;
 pub mod encoding;
 
 pub use crate::encoding::length_delimiter::{
-    decode_length_delimiter, encode_length_delimiter, length_delimiter_len,
+  decode_length_delimiter, encode_length_delimiter, length_delimiter_len,
 };
-pub use crate::error::{DecodeError, EncodeError, UnknownEnumValue};
+pub use crate::error::{
+  decode_error_kind, DecodeError, DecodeErrorKind, EncodeError, ErrorPath, ErrorPathSegment,
+  UnknownEnumValue,
+};
 pub use crate::message::Message;
 pub use crate::name::Name;
 
@@ -29,14 +39,6 @@ pub use crate::name::Name;
 #[cfg(not(feature = "no-recursion-limit"))]
 const RECURSION_LIMIT: u32 = 100;
 
-// Re-export #[derive(Message, Enumeration, Oneof)].
-// Based on serde's equivalent re-export [1], but enabled by default.
-//
-// [1]: https://github.com/serde-rs/serde/blob/v1.0.89/serde/src/lib.rs#L245-L256
-#[cfg(feature = "derive")]
-#[allow(unused_imports)]
-#[macro_use]
-extern crate prost_derive;
 #[cfg(feature = "derive")]
 #[doc(hidden)]
 pub use prost_derive::*;


### PR DESCRIPTION
This commit updates the Error API and exposes it publicly.

The location of the error becomes fully accessible to consumer code through the `ErrorPath` abstraction. It allows to read the logical path without exposing implementation details.

The error kind is turned into an enum of source errors. Each source error and the error kind itself are non-exhaustive. This allows to new fields in the future without breaking backwards compatibility.

Public constructors are provided to enable advanced use-cases in third-party crate that want to create new error types.

`DecodeError` uses the `core::error::Error` API to expose source errors. In particular, it does not print the source error in its own display message. This allows better integration with error reporting frameworks.

Closes https://github.com/tokio-rs/prost/issues/1375