### PR TITLE
fix some forgotten prost import paths

### DIFF
--- a/prost-build/src/collections.rs
+++ b/prost-build/src/collections.rs
@@ -28,14 +28,6 @@ impl MapType {
             MapType::BTreeMap => "btree_map",
         }
     }
-
-    /// The fully-qualified Rust type corresponding to the map type.
-    pub fn rust_type(&self) -> &'static str {
-        match self {
-            MapType::HashMap => "::std::collections::HashMap",
-            MapType::BTreeMap => "::prost::alloc::collections::BTreeMap",
-        }
-    }
 }
 
 impl BytesType {
@@ -44,14 +36,6 @@ impl BytesType {
         match self {
             BytesType::Vec => "vec",
             BytesType::Bytes => "bytes",
-        }
-    }
-
-    /// The fully-qualified Rust type corresponding to the bytes type.
-    pub fn rust_type(&self) -> &'static str {
-        match self {
-            BytesType::Vec => "::prost::alloc::vec::Vec<u8>",
-            BytesType::Bytes => "::prost::bytes::Bytes",
         }
     }
 }


### PR DESCRIPTION
For rama we make use of prost to generate code, however it's pretty inconvient
that a user would need to add also prost or prost-types to their direct dependencies
in their cargo.toml given that it means they have to worry about it being compatible
with what rama uses and that kind of bookkeeping work.

And while you already have an option to support a custom path for both
the `prost` and `prost-types` crate, it seems there were a couple of locations
where `::prost` was still hardcoded. Which makes me think that:

- either I do something wrong
- or that custom import path is not really verified/tested?

Anyhow, it's my first PR to this project so please do tell me if I'm off in the weeds with this one.