### PR TITLE
fix: Add back `DecodeError::new`

### DIFF
--- a/prost/src/error.rs
+++ b/prost/src/error.rs
@@ -39,6 +39,7 @@ impl DecodeError {
         note = "This function was meant for internal use only. Because of `doc(hidden)` it was publicly available and it is actually used by users. The prost project intents to remove this function in the next breaking release."
     )]
     #[cold]
+    #[doc(hidden)]
     pub fn new(description: impl Into<Cow<'static, str>>) -> DecodeError {
         DecodeErrorKind::Other {
             description: description.into(),


### PR DESCRIPTION
This function was meant for internal use only. Because of `doc(hidden)` it was publicly available and it is actually used by users. The prost 0.14.2 release broken some of the crate ecosystem. That release was yanked. To prevent more breakage, this PR adds the function back. This time as a public function that is documented to not be used.

The prost project intents to remove this function in the next breaking release.
