### PR TITLE
feat(prost-derive): make is_valid a constant function

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ The `#[derive(::prost::Enumeration)]` annotation added to the generated
 
 ```rust,ignore
 impl PhoneType {
-    pub fn is_valid(value: i32) -> bool { ... }
+    pub const fn is_valid(value: i32) -> bool { ... }
     #[deprecated]
     pub fn from_i32(value: i32) -> Option<PhoneType> { ... }
 }

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -323,7 +323,7 @@ fn try_enumeration(input: TokenStream) -> Result<TokenStream, Error> {
     let expanded = quote! {
         impl #impl_generics #ident #ty_generics #where_clause {
             #[doc=#is_valid_doc]
-            pub fn is_valid(value: i32) -> bool {
+            pub const fn is_valid(value: i32) -> bool {
                 match value {
                     #(#is_valid,)*
                     _ => false,


### PR DESCRIPTION
Continuation of https://github.com/tokio-rs/prost/pull/1313