### PR TITLE
style: Prevent needless borrow

### DIFF
--- a/benchmarks/benches/dataset.rs
+++ b/benchmarks/benches/dataset.rs
@@ -37,7 +37,7 @@ fn benchmark_dataset<M>(criterion: &mut Criterion, name: &str, dataset: &'static
 where
     M: prost::Message + Default + 'static,
 {
-    let mut group = criterion.benchmark_group(&format!("dataset/{}", name));
+    let mut group = criterion.benchmark_group(format!("dataset/{}", name));
 
     group.bench_function("merge", move |b| {
         let dataset = load_dataset(dataset).unwrap();


### PR DESCRIPTION
Prevent clippy warnings like:
```

error: the borrowed expression implements the required traits
  --> benchmarks/benches/dataset.rs:40:47
   |
40 |     let mut group = criterion.benchmark_group(&format!("dataset/{}", name));
   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: change this to: `format!("dataset/{}", name)`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrows_for_generic_args
   = note: `-D clippy::needless-borrows-for-generic-args` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::needless_borrows_for_generic_args)]`