### PR TITLE
style: use `std::hint::black_box()`

### DIFF
--- a/benchmarks/benches/dataset.rs
+++ b/benchmarks/benches/dataset.rs
@@ -46,7 +46,7 @@ where
             for buf in &dataset.payload {
                 message.clear();
                 message.merge(buf.as_slice()).unwrap();
-                criterion::black_box(&message);
+                std::hint::black_box(&message);
             }
         });
     });
@@ -66,7 +66,7 @@ where
             for message in &messages {
                 message.encode(&mut buf).unwrap();
             }
-            criterion::black_box(&buf);
+            std::hint::black_box(&buf);
         });
     });
 
@@ -81,7 +81,7 @@ where
             .unwrap();
         b.iter(|| {
             let encoded_len = messages.iter().map(M::encoded_len).sum::<usize>();
-            criterion::black_box(encoded_len)
+            std::hint::black_box(encoded_len)
         });
     });
 }

--- a/prost/benches/varint.rs
+++ b/prost/benches/varint.rs
@@ -28,7 +28,7 @@ fn benchmark_varint(criterion: &mut Criterion, name: &str, mut values: Vec<u64>)
                     for &value in &encode_values {
                         encode_varint(value, &mut buf);
                     }
-                    criterion::black_box(&buf);
+                    std::hint::black_box(&buf);
                 })
             }
         })
@@ -50,7 +50,7 @@ fn benchmark_varint(criterion: &mut Criterion, name: &str, mut values: Vec<u64>)
                     while buf.has_remaining() {
                         let result = decode_varint(&mut buf);
                         debug_assert!(result.is_ok());
-                        criterion::black_box(&result);
+                        std::hint::black_box(&result);
                     }
                 })
             }
@@ -65,7 +65,7 @@ fn benchmark_varint(criterion: &mut Criterion, name: &str, mut values: Vec<u64>)
                 for &value in &values {
                     sum += encoded_len_varint(value);
                 }
-                criterion::black_box(sum);
+                std::hint::black_box(sum);
             })
         })
         .throughput(Throughput::Bytes(decoded_len));


### PR DESCRIPTION
Prevent usage of deprecated `criterion::black_box()`

Prevent clippy warnings like:
```

error: use of deprecated function `criterion::black_box`: use `std::hint::black_box()` instead
  --> prost/benches/varint.rs:31:32
   |
31 |                     criterion::black_box(&buf);
   |                                ^^^^^^^^^
   |
   = note: `-D deprecated` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(deprecated)]`
```