### PR TITLE
Fix maps not preserving float `-0.0`.

### DIFF
--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -207,6 +207,8 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
                 #default
             }
         }
+
+        impl #impl_generics #prost_path::encoding::IsDefault for #ident #ty_generics #where_clause {}
     };
     let expanded = if skip_debug {
         expanded

--- a/prost/src/encoding.rs
+++ b/prost/src/encoding.rs
@@ -97,6 +97,42 @@ impl DecodeContext {
     }
 }
 
+/// Trait for checking if a value equals its default.
+///
+/// This trait exists because IEEE 754 floats have `-0.0 == 0.0`, but they are
+/// distinct bit patterns. For map encoding, we need to preserve `-0.0` values
+/// rather than treating them as the default `0.0`.
+pub trait IsDefault: PartialEq {
+    #[inline]
+    fn is_default(&self, default: &Self) -> bool {
+        self == default
+    }
+}
+
+impl IsDefault for f32 {
+    #[inline]
+    fn is_default(&self, default: &Self) -> bool {
+        self.to_bits() == default.to_bits()
+    }
+}
+
+impl IsDefault for f64 {
+    #[inline]
+    fn is_default(&self, default: &Self) -> bool {
+        self.to_bits() == default.to_bits()
+    }
+}
+
+impl<T: PartialEq> IsDefault for Option<T> {}
+impl<T: PartialEq> IsDefault for Vec<T> {}
+impl IsDefault for bool {}
+impl IsDefault for i32 {}
+impl IsDefault for i64 {}
+impl IsDefault for u32 {}
+impl IsDefault for u64 {}
+impl IsDefault for String {}
+impl IsDefault for Bytes {}
+
 pub const MIN_TAG: u32 = 1;
 pub const MAX_TAG: u32 = (1 << 29) - 1;
 
@@ -966,7 +1002,7 @@ macro_rules! map {
             buf: &mut B,
         ) where
             K: Default + Eq + Hash + Ord,
-            V: Default + PartialEq,
+            V: Default + IsDefault,
             B: BufMut,
             KE: Fn(u32, &K, &mut B),
             KL: Fn(u32, &K) -> usize,
@@ -1012,7 +1048,7 @@ macro_rules! map {
         ) -> usize
         where
             K: Default + Eq + Hash + Ord,
-            V: Default + PartialEq,
+            V: Default + IsDefault,
             KL: Fn(u32, &K) -> usize,
             VL: Fn(u32, &V) -> usize,
         {
@@ -1034,7 +1070,7 @@ macro_rules! map {
             buf: &mut B,
         ) where
             K: Default + Eq + Hash + Ord,
-            V: PartialEq,
+            V: IsDefault,
             B: BufMut,
             KE: Fn(u32, &K, &mut B),
             KL: Fn(u32, &K) -> usize,
@@ -1043,7 +1079,7 @@ macro_rules! map {
         {
             for (key, val) in values.iter() {
                 let skip_key = key == &K::default();
-                let skip_val = val == val_default;
+                let skip_val = val.is_default(val_default);
 
                 let len = (if skip_key { 0 } else { key_encoded_len(1, key) })
                     + (if skip_val { 0 } else { val_encoded_len(2, val) });
@@ -1111,7 +1147,7 @@ macro_rules! map {
         ) -> usize
         where
             K: Default + Eq + Hash + Ord,
-            V: PartialEq,
+            V: IsDefault,
             KL: Fn(u32, &K) -> usize,
             VL: Fn(u32, &V) -> usize,
         {
@@ -1123,7 +1159,7 @@ macro_rules! map {
                             0
                         } else {
                             key_encoded_len(1, key)
-                        }) + (if val == val_default {
+                        }) + (if val.is_default(val_default) {
                             0
                         } else {
                             val_encoded_len(2, val)
@@ -1278,7 +1314,7 @@ mod test {
         }
         let original = get(&map, &1).unwrap();
         let modified = get(&decoded, &1).unwrap();
-        prop_assert!(equal(&original, &modified));
+        prop_assert!(equal(original, modified));
         Ok(())
     }
 

--- a/tests/src/generic_derive.rs
+++ b/tests/src/generic_derive.rs
@@ -1,4 +1,4 @@
-pub trait CustomType: prost::Message + Default + core::fmt::Debug {}
+pub trait CustomType: prost::Message + Default + core::fmt::Debug + PartialEq {}
 
 impl CustomType for u64 {}
 
@@ -11,7 +11,7 @@ enum GenericEnum<A: CustomType> {
     Number(u64),
 }
 
-#[derive(Clone, prost::Message)]
+#[derive(Clone, prost::Message, PartialEq)]
 struct GenericMessage<A: CustomType> {
     #[prost(message, tag = "1")]
     data: Option<A>,


### PR DESCRIPTION
Maps currently don't preserve `-0.0`. If you add `-0.0` as a value in a map, and read it, you will get `0.0`.

This isn't true of other structures. 

It happens because the default value is `0.0`, and when adding a new value, the code checks if it is equal to the default value using `PartialEq`, which for floats treats `0.0` and `-0.0` as equal.