### PR TITLE
Introduce Encoding trait and use it for bytes

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -443,14 +443,6 @@ impl<'b> CodeGenerator<'_, 'b> {
         let type_tag = self.field_type_tag(&field.descriptor);
         self.buf.push_str(&type_tag);
 
-        if type_ == Type::Bytes {
-            let bytes_type = self
-                .context
-                .bytes_type(fq_message_name, field.descriptor.name());
-            self.buf
-                .push_str(&format!(" = {:?}", bytes_type.annotation()));
-        }
-
         match field.descriptor.label() {
             Label::Optional => {
                 if optional {
@@ -506,6 +498,21 @@ impl<'b> CodeGenerator<'_, 'b> {
                 self.buf.push_str(&enum_value);
             } else {
                 self.buf.push_str(&default.escape_default().to_string());
+            }
+        }
+
+        if let Some(type_info) = self.context.custom_type(
+            field.descriptor.r#type(),
+            fq_message_name,
+            field.descriptor.name(),
+        ) {
+            self.buf.push_str(", encoding=\"");
+            self.buf.push_str(&type_info.encoding);
+            self.buf.push('\"');
+            if let Some(module) = type_info.encoding_module.as_deref() {
+                self.buf.push_str(", encoding_module=\"");
+                self.buf.push_str(module);
+                self.buf.push('\"');
             }
         }
 
@@ -987,6 +994,18 @@ impl<'b> CodeGenerator<'_, 'b> {
     }
 
     fn resolve_type(&self, field: &FieldDescriptorProto, fq_message_name: &str) -> String {
+        if let Some(type_info) =
+            self.context
+                .custom_type(field.r#type(), fq_message_name, field.name())
+        {
+            if field.r#type() == Type::Bytes {
+                return type_info
+                    .ty
+                    .replace("{prost_path}", self.context.prost_path());
+            } else {
+                return type_info.ty.clone();
+            }
+        }
         match field.r#type() {
             Type::Float => String::from("f32"),
             Type::Double => String::from("f64"),
@@ -996,12 +1015,7 @@ impl<'b> CodeGenerator<'_, 'b> {
             Type::Int64 | Type::Sfixed64 | Type::Sint64 => String::from("i64"),
             Type::Bool => String::from("bool"),
             Type::String => format!("{}::alloc::string::String", self.context.prost_path()),
-            Type::Bytes => match self.context.bytes_type(fq_message_name, field.name()) {
-                crate::BytesType::Vec => {
-                    format!("{}::alloc::vec::Vec<u8>", self.context.prost_path())
-                }
-                crate::BytesType::Bytes => format!("{}::bytes::Bytes", self.context.prost_path()),
-            },
+            Type::Bytes => format!("{}::alloc::vec::Vec<u8>", self.context.prost_path()),
             Type::Group | Type::Message => self.resolve_ident(field.type_name()),
         }
     }

--- a/prost-build/src/collections.rs
+++ b/prost-build/src/collections.rs
@@ -9,33 +9,12 @@ pub(crate) enum MapType {
     BTreeMap,
 }
 
-/// The bytes collection type to output for Protobuf `bytes` fields.
-#[non_exhaustive]
-#[derive(Default, Clone, Copy, Debug, PartialEq)]
-pub(crate) enum BytesType {
-    /// The [`prost::alloc::vec::Vec<u8>`] type.
-    #[default]
-    Vec,
-    /// The [`bytes::Bytes`](prost::bytes::Bytes) type.
-    Bytes,
-}
-
 impl MapType {
     /// The `prost-derive` annotation type corresponding to the map type.
     pub fn annotation(&self) -> &'static str {
         match self {
             MapType::HashMap => "map",
             MapType::BTreeMap => "btree_map",
-        }
-    }
-}
-
-impl BytesType {
-    /// The `prost-derive` annotation type corresponding to the bytes type.
-    pub fn annotation(&self) -> &'static str {
-        match self {
-            BytesType::Vec => "vec",
-            BytesType::Bytes => "bytes",
         }
     }
 }

--- a/prost-build/src/config.rs
+++ b/prost-build/src/config.rs
@@ -7,11 +7,13 @@ use std::fs;
 use std::io::{Error, ErrorKind, Result, Write};
 use std::path::{Path, PathBuf};
 use std::process::Command;
+use std::rc::Rc;
 
 use log::debug;
 use log::trace;
 
 use prost::Message;
+use prost_types::field_descriptor_proto::Type;
 use prost_types::{FileDescriptorProto, FileDescriptorSet};
 
 use crate::code_generator::CodeGenerator;
@@ -19,10 +21,16 @@ use crate::context::Context;
 use crate::extern_paths::ExternPaths;
 use crate::message_graph::MessageGraph;
 use crate::path::PathMap;
-use crate::BytesType;
 use crate::MapType;
 use crate::Module;
 use crate::ServiceGenerator;
+
+#[derive(Debug)]
+pub(crate) struct CustomTypeInfo {
+    pub(crate) ty: String,
+    pub(crate) encoding: String,
+    pub(crate) encoding_module: Option<String>,
+}
 
 /// Configuration options for Protobuf code generation.
 ///
@@ -31,7 +39,7 @@ pub struct Config {
     pub(crate) file_descriptor_set_path: Option<PathBuf>,
     pub(crate) service_generator: Option<Box<dyn ServiceGenerator>>,
     pub(crate) map_type: PathMap<MapType>,
-    pub(crate) bytes_type: PathMap<BytesType>,
+    pub(crate) custom_type: HashMap<Type, PathMap<Rc<CustomTypeInfo>>>,
     pub(crate) type_attributes: PathMap<String>,
     pub(crate) message_attributes: PathMap<String>,
     pub(crate) enum_attributes: PathMap<String>,
@@ -176,10 +184,38 @@ impl Config {
         I: IntoIterator<Item = S>,
         S: AsRef<str>,
     {
-        self.bytes_type.clear();
+        self.custom_type.remove(&Type::Bytes);
+        self.custom_type(
+            Type::Bytes,
+            "{prost_path}::bytes::Bytes",
+            "BytesEncoding",
+            None,
+            paths,
+        )
+    }
+
+    fn custom_type<I, S, TS, ES>(
+        &mut self,
+        proto_type: Type,
+        user_type: TS,
+        encoding: ES,
+        encoding_module: Option<&str>,
+        paths: I,
+    ) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+        TS: AsRef<str>,
+        ES: AsRef<str>,
+    {
+        let info = Rc::new(CustomTypeInfo {
+            ty: user_type.as_ref().to_owned(),
+            encoding: encoding.as_ref().to_owned(),
+            encoding_module: encoding_module.map(ToOwned::to_owned),
+        });
+        let map = self.custom_type.entry(proto_type).or_default();
         for matcher in paths {
-            self.bytes_type
-                .insert(matcher.as_ref().to_string(), BytesType::Bytes);
+            map.insert(matcher.as_ref().to_string(), Rc::clone(&info));
         }
         self
     }
@@ -1197,7 +1233,7 @@ impl default::Default for Config {
             file_descriptor_set_path: None,
             service_generator: None,
             map_type: PathMap::default(),
-            bytes_type: PathMap::default(),
+            custom_type: HashMap::default(),
             type_attributes: PathMap::default(),
             message_attributes: PathMap::default(),
             enum_attributes: PathMap::default(),
@@ -1231,7 +1267,7 @@ impl fmt::Debug for Config {
             .field("file_descriptor_set_path", &self.file_descriptor_set_path)
             .field("service_generator", &self.service_generator.is_some())
             .field("map_type", &self.map_type)
-            .field("bytes_type", &self.bytes_type)
+            .field("custom_type", &self.custom_type)
             .field("type_attributes", &self.type_attributes)
             .field("field_attributes", &self.field_attributes)
             .field("prost_types", &self.prost_types)

--- a/prost-build/src/context.rs
+++ b/prost-build/src/context.rs
@@ -1,13 +1,13 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, rc::Rc};
 
 use prost_types::{
     field_descriptor_proto::{Label, Type},
     FieldDescriptorProto,
 };
 
-use crate::extern_paths::ExternPaths;
 use crate::message_graph::MessageGraph;
-use crate::{BytesType, Config, MapType, ServiceGenerator};
+use crate::{config::CustomTypeInfo, extern_paths::ExternPaths};
+use crate::{Config, MapType, ServiceGenerator};
 
 /// The context providing all the global information needed to generate code.
 /// It also provides a more disciplined access to Config
@@ -101,13 +101,17 @@ impl<'a> Context<'a> {
             .map(|s| s.as_str())
     }
 
-    /// Returns the bytes type configured for the named message field.
-    pub(crate) fn bytes_type(&self, fq_message_name: &str, field_name: &str) -> BytesType {
+    /// Returns the custom type configured for the named message field.
+    pub(crate) fn custom_type(
+        &self,
+        field_type: Type,
+        fq_message_name: &str,
+        field_name: &str,
+    ) -> Option<Rc<CustomTypeInfo>> {
         self.config
-            .bytes_type
-            .get_first_field(fq_message_name, field_name)
-            .copied()
-            .unwrap_or_default()
+            .custom_type
+            .get(&field_type)
+            .and_then(|m| m.get_first_field(fq_message_name, field_name).cloned())
     }
 
     /// Returns the map type configured for the named message field.

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -144,7 +144,7 @@ mod ast;
 pub use crate::ast::{Comments, Method, Service};
 
 mod collections;
-pub(crate) use collections::{BytesType, MapType};
+pub(crate) use collections::MapType;
 
 mod code_generator;
 mod context;

--- a/prost-build/src/path.rs
+++ b/prost-build/src/path.rs
@@ -3,11 +3,19 @@
 use std::iter;
 
 /// Maps a fully-qualified Protobuf path to a value using path matchers.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub(crate) struct PathMap<T> {
     // insertion order might actually matter (to avoid warning about legacy-derive-helpers)
     // see: https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#legacy-derive-helpers
     pub(crate) matchers: Vec<(String, T)>,
+}
+
+impl<T> Default for PathMap<T> {
+    fn default() -> Self {
+        Self {
+            matchers: Vec::default(),
+        }
+    }
 }
 
 impl<T> PathMap<T> {

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -4,7 +4,7 @@ use quote::quote;
 use syn::punctuated::Punctuated;
 use syn::{Expr, ExprLit, Ident, Lit, Meta, MetaNameValue, Path, Token};
 
-use crate::field::{scalar, set_option, tag_attr};
+use crate::field::{scalar, set_option, tag_attr, TyWithEncoding};
 
 #[derive(Clone, Debug)]
 pub enum MapTy {
@@ -39,7 +39,7 @@ impl MapTy {
 fn fake_scalar(ty: scalar::Ty) -> scalar::Field {
     let kind = scalar::Kind::Plain(scalar::DefaultValue::new(&ty));
     scalar::Field {
-        ty,
+        ty: TyWithEncoding::default_encoding(ty),
         kind,
         tag: 0, // Not used here
     }

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -4,7 +4,7 @@ use quote::quote;
 use syn::punctuated::Punctuated;
 use syn::{Expr, ExprLit, Ident, Lit, Meta, MetaNameValue, Path, Token};
 
-use crate::field::{scalar, set_option, tag_attr, TyWithEncoding};
+use crate::field::{ident_attr, path_attr, scalar, set_option, tag_attr, TyWithEncoding};
 
 #[derive(Clone, Debug)]
 pub enum MapTy {
@@ -57,6 +57,8 @@ impl Field {
     pub fn new(attrs: &[Meta], inferred_tag: Option<u32>) -> Result<Option<Field>, Error> {
         let mut types = None;
         let mut tag = None;
+        let mut value_encoding_ty = None;
+        let mut value_encoding_module = None;
 
         for attr in attrs {
             if let Some(t) = tag_attr(attr)? {
@@ -103,6 +105,18 @@ impl Field {
                     (map_ty, key_ty_from_str(&k)?, ValueTy::from_str(&v)?),
                     "duplicate map type attribute",
                 )?;
+            } else if let Some(ty) = ident_attr("value_encoding", attr)? {
+                set_option(
+                    &mut value_encoding_ty,
+                    ty,
+                    "duplicate value_encoding attributes",
+                )?;
+            } else if let Some(module) = path_attr("value_encoding_module", attr)? {
+                set_option(
+                    &mut value_encoding_module,
+                    module,
+                    "duplicate value_encoding_module attributes",
+                )?;
             } else {
                 return Ok(None);
             }
@@ -112,7 +126,11 @@ impl Field {
             (Some((map_ty, key_ty, value_ty)), Some(tag)) => Some(Field {
                 map_ty,
                 key_ty,
-                value_ty,
+                value_ty: value_ty.with_encoding(
+                    value_encoding_ty,
+                    value_encoding_module,
+                    "value",
+                )?,
                 tag,
             }),
             _ => None,
@@ -420,6 +438,48 @@ impl ValueTy {
             Ok(ValueTy::Message)
         } else {
             bail!("invalid map value type: {s}");
+        }
+    }
+
+    fn with_encoding(
+        self,
+        encoding_ty: Option<Ident>,
+        encoding_module: Option<syn::Path>,
+        prefix: &str,
+    ) -> Result<Self, Error> {
+        match self {
+            ValueTy::Scalar(ty) => {
+                if encoding_module.is_some() && encoding_ty.is_none() {
+                    bail!(
+                        "{prefix}_encoding_module attribute can only be applied in pair with {prefix}_encoding attribute"
+                    );
+                }
+
+                if encoding_ty.is_some() && !matches!(ty.ty, scalar::Ty::Bytes) {
+                    bail!("only the bytes type support the {prefix}_encoding attibute");
+                }
+
+                if encoding_ty.is_some() {
+                    Ok(ValueTy::Scalar(TyWithEncoding {
+                        ty: ty.ty,
+                        encoding_ty,
+                        encoding_module,
+                    }))
+                } else {
+                    Ok(ValueTy::Scalar(ty))
+                }
+            }
+            ValueTy::Message => {
+                if encoding_ty.is_some() {
+                    bail!("message value type does not support the {prefix}_encoding attribute");
+                }
+                if encoding_module.is_some() {
+                    bail!(
+                        "message value type does not support the {prefix}_encoding_module attribute"
+                    );
+                }
+                Ok(ValueTy::Message)
+            }
         }
     }
 

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -36,10 +36,10 @@ impl MapTy {
     }
 }
 
-fn fake_scalar(ty: scalar::Ty) -> scalar::Field {
-    let kind = scalar::Kind::Plain(scalar::DefaultValue::new(&ty));
+fn fake_scalar(ty: TyWithEncoding<scalar::Ty>) -> scalar::Field {
+    let kind = scalar::Kind::Plain(scalar::DefaultValue::new(&ty.ty));
     scalar::Field {
-        ty: TyWithEncoding::default_encoding(ty),
+        ty,
         kind,
         tag: 0, // Not used here
     }
@@ -131,7 +131,10 @@ impl Field {
         let kl = quote!(#prost_path::encoding::#key_mod::encoded_len);
         let module = self.map_ty.module();
         match &self.value_ty {
-            ValueTy::Scalar(scalar::Ty::Enumeration(ty)) => {
+            ValueTy::Scalar(TyWithEncoding {
+                ty: scalar::Ty::Enumeration(ty),
+                ..
+            }) => {
                 let default = quote!(#ty::default() as i32);
                 quote! {
                     #prost_path::encoding::#module::encode_with_default(
@@ -147,9 +150,19 @@ impl Field {
                 }
             }
             ValueTy::Scalar(value_ty) => {
-                let val_mod = value_ty.module();
-                let ve = quote!(#prost_path::encoding::#val_mod::encode);
-                let vl = quote!(#prost_path::encoding::#val_mod::encoded_len);
+                let (ve, vl) = match value_ty.encoding_ty(prost_path) {
+                    Some(encoding_ty) => (
+                        quote!(#encoding_ty::encode),
+                        quote!(#encoding_ty::encoded_len),
+                    ),
+                    None => {
+                        let val_mod = value_ty.ty.module();
+                        (
+                            quote!(#prost_path::encoding::#val_mod::encode),
+                            quote!(#prost_path::encoding::#val_mod::encoded_len),
+                        )
+                    }
+                };
                 quote! {
                     #prost_path::encoding::#module::encode(
                         #ke,
@@ -183,7 +196,10 @@ impl Field {
         let km = quote!(#prost_path::encoding::#key_mod::merge);
         let module = self.map_ty.module();
         match &self.value_ty {
-            ValueTy::Scalar(scalar::Ty::Enumeration(ty)) => {
+            ValueTy::Scalar(TyWithEncoding {
+                ty: scalar::Ty::Enumeration(ty),
+                ..
+            }) => {
                 let default = quote!(#ty::default() as i32);
                 quote! {
                     #prost_path::encoding::#module::merge_with_default(
@@ -197,8 +213,13 @@ impl Field {
                 }
             }
             ValueTy::Scalar(value_ty) => {
-                let val_mod = value_ty.module();
-                let vm = quote!(#prost_path::encoding::#val_mod::merge);
+                let vm = match value_ty.encoding_ty(prost_path) {
+                    Some(encoding_ty) => quote!(#encoding_ty::merge),
+                    None => {
+                        let val_mod = value_ty.ty.module();
+                        quote!(#prost_path::encoding::#val_mod::merge)
+                    }
+                };
                 quote!(#prost_path::encoding::#module::merge(#km, #vm, &mut #ident, buf, ctx))
             }
             ValueTy::Message => quote! {
@@ -220,7 +241,10 @@ impl Field {
         let kl = quote!(#prost_path::encoding::#key_mod::encoded_len);
         let module = self.map_ty.module();
         match &self.value_ty {
-            ValueTy::Scalar(scalar::Ty::Enumeration(ty)) => {
+            ValueTy::Scalar(TyWithEncoding {
+                ty: scalar::Ty::Enumeration(ty),
+                ..
+            }) => {
                 let default = quote!(#ty::default() as i32);
                 quote! {
                     #prost_path::encoding::#module::encoded_len_with_default(
@@ -233,8 +257,13 @@ impl Field {
                 }
             }
             ValueTy::Scalar(value_ty) => {
-                let val_mod = value_ty.module();
-                let vl = quote!(#prost_path::encoding::#val_mod::encoded_len);
+                let vl = match value_ty.encoding_ty(prost_path) {
+                    Some(encoding_ty) => quote!(#encoding_ty::encoded_len),
+                    None => {
+                        let val_mod = value_ty.ty.module();
+                        quote!(#prost_path::encoding::#val_mod::encoded_len)
+                    }
+                };
                 quote!(#prost_path::encoding::#module::encoded_len(#kl, #vl, #tag, &#ident))
             }
             ValueTy::Message => quote! {
@@ -254,7 +283,11 @@ impl Field {
 
     /// Returns methods to embed in the message.
     pub fn methods(&self, prost_path: &Path, ident: &TokenStream) -> Option<TokenStream> {
-        if let ValueTy::Scalar(scalar::Ty::Enumeration(ty)) = &self.value_ty {
+        if let ValueTy::Scalar(TyWithEncoding {
+            ty: scalar::Ty::Enumeration(ty),
+            ..
+        }) = &self.value_ty
+        {
             let key_ty = self.key_ty.rust_type(prost_path);
             let key_ref_ty = self.key_ty.rust_ref_type();
 
@@ -303,7 +336,8 @@ impl Field {
         };
 
         // A fake field for generating the debug wrapper
-        let key_wrapper = fake_scalar(self.key_ty.clone()).debug(prost_path, quote!(KeyWrapper));
+        let key_wrapper = fake_scalar(TyWithEncoding::default_encoding(self.key_ty.clone()))
+            .debug(prost_path, quote!(KeyWrapper));
         let key = self.key_ty.rust_type(prost_path);
         let value_wrapper = self.value_ty.debug(prost_path);
         let libname = self.map_ty.lib();
@@ -319,7 +353,7 @@ impl Field {
             }
         };
         match &self.value_ty {
-            ValueTy::Scalar(ty) => {
+            ValueTy::Scalar(TyWithEncoding { ty, .. }) => {
                 if let scalar::Ty::Bytes(_) = *ty {
                     return quote! {
                         struct #wrapper_name<'a>(&'a dyn ::core::fmt::Debug);
@@ -372,16 +406,16 @@ fn key_ty_from_str(s: &str) -> Result<scalar::Ty, Error> {
 }
 
 /// A map value type.
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 pub enum ValueTy {
-    Scalar(scalar::Ty),
+    Scalar(TyWithEncoding<scalar::Ty>),
     Message,
 }
 
 impl ValueTy {
     fn from_str(s: &str) -> Result<ValueTy, Error> {
         if let Ok(ty) = scalar::Ty::from_str(s) {
-            Ok(ValueTy::Scalar(ty))
+            Ok(ValueTy::Scalar(TyWithEncoding::try_from(ty, None, None)?))
         } else if s.trim() == "message" {
             Ok(ValueTy::Message)
         } else {

--- a/prost-derive/src/field/map.rs
+++ b/prost-derive/src/field/map.rs
@@ -353,8 +353,8 @@ impl Field {
             }
         };
         match &self.value_ty {
-            ValueTy::Scalar(TyWithEncoding { ty, .. }) => {
-                if let scalar::Ty::Bytes(_) = *ty {
+            ValueTy::Scalar(ty) => {
+                if let scalar::Ty::Bytes = &ty.ty {
                     return quote! {
                         struct #wrapper_name<'a>(&'a dyn ::core::fmt::Debug);
                         impl<'a> ::core::fmt::Debug for #wrapper_name<'a> {
@@ -365,7 +365,7 @@ impl Field {
                     };
                 }
 
-                let value = ty.rust_type(prost_path);
+                let value = ty.owned_type(prost_path);
                 quote! {
                     struct #wrapper_name<'a>(&'a ::#libname::collections::#type_name<#key, #value>);
                     impl<'a> ::core::fmt::Debug for #wrapper_name<'a> {

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -9,6 +9,7 @@ use std::slice;
 
 use anyhow::{bail, Error};
 use proc_macro2::Ident;
+use proc_macro2::Span;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::punctuated::Punctuated;
@@ -353,6 +354,44 @@ fn tags_attr(attr: &Meta) -> Result<Option<Vec<u32>>, Error> {
             .collect::<Result<Vec<u32>, _>>()
             .map(Some),
         _ => bail!("invalid tag attribute: {attr:?}"),
+    }
+}
+
+fn ident_attr(key: &str, attr: &Meta) -> Result<Option<Ident>, Error> {
+    if !attr.path().is_ident(key) {
+        return Ok(None);
+    }
+
+    match *attr {
+        Meta::NameValue(MetaNameValue {
+            value:
+                Expr::Lit(ExprLit {
+                    lit: Lit::Str(ref lit),
+                    ..
+                }),
+            ..
+        }) => Ok(Some(Ident::new(lit.value().as_str(), Span::call_site()))),
+        _ => bail!("invalid {key} attribute"),
+    }
+}
+
+fn path_attr(key: &str, attr: &Meta) -> Result<Option<syn::Path>, Error> {
+    if !attr.path().is_ident(key) {
+        return Ok(None);
+    }
+    match *attr {
+        Meta::NameValue(MetaNameValue {
+            value:
+                Expr::Lit(ExprLit {
+                    lit: Lit::Str(ref lit),
+                    ..
+                }),
+            ..
+        }) => match lit.parse() {
+            Ok(expr) => Ok(Some(expr)),
+            Err(err) => bail!("invalid {key} attribute: {err}"),
+        },
+        _ => bail!("invalid {key} attribute"),
     }
 }
 

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -8,6 +8,7 @@ use std::fmt;
 use std::slice;
 
 use anyhow::{bail, Error};
+use proc_macro2::Ident;
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::punctuated::Punctuated;
@@ -352,5 +353,25 @@ fn tags_attr(attr: &Meta) -> Result<Option<Vec<u32>>, Error> {
             .collect::<Result<Vec<u32>, _>>()
             .map(Some),
         _ => bail!("invalid tag attribute: {attr:?}"),
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct TyWithEncoding<T> {
+    // The underlying type
+    ty: T,
+    // The encoding type
+    encoding_ty: Option<Ident>,
+    // The encoding module: this allows for encoding defined outside of `prost::encoding`
+    encoding_module: Option<syn::Path>,
+}
+
+impl<T> TyWithEncoding<T> {
+    pub fn encoding_ty(&self, prost_path: &Path) -> Option<TokenStream> {
+        match (self.encoding_ty.as_ref(), self.encoding_module.as_ref()) {
+            (Some(ty), Some(module)) => Some(quote!(#module::#ty)),
+            (Some(ty), None) => Some(quote!(#prost_path::encoding::#ty)),
+            (None, _) => None,
+        }
     }
 }

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -22,12 +22,21 @@ impl Field {
         let mut packed = None;
         let mut default = None;
         let mut tag = None;
+        let mut encoding_ty = None;
+        let mut encoding_module = None;
 
         let mut unknown_attrs = Vec::new();
 
         for attr in attrs {
             if let Some(t) = Ty::from_attr(attr)? {
                 set_option(&mut ty, t, "duplicate type attributes")?;
+            } else if let Some((t, encoding)) = legacy_bytes_attr(attr)? {
+                if let Some(existing) = ty.as_ref() {
+                    bail!("duplicate type attributes: {existing:?} and {t:?}");
+                }
+                ty = Some(t);
+                encoding_ty = Some(encoding);
+                encoding_module = Some(None);
             } else if let Some(p) = bool_attr("packed", attr)? {
                 set_option(&mut packed, p, "duplicate packed attributes")?;
             } else if let Some(t) = tag_attr(attr)? {
@@ -87,7 +96,7 @@ impl Field {
         };
 
         Ok(Some(Field {
-            ty: TyWithEncoding::try_from(ty, None, None)?,
+            ty: TyWithEncoding::try_from(ty, encoding_ty, encoding_module.flatten())?,
             kind,
             tag,
         }))
@@ -213,7 +222,7 @@ impl Field {
             Kind::Plain(ref default) | Kind::Required(ref default) => {
                 let default = default.typed();
                 match self.ty.ty {
-                    Ty::String | Ty::Bytes(..) => quote!(#ident.clear()),
+                    Ty::String | Ty::Bytes => quote!(#ident.clear()),
                     _ => quote!(#ident = #default),
                 }
             }
@@ -257,7 +266,7 @@ impl Field {
     /// Returns a fragment for formatting the field `ident` in `Debug`.
     pub fn debug(&self, prost_path: &Path, wrapper_name: TokenStream) -> TokenStream {
         let wrapper = self.debug_inner(quote!(Inner));
-        let inner_ty = self.ty.ty.rust_type(prost_path);
+        let inner_ty = self.ty.owned_type(prost_path);
         match self.kind {
             Kind::Plain(_) | Kind::Required(_) => self.debug_inner(wrapper_name),
             Kind::Optional(_) => quote! {
@@ -413,30 +422,32 @@ pub enum Ty {
     Sfixed64,
     Bool,
     String,
-    Bytes(BytesTy),
+    Bytes,
     Enumeration(Path),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub enum BytesTy {
-    Vec,
-    Bytes,
-}
-
-impl BytesTy {
-    fn try_from_str(s: &str) -> Result<Self, Error> {
-        match s {
-            "vec" => Ok(BytesTy::Vec),
-            "bytes" => Ok(BytesTy::Bytes),
-            _ => bail!("Invalid bytes type: {s}"),
-        }
-    }
-
-    fn rust_type(&self, prost_path: &Path) -> TokenStream {
-        match self {
-            BytesTy::Vec => quote! { #prost_path::alloc::vec::Vec<u8> },
-            BytesTy::Bytes => quote! { #prost_path::bytes::Bytes },
-        }
+fn legacy_bytes_attr(attr: &Meta) -> Result<Option<(Ty, Ident)>, Error> {
+    match *attr {
+        Meta::NameValue(MetaNameValue {
+            ref path,
+            value:
+                Expr::Lit(ExprLit {
+                    lit: Lit::Str(ref l),
+                    ..
+                }),
+            ..
+        }) if path.is_ident("bytes") => match l.value().as_str() {
+            "vec" => Ok(Some((
+                Ty::Bytes,
+                Ident::new("VecU8Encoding", Span::call_site()),
+            ))),
+            "bytes" => Ok(Some((
+                Ty::Bytes,
+                Ident::new("BytesEncoding", Span::call_site()),
+            ))),
+            s => bail!("Invalid bytes type: {s}"),
+        },
+        _ => Ok(None),
     }
 }
 
@@ -457,16 +468,7 @@ impl Ty {
             Meta::Path(ref name) if name.is_ident("sfixed64") => Ty::Sfixed64,
             Meta::Path(ref name) if name.is_ident("bool") => Ty::Bool,
             Meta::Path(ref name) if name.is_ident("string") => Ty::String,
-            Meta::Path(ref name) if name.is_ident("bytes") => Ty::Bytes(BytesTy::Vec),
-            Meta::NameValue(MetaNameValue {
-                ref path,
-                value:
-                    Expr::Lit(ExprLit {
-                        lit: Lit::Str(ref l),
-                        ..
-                    }),
-                ..
-            }) if path.is_ident("bytes") => Ty::Bytes(BytesTy::try_from_str(&l.value())?),
+            Meta::Path(ref name) if name.is_ident("bytes") => Ty::Bytes,
             Meta::NameValue(MetaNameValue {
                 ref path,
                 value:
@@ -502,7 +504,7 @@ impl Ty {
             "sfixed64" => Ty::Sfixed64,
             "bool" => Ty::Bool,
             "string" => Ty::String,
-            "bytes" => Ty::Bytes(BytesTy::Vec),
+            "bytes" => Ty::Bytes,
             s if s.len() > enumeration_len && &s[..enumeration_len] == "enumeration" => {
                 let s = &s[enumeration_len..].trim();
                 match s.chars().next() {
@@ -538,16 +540,16 @@ impl Ty {
             Ty::Sfixed64 => "sfixed64",
             Ty::Bool => "bool",
             Ty::String => "string",
-            Ty::Bytes(..) => "bytes",
+            Ty::Bytes => "bytes",
             Ty::Enumeration(..) => "enum",
         }
     }
 
-    // TODO: rename to 'owned_type'.
+    // TODO: remove (still use for map.rs keys)
     pub fn rust_type(&self, prost_path: &Path) -> TokenStream {
         match self {
             Ty::String => quote!(#prost_path::alloc::string::String),
-            Ty::Bytes(ty) => ty.rust_type(prost_path),
+            Ty::Bytes => quote!(#prost_path::alloc::vec::Vec),
             _ => self.rust_ref_type(),
         }
     }
@@ -569,7 +571,7 @@ impl Ty {
             Ty::Sfixed64 => quote!(i64),
             Ty::Bool => quote!(bool),
             Ty::String => quote!(&str),
-            Ty::Bytes(..) => quote!(&[u8]),
+            Ty::Bytes => quote!(&[u8]),
             Ty::Enumeration(..) => quote!(i32),
         }
     }
@@ -583,7 +585,7 @@ impl Ty {
 
     /// Returns false if the scalar type is length delimited (i.e., `string` or `bytes`).
     pub fn is_numeric(&self) -> bool {
-        !matches!(self, Ty::String | Ty::Bytes(..))
+        !matches!(self, Ty::String | Ty::Bytes)
     }
 }
 
@@ -620,8 +622,11 @@ impl TyWithEncoding<Ty> {
         encoding_ty: Option<Ident>,
         encoding_module: Option<Path>,
     ) -> Result<Self, Error> {
-        if encoding_module.is_some() || encoding_ty.is_some() {
-            bail!("not implemented yet");
+        if encoding_module.is_some() {
+            bail!("not supported yet");
+        }
+        if encoding_ty.is_some() && !matches!(ty, Ty::Bytes) {
+            bail!("only the bytes type support the encoding attibute");
         }
 
         if encoding_ty.is_none() {
@@ -636,10 +641,48 @@ impl TyWithEncoding<Ty> {
     }
 
     pub fn default_encoding(ty: Ty) -> Self {
+        let encoding_ty = match ty {
+            Ty::Bytes => Some(Ident::new("VecU8Encoding", Span::call_site())),
+            _ => None,
+        };
+
         Self {
             ty,
-            encoding_ty: None,
+            encoding_ty,
             encoding_module: None,
+        }
+    }
+
+    pub fn owned_type(&self, prost_path: &Path) -> TokenStream {
+        match (self.encoding_ty.as_ref(), self.encoding_module.as_ref()) {
+            (None, _) | (Some(_), None) => {
+                // for types with encoding in our control, we use direct type
+                // to make the generated code simpler and hopefully faster to compile
+                match self.ty {
+                    Ty::Bytes => {
+                        if self
+                            .encoding_ty
+                            .as_ref()
+                            .is_none_or(|ty| ty == "VecU8Encoding")
+                        {
+                            quote! ( #prost_path::alloc::vec::Vec<u8> )
+                        } else {
+                            assert!(self
+                                .encoding_ty
+                                .as_ref()
+                                .is_some_and(|ty| ty == "BytesEncoding"));
+                            quote! ( #prost_path::bytes::Bytes )
+                        }
+                    }
+                    _ => match self.ty {
+                        Ty::String => quote!(#prost_path::alloc::string::String),
+                        _ => self.ty.rust_ref_type(),
+                    },
+                }
+            }
+            (Some(ty), Some(module)) => {
+                quote!(<#module::#ty as #prost_path::encoding::Encoding>::Type)
+            }
         }
     }
 }
@@ -710,11 +753,7 @@ impl DefaultValue {
 
             Lit::Bool(ref lit) if *ty == Ty::Bool => DefaultValue::Bool(lit.value),
             Lit::Str(ref lit) if *ty == Ty::String => DefaultValue::String(lit.value()),
-            Lit::ByteStr(ref lit)
-                if *ty == Ty::Bytes(BytesTy::Bytes) || *ty == Ty::Bytes(BytesTy::Vec) =>
-            {
-                DefaultValue::Bytes(lit.value())
-            }
+            Lit::ByteStr(ref lit) if *ty == Ty::Bytes => DefaultValue::Bytes(lit.value()),
 
             Lit::Str(ref lit) => {
                 let value = lit.value();
@@ -819,7 +858,7 @@ impl DefaultValue {
 
             Ty::Bool => DefaultValue::Bool(false),
             Ty::String => DefaultValue::String(String::new()),
-            Ty::Bytes(..) => DefaultValue::Bytes(Vec::new()),
+            Ty::Bytes => DefaultValue::Bytes(Vec::new()),
             Ty::Enumeration(ref path) => DefaultValue::Enumeration(quote!(#path::default())),
         }
     }

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -5,7 +5,7 @@ use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{parse_str, Expr, ExprLit, Ident, Index, Lit, LitByteStr, Meta, MetaNameValue, Path};
 
-use crate::field::{bool_attr, set_option, tag_attr, Label, TyWithEncoding};
+use crate::field::{bool_attr, ident_attr, path_attr, set_option, tag_attr, Label, TyWithEncoding};
 
 /// A scalar protobuf field.
 #[derive(Clone)]
@@ -34,6 +34,9 @@ impl Field {
                 if let Some(existing) = ty.as_ref() {
                     bail!("duplicate type attributes: {existing:?} and {t:?}");
                 }
+                if encoding_ty.is_some() || encoding_module.is_some() {
+                    bail!("legacy bytes notation can not be used with 'encoding' and 'encoding_module' attributes");
+                }
                 ty = Some(t);
                 encoding_ty = Some(encoding);
                 encoding_module = Some(None);
@@ -45,6 +48,14 @@ impl Field {
                 set_option(&mut label, l, "duplicate label attributes")?;
             } else if let Some(d) = DefaultValue::from_attr(attr)? {
                 set_option(&mut default, d, "duplicate default attributes")?;
+            } else if let Some(ty) = ident_attr("encoding", attr)? {
+                set_option(&mut encoding_ty, ty, "duplicate encoding attributes")?;
+            } else if let Some(module) = path_attr("encoding_module", attr)? {
+                set_option(
+                    &mut encoding_module,
+                    Some(module),
+                    "duplicate encoding_module attributes",
+                )?;
             } else {
                 unknown_attrs.push(attr);
             }
@@ -622,8 +633,8 @@ impl TyWithEncoding<Ty> {
         encoding_ty: Option<Ident>,
         encoding_module: Option<Path>,
     ) -> Result<Self, Error> {
-        if encoding_module.is_some() {
-            bail!("not supported yet");
+        if encoding_module.is_some() && encoding_ty.is_none() {
+            bail!("encoding_module attribute can only be applied in pair with encoding attribute");
         }
         if encoding_ty.is_some() && !matches!(ty, Ty::Bytes) {
             bail!("only the bytes type support the encoding attibute");

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -110,13 +110,18 @@ impl Field {
     }
 
     pub fn encode(&self, prost_path: &Path, ident: TokenStream) -> TokenStream {
-        let module = self.ty.ty.module();
         let encode_fn = match self.kind {
             Kind::Plain(..) | Kind::Optional(..) | Kind::Required(..) => quote!(encode),
             Kind::Repeated => quote!(encode_repeated),
             Kind::Packed => quote!(encode_packed),
         };
-        let encode_fn = quote!(#prost_path::encoding::#module::#encode_fn);
+        let encode_fn = match self.ty.encoding_ty(prost_path) {
+            Some(encoding_ty) => quote!(#encoding_ty::#encode_fn),
+            None => {
+                let module = self.ty.ty.module();
+                quote!(#prost_path::encoding::#module::#encode_fn)
+            }
+        };
         let tag = self.tag;
 
         match self.kind {
@@ -142,12 +147,17 @@ impl Field {
     /// Returns an expression which evaluates to the result of merging a decoded
     /// scalar value into the field.
     pub fn merge(&self, prost_path: &Path, ident: TokenStream) -> TokenStream {
-        let module = self.ty.ty.module();
         let merge_fn = match self.kind {
             Kind::Plain(..) | Kind::Optional(..) | Kind::Required(..) => quote!(merge),
             Kind::Repeated | Kind::Packed => quote!(merge_repeated),
         };
-        let merge_fn = quote!(#prost_path::encoding::#module::#merge_fn);
+        let merge_fn = match self.ty.encoding_ty(prost_path) {
+            Some(encoding_ty) => quote!(#encoding_ty::#merge_fn),
+            None => {
+                let module = self.ty.ty.module();
+                quote!(#prost_path::encoding::#module::#merge_fn)
+            }
+        };
 
         match self.kind {
             Kind::Plain(..) | Kind::Required(..) | Kind::Repeated | Kind::Packed => quote! {
@@ -164,13 +174,18 @@ impl Field {
 
     /// Returns an expression which evaluates to the encoded length of the field.
     pub fn encoded_len(&self, prost_path: &Path, ident: TokenStream) -> TokenStream {
-        let module = self.ty.ty.module();
         let encoded_len_fn = match self.kind {
             Kind::Plain(..) | Kind::Optional(..) | Kind::Required(..) => quote!(encoded_len),
             Kind::Repeated => quote!(encoded_len_repeated),
             Kind::Packed => quote!(encoded_len_packed),
         };
-        let encoded_len_fn = quote!(#prost_path::encoding::#module::#encoded_len_fn);
+        let encoded_len_fn = match self.ty.encoding_ty(prost_path) {
+            Some(encoding_ty) => quote!(#encoding_ty::#encoded_len_fn),
+            None => {
+                let module = self.ty.ty.module();
+                quote!(#prost_path::encoding::#module::#encoded_len_fn)
+            }
+        };
         let tag = self.tag;
 
         match self.kind {

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -5,12 +5,12 @@ use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens, TokenStreamExt};
 use syn::{parse_str, Expr, ExprLit, Ident, Index, Lit, LitByteStr, Meta, MetaNameValue, Path};
 
-use crate::field::{bool_attr, set_option, tag_attr, Label};
+use crate::field::{bool_attr, set_option, tag_attr, Label, TyWithEncoding};
 
 /// A scalar protobuf field.
 #[derive(Clone)]
 pub struct Field {
-    pub ty: Ty,
+    pub ty: TyWithEncoding<Ty>,
     pub kind: Kind,
     pub tag: u32,
 }
@@ -86,7 +86,11 @@ impl Field {
             (Some(Label::Repeated), _, false) => Kind::Repeated,
         };
 
-        Ok(Some(Field { ty, kind, tag }))
+        Ok(Some(Field {
+            ty: TyWithEncoding::try_from(ty, None, None)?,
+            kind,
+            tag,
+        }))
     }
 
     pub fn new_oneof(attrs: &[Meta]) -> Result<Option<Field>, Error> {
@@ -106,7 +110,7 @@ impl Field {
     }
 
     pub fn encode(&self, prost_path: &Path, ident: TokenStream) -> TokenStream {
-        let module = self.ty.module();
+        let module = self.ty.ty.module();
         let encode_fn = match self.kind {
             Kind::Plain(..) | Kind::Optional(..) | Kind::Required(..) => quote!(encode),
             Kind::Repeated => quote!(encode_repeated),
@@ -138,7 +142,7 @@ impl Field {
     /// Returns an expression which evaluates to the result of merging a decoded
     /// scalar value into the field.
     pub fn merge(&self, prost_path: &Path, ident: TokenStream) -> TokenStream {
-        let module = self.ty.module();
+        let module = self.ty.ty.module();
         let merge_fn = match self.kind {
             Kind::Plain(..) | Kind::Optional(..) | Kind::Required(..) => quote!(merge),
             Kind::Repeated | Kind::Packed => quote!(merge_repeated),
@@ -160,7 +164,7 @@ impl Field {
 
     /// Returns an expression which evaluates to the encoded length of the field.
     pub fn encoded_len(&self, prost_path: &Path, ident: TokenStream) -> TokenStream {
-        let module = self.ty.module();
+        let module = self.ty.ty.module();
         let encoded_len_fn = match self.kind {
             Kind::Plain(..) | Kind::Optional(..) | Kind::Required(..) => quote!(encoded_len),
             Kind::Repeated => quote!(encoded_len_repeated),
@@ -193,7 +197,7 @@ impl Field {
         match self.kind {
             Kind::Plain(ref default) | Kind::Required(ref default) => {
                 let default = default.typed();
-                match self.ty {
+                match self.ty.ty {
                     Ty::String | Ty::Bytes(..) => quote!(#ident.clear()),
                     _ => quote!(#ident = #default),
                 }
@@ -214,7 +218,7 @@ impl Field {
 
     /// An inner debug wrapper, around the base type.
     fn debug_inner(&self, wrap_name: TokenStream) -> TokenStream {
-        if let Ty::Enumeration(ref ty) = self.ty {
+        if let Ty::Enumeration(ref ty) = self.ty.ty {
             quote! {
                 struct #wrap_name<'a>(&'a i32);
                 impl<'a> ::core::fmt::Debug for #wrap_name<'a> {
@@ -238,7 +242,7 @@ impl Field {
     /// Returns a fragment for formatting the field `ident` in `Debug`.
     pub fn debug(&self, prost_path: &Path, wrapper_name: TokenStream) -> TokenStream {
         let wrapper = self.debug_inner(quote!(Inner));
-        let inner_ty = self.ty.rust_type(prost_path);
+        let inner_ty = self.ty.ty.rust_type(prost_path);
         match self.kind {
             Kind::Plain(_) | Kind::Required(_) => self.debug_inner(wrapper_name),
             Kind::Optional(_) => quote! {
@@ -284,7 +288,7 @@ impl Field {
             Err(_) => quote!(#ident),
         };
 
-        if let Ty::Enumeration(ref ty) = self.ty {
+        if let Ty::Enumeration(ref ty) = self.ty.ty {
             let set = Ident::new(&format!("set_{ident_str}"), Span::call_site());
             let set_doc = format!("Sets `{ident_str}` to the provided enum value.");
             Some(match self.kind {
@@ -350,9 +354,9 @@ impl Field {
                 }
             })
         } else if let Kind::Optional(ref default) = self.kind {
-            let ty = self.ty.rust_ref_type();
+            let ty = self.ty.ty.rust_ref_type();
 
-            let match_some = if self.ty.is_numeric() {
+            let match_some = if self.ty.ty.is_numeric() {
                 quote!(::core::option::Option::Some(val) => val,)
             } else {
                 quote!(::core::option::Option::Some(ref val) => &val[..],)
@@ -593,6 +597,36 @@ pub enum Kind {
     Repeated,
     /// A packed repeated scalar field.
     Packed,
+}
+
+impl TyWithEncoding<Ty> {
+    pub fn try_from(
+        ty: Ty,
+        encoding_ty: Option<Ident>,
+        encoding_module: Option<Path>,
+    ) -> Result<Self, Error> {
+        if encoding_module.is_some() || encoding_ty.is_some() {
+            bail!("not implemented yet");
+        }
+
+        if encoding_ty.is_none() {
+            Ok(Self::default_encoding(ty))
+        } else {
+            Ok(Self {
+                ty,
+                encoding_ty,
+                encoding_module,
+            })
+        }
+    }
+
+    pub fn default_encoding(ty: Ty) -> Self {
+        Self {
+            ty,
+            encoding_ty: None,
+            encoding_module: None,
+        }
+    }
 }
 
 /// Scalar Protobuf field default value.

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -173,6 +173,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
         impl #impl_generics #prost_path::Message for #ident #ty_generics #where_clause {
             #[allow(unused_variables)]
             fn encode_raw(&self, buf: &mut impl #prost_path::bytes::BufMut) {
+                use #prost_path::encoding::Encoding as _;
                 #(#encode)*
             }
 
@@ -185,6 +186,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
                 ctx: #prost_path::encoding::DecodeContext,
             ) -> ::core::result::Result<(), #prost_path::DecodeError>
             {
+                use #prost_path::encoding::Encoding as _;
                 #struct_name
                 match tag {
                     #(#merge)*
@@ -194,6 +196,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
 
             #[inline]
             fn encoded_len(&self) -> usize {
+                use #prost_path::encoding::Encoding as _;
                 0 #(+ #encoded_len)*
             }
 
@@ -463,6 +466,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
         impl #impl_generics #ident #ty_generics #where_clause {
             /// Encodes the message to a buffer.
             pub fn encode(&self, buf: &mut impl #prost_path::bytes::BufMut) {
+                use #prost_path::encoding::Encoding as _;
                 match *self {
                     #(#encode,)*
                 }
@@ -477,6 +481,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
                 ctx: #prost_path::encoding::DecodeContext,
             ) -> ::core::result::Result<(), #prost_path::DecodeError>
             {
+                use #prost_path::encoding::Encoding as _;
                 match tag {
                     #(#merge,)*
                     _ => unreachable!(concat!("invalid ", stringify!(#ident), " tag: {}"), tag),
@@ -486,6 +491,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
             /// Returns the encoded length of the message without a length delimiter.
             #[inline]
             pub fn encoded_len(&self) -> usize {
+                use #prost_path::encoding::Encoding as _;
                 match *self {
                     #(#encoded_len,)*
                 }

--- a/prost-types/src/protobuf.rs
+++ b/prost-types/src/protobuf.rs
@@ -977,7 +977,7 @@ pub struct UninterpretedOption {
     pub negative_int_value: ::core::option::Option<i64>,
     #[prost(double, optional, tag = "6")]
     pub double_value: ::core::option::Option<f64>,
-    #[prost(bytes = "vec", optional, tag = "7")]
+    #[prost(bytes, optional, tag = "7")]
     pub string_value: ::core::option::Option<::prost::alloc::vec::Vec<u8>>,
     #[prost(string, optional, tag = "8")]
     pub aggregate_value: ::core::option::Option<::prost::alloc::string::String>,
@@ -1304,7 +1304,7 @@ pub struct Any {
     #[prost(string, tag = "1")]
     pub type_url: ::prost::alloc::string::String,
     /// Must be a valid serialized protocol buffer of the above specified type.
-    #[prost(bytes = "vec", tag = "2")]
+    #[prost(bytes, tag = "2")]
     pub value: ::prost::alloc::vec::Vec<u8>,
 }
 /// `SourceContext` represents information about the source of a

--- a/prost/src/encoding.rs
+++ b/prost/src/encoding.rs
@@ -100,6 +100,41 @@ impl DecodeContext {
 pub const MIN_TAG: u32 = 1;
 pub const MAX_TAG: u32 = (1 << 29) - 1;
 
+pub trait Encoding {
+    type Type: Default;
+
+    fn encoded_len(tag: u32, value: &Self::Type) -> usize;
+    fn encode(tag: u32, value: &Self::Type, buf: &mut impl BufMut);
+    fn merge<B: Buf>(
+        wire_type: WireType,
+        value: &mut Self::Type,
+        buf: &mut B,
+        _ctx: DecodeContext,
+    ) -> Result<(), DecodeError>;
+
+    #[inline]
+    fn encoded_len_repeated(tag: u32, values: &[Self::Type]) -> usize {
+        values.iter().map(|v| Self::encoded_len(tag, v)).sum()
+    }
+    fn encode_repeated(tag: u32, values: &[Self::Type], buf: &mut impl BufMut) {
+        for value in values {
+            Self::encode(tag, value, buf);
+        }
+    }
+    fn merge_repeated<B: Buf>(
+        wire_type: WireType,
+        values: &mut Vec<Self::Type>,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError> {
+        check_wire_type(WireType::LengthDelimited, wire_type)?;
+        let mut value = Self::Type::default();
+        Self::merge(wire_type, &mut value, buf, ctx)?;
+        values.push(value);
+        Ok(())
+    }
+}
+
 /// Encodes a Protobuf field key, which consists of a wire type designator and
 /// the field tag.
 #[inline]

--- a/prost/src/encoding.rs
+++ b/prost/src/encoding.rs
@@ -817,6 +817,57 @@ pub mod bytes {
     }
 }
 
+pub struct VecU8Encoding;
+pub struct BytesEncoding;
+
+impl Encoding for VecU8Encoding {
+    type Type = Vec<u8>;
+
+    #[inline]
+    fn encoded_len(tag: u32, value: &Self::Type) -> usize {
+        bytes::encoded_len(tag, value)
+    }
+
+    #[inline]
+    fn encode(tag: u32, value: &Self::Type, buf: &mut impl BufMut) {
+        bytes::encode(tag, value, buf);
+    }
+
+    #[inline]
+    fn merge<B: Buf>(
+        wire_type: WireType,
+        value: &mut Self::Type,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError> {
+        bytes::merge_one_copy(wire_type, value, buf, ctx)
+    }
+}
+
+impl Encoding for BytesEncoding {
+    type Type = Bytes;
+
+    #[inline]
+    fn encoded_len(tag: u32, value: &Self::Type) -> usize {
+        bytes::encoded_len(tag, value)
+    }
+
+    #[inline]
+    fn encode(tag: u32, value: &Self::Type, buf: &mut impl BufMut) {
+        bytes::encode(tag, value, buf);
+    }
+
+    #[inline]
+    fn merge<B: Buf>(
+        wire_type: WireType,
+        value: &mut Self::Type,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError> {
+        bytes::merge(wire_type, value, buf, ctx)
+    }
+}
+
 pub mod message {
     use super::*;
 

--- a/tests/src/bytes.rs
+++ b/tests/src/bytes.rs
@@ -1,0 +1,130 @@
+use alloc::collections::BTreeMap;
+use alloc::vec::Vec;
+
+use prost::bytes::Bytes;
+use prost::encoding::wire_type::WireType;
+use prost::encoding::DecodeContext;
+
+#[derive(Clone, prost::Message)]
+struct MessageWithBytes {
+    #[prost(bytes = "vec", tag = "1")]
+    legacy_vec: Vec<u8>,
+    #[prost(bytes = "vec", optional, tag = "2")]
+    legacy_opt_vec: Option<Vec<u8>>,
+    #[prost(bytes = "vec", repeated, tag = "3")]
+    legacy_rep_vec: Vec<Vec<u8>>,
+
+    #[prost(bytes = "bytes", tag = "4")]
+    legacy_bytes: Bytes,
+    #[prost(bytes = "bytes", optional, tag = "5")]
+    legacy_opt_bytes: Option<Bytes>,
+    #[prost(bytes = "bytes", repeated, tag = "6")]
+    legacy_rep_bytes: Vec<Bytes>,
+
+    #[prost(bytes, tag = "11")]
+    vec_default: Vec<u8>,
+    #[prost(bytes, optional, tag = "12")]
+    opt_vec_default: Option<Vec<u8>>,
+    #[prost(bytes, repeated, tag = "13")]
+    rep_vec_default: Vec<Vec<u8>>,
+
+    #[prost(bytes, encoding = "VecU8Encoding", tag = "14")]
+    vec: Vec<u8>,
+    #[prost(bytes, encoding = "VecU8Encoding", optional, tag = "15")]
+    opt_vec: Option<Vec<u8>>,
+    #[prost(bytes, encoding = "VecU8Encoding", repeated, tag = "16")]
+    rep_vec: Vec<Vec<u8>>,
+
+    #[prost(bytes, encoding = "BytesEncoding", tag = "17")]
+    bytes: Bytes,
+    #[prost(bytes, encoding = "BytesEncoding", optional, tag = "18")]
+    opt_bytes: Option<Bytes>,
+    #[prost(bytes, encoding = "BytesEncoding", repeated, tag = "19")]
+    rep_bytes: Vec<Bytes>,
+
+    #[prost(btree_map = "uint32, bytes", tag = "21")]
+    map_vec_default: BTreeMap<u32, Vec<u8>>,
+    #[prost(
+        btree_map = "uint32, bytes",
+        value_encoding = "VecU8Encoding",
+        tag = "22"
+    )]
+    map_vec: BTreeMap<u32, Vec<u8>>,
+    #[prost(
+        btree_map = "uint32, bytes",
+        value_encoding = "BytesEncoding",
+        tag = "23"
+    )]
+    map_bytes: BTreeMap<u32, Bytes>,
+
+    #[prost(
+        bytes,
+        encoding = "MyBytesEncoding",
+        encoding_module = "self",
+        tag = "31"
+    )]
+    my_bytes: MyBytes,
+    #[prost(
+        bytes,
+        encoding = "MyBytesEncoding",
+        encoding_module = "self",
+        optional,
+        tag = "32"
+    )]
+    opt_my_bytes: Option<MyBytes>,
+    #[prost(
+        bytes,
+        encoding = "MyBytesEncoding",
+        encoding_module = "crate::bytes",
+        repeated,
+        tag = "33"
+    )]
+    rep_my_bytes: Vec<MyBytes>,
+}
+
+#[derive(Default, Clone, Debug, PartialEq, Eq)]
+struct MyBytes(Vec<u8>);
+
+impl core::ops::Deref for MyBytes {
+    type Target = [u8];
+    fn deref(&self) -> &Self::Target {
+        self.0.as_slice()
+    }
+}
+
+impl MyBytes {
+    fn clear(&mut self) {
+        self.0.clear();
+    }
+}
+
+impl PartialEq<&[u8]> for MyBytes {
+    fn eq(&self, other: &&[u8]) -> bool {
+        self.0.as_slice() == *other
+    }
+}
+
+struct MyBytesEncoding;
+
+impl prost::encoding::Encoding for MyBytesEncoding {
+    type Type = MyBytes;
+
+    fn encoded_len(tag: u32, value: &Self::Type) -> usize {
+        prost::encoding::bytes::encoded_len(tag, &value.0)
+    }
+
+    fn encode(tag: u32, value: &Self::Type, buf: &mut impl prost::bytes::BufMut) {
+        prost::encoding::bytes::encode(tag, &value.0, buf);
+    }
+
+    fn merge<B: prost::bytes::Buf>(
+        wire_type: WireType,
+        value: &mut Self::Type,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), prost::DecodeError> {
+        prost::encoding::bytes::merge(wire_type, &mut value.0, buf, ctx)
+    }
+}
+
+// No actual tests: This test that the prost-derive attributes works

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -31,6 +31,8 @@ pub mod unittest;
 #[cfg(test)]
 mod bootstrap;
 #[cfg(test)]
+mod bytes;
+#[cfg(test)]
 mod debug;
 #[cfg(test)]
 mod derive_copy;


### PR DESCRIPTION
Following this comment : https://github.com/tokio-rs/prost/pull/1380#pullrequestreview-3761479526

This extract the trait `CustomScalarInterface` from the previous MR and generalised it by renaming it to `ScalarEncoding` .
It is then used to rework the `Bytes` and `Vec<u8>` encoding.

On my fork, I also have two following branches: `scalar-interface-string` and `scalar-interface-numerical` which continue the migration work, by the end `prost-derive/src/field/scalar.rs` only generates  code the use the trait (In the mean time some code is duplicated). With all of this,  we should be in a good state to re-introduce the custom-scalar feature using the new `ScalarEncoding`.  