### PR TITLE
Bugfix: default Name implementation produces invalid URLs with empty packages.

### DIFF
--- a/prost/src/name.rs
+++ b/prost/src/name.rs
@@ -21,7 +21,11 @@ pub trait Name: Message {
     /// By default, this is the package name followed by the message name.
     /// Fully-qualified names must be unique within a domain of Type URLs.
     fn full_name() -> String {
-        format!("{}.{}", Self::PACKAGE, Self::NAME)
+        if Self::PACKAGE.is_empty() {
+            Self::NAME.into()
+        } else {
+            format!("{}.{}", Self::PACKAGE, Self::NAME)
+        }
     }
 
     /// Type URL for this [`Message`], which by default is the full name with a


### PR DESCRIPTION
The default `full_name()` and `type_url()` implementations in the `Name` trait produce invalid type URLs when `PACKAGE` is empty.

Example:
```rust
#[derive(Clone, PartialEq, Debug, Default)]
struct Test {
    value: i32,
}

impl prost::Message for Test {
    // ... Message implementation ...
}

impl Name for Test {
    const PACKAGE: &'static str = "";
    const NAME: &'static str = "test";
    // Using default type_url()/full_name() implementation from Name trait
}

#[test]
fn empty_package_default_url_fails_roundtrip() {
  let type_url = Test::type_url();
  assert_eq!(type_url, "/.test"); // URL has leading dot
  TypeUrl::new(&type_url).unwrap(); // This panics
}
```

This will happen with any message type with `PACKAGE = ""` using the default `type_url()` implementation.

To fix, I adjusted the implementation of `Name::full_name()` to handle the special case of an empty package.

Let me know if you'd like me to adjust anything.
