### PR TITLE
feat: add skip_field_names attribute to strip struct/field names

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -260,6 +260,7 @@ impl<'b> CodeGenerator<'_, 'b> {
         ));
         self.append_prost_path_attribute();
         self.append_skip_debug(&fq_message_name);
+        self.append_skip_field_names(&fq_message_name);
         self.push_indent();
         self.buf.push_str("pub struct ");
         self.buf.push_str(&to_upper_camel(&message_name));
@@ -392,6 +393,14 @@ impl<'b> CodeGenerator<'_, 'b> {
         if self.context.should_skip_debug(fq_message_name) {
             push_indent(self.buf, self.depth);
             self.buf.push_str("#[prost(skip_debug)]");
+            self.buf.push('\n');
+        }
+    }
+
+    fn append_skip_field_names(&mut self, fq_message_name: &str) {
+        if self.context.should_skip_field_names(fq_message_name) {
+            push_indent(self.buf, self.depth);
+            self.buf.push_str("#[prost(skip_field_names)]");
             self.buf.push('\n');
         }
     }
@@ -653,6 +662,7 @@ impl<'b> CodeGenerator<'_, 'b> {
         ));
         self.append_prost_path_attribute();
         self.append_skip_debug(fq_message_name);
+        self.append_skip_field_names(fq_message_name);
         self.push_indent();
         self.buf.push_str("pub enum ");
         self.buf.push_str(&oneof.type_name());

--- a/prost-build/src/config.rs
+++ b/prost-build/src/config.rs
@@ -48,6 +48,7 @@ pub struct Config {
     pub(crate) protoc_executable: PathBuf,
     pub(crate) disable_comments: PathMap<()>,
     pub(crate) skip_debug: PathMap<()>,
+    pub(crate) skip_field_names: PathMap<()>,
     pub(crate) skip_protoc_run: bool,
     pub(crate) skip_source_info: bool,
     pub(crate) include_file: Option<PathBuf>,
@@ -433,6 +434,24 @@ impl Config {
         self.skip_debug.clear();
         for matcher in paths {
             self.skip_debug.insert(matcher.as_ref().to_string(), ());
+        }
+        self
+    }
+
+    /// Skips generating field names in `Message` trait implementations.
+    ///
+    /// When enabled, `stringify!()` calls that embed struct and field names
+    /// into the binary are removed. Useful for security-sensitive applications
+    /// where leaking type information into binaries is undesirable.
+    pub fn skip_field_names<I, S>(&mut self, paths: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        self.skip_field_names.clear();
+        for matcher in paths {
+            self.skip_field_names
+                .insert(matcher.as_ref().to_string(), ());
         }
         self
     }
@@ -1214,6 +1233,7 @@ impl default::Default for Config {
             protoc_executable: protoc_from_env(),
             disable_comments: PathMap::default(),
             skip_debug: PathMap::default(),
+            skip_field_names: PathMap::default(),
             skip_protoc_run: false,
             skip_source_info: false,
             include_file: None,
@@ -1244,6 +1264,7 @@ impl fmt::Debug for Config {
             .field("protoc_args", &self.protoc_args)
             .field("disable_comments", &self.disable_comments)
             .field("skip_debug", &self.skip_debug)
+            .field("skip_field_names", &self.skip_field_names)
             .field("prost_path", &self.prost_path)
             .finish()
     }

--- a/prost-build/src/context.rs
+++ b/prost-build/src/context.rs
@@ -306,6 +306,17 @@ impl<'a> Context<'a> {
         self.config.skip_debug.get(fq_message_name).next().is_some()
     }
 
+    /// Returns whether the named message should skip generating field names
+    /// in the `Message` trait implementation.
+    pub fn should_skip_field_names(&self, fq_message_name: &str) -> bool {
+        assert_eq!(b'.', fq_message_name.as_bytes()[0]);
+        self.config
+            .skip_field_names
+            .get(fq_message_name)
+            .next()
+            .is_some()
+    }
+
     /// Returns the type name domain URL for the named message,
     /// or an empty string if such is not configured.
     pub fn type_name_domain(&self, fq_message_name: &str) -> &str {

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -26,6 +26,7 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
 
     let Attributes {
         skip_debug,
+        skip_field_names,
         prost_path,
     } = Attributes::new(input.attrs)?;
 
@@ -113,18 +114,27 @@ fn try_message(input: TokenStream) -> Result<TokenStream, Error> {
         let tags = field.tags().into_iter().map(|tag| quote!(#tag));
         let tags = Itertools::intersperse(tags, quote!(|));
 
-        quote! {
-            #(#tags)* => {
-                let mut value = &mut self.#field_ident;
-                #merge.map_err(|mut error| {
-                    error.push(STRUCT_NAME, stringify!(#field_ident));
-                    error
-                })
-            },
+        if skip_field_names {
+            quote! {
+                #(#tags)* => {
+                    let mut value = &mut self.#field_ident;
+                    #merge
+                },
+            }
+        } else {
+            quote! {
+                #(#tags)* => {
+                    let mut value = &mut self.#field_ident;
+                    #merge.map_err(|mut error| {
+                        error.push(STRUCT_NAME, stringify!(#field_ident));
+                        error
+                    })
+                },
+            }
         }
     });
 
-    let struct_name = if fields.is_empty() {
+    let struct_name = if fields.is_empty() || skip_field_names {
         quote!()
     } else {
         quote!(
@@ -379,6 +389,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
 
     let Attributes {
         skip_debug,
+        skip_field_names,
         prost_path,
     } = Attributes::new(input.attrs)?;
 
@@ -459,6 +470,12 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
         quote!(#deprecated #ident::#variant_ident(ref value) => #encoded_len)
     });
 
+    let unreachable_arm = if skip_field_names {
+        quote!(_ => unreachable!())
+    } else {
+        quote!(_ => unreachable!(concat!("invalid ", stringify!(#ident), " tag: {}"), tag))
+    };
+
     let expanded = quote! {
         impl #impl_generics #ident #ty_generics #where_clause {
             /// Encodes the message to a buffer.
@@ -479,7 +496,7 @@ fn try_oneof(input: TokenStream) -> Result<TokenStream, Error> {
             {
                 match tag {
                     #(#merge,)*
-                    _ => unreachable!(concat!("invalid ", stringify!(#ident), " tag: {}"), tag),
+                    #unreachable_arm
                 }
             }
 
@@ -575,19 +592,31 @@ fn get_prost_path(attrs: &[Meta]) -> Result<Path, Error> {
 
 struct Attributes {
     skip_debug: bool,
+    skip_field_names: bool,
     prost_path: Path,
 }
 
 impl Attributes {
     fn new(attrs: Vec<Attribute>) -> Result<Self, Error> {
         syn::custom_keyword!(skip_debug);
-        let skip_debug = attrs.iter().any(|a| a.parse_args::<skip_debug>().is_ok());
+        syn::custom_keyword!(skip_field_names);
+        let mut found_skip_debug = false;
+        let mut found_skip_field_names = false;
+        for a in &attrs {
+            if a.parse_args::<skip_debug>().is_ok() {
+                found_skip_debug = true;
+            }
+            if a.parse_args::<skip_field_names>().is_ok() {
+                found_skip_field_names = true;
+            }
+        }
 
         let attrs = prost_attrs(attrs)?;
         let prost_path = get_prost_path(&attrs)?;
 
         Ok(Self {
-            skip_debug,
+            skip_debug: found_skip_debug,
+            skip_field_names: found_skip_field_names,
             prost_path,
         })
     }


### PR DESCRIPTION
prost-derive's Message trait impl embeds struct and field names via stringify!() in STRUCT_NAME constants and merge_field error paths. These survive even when skip_debug is enabled, leaking type information into compiled binaries.

Add a new #[prost(skip_field_names)] attribute (independent of skip_debug) that when set:
- Removes the STRUCT_NAME constant generation
- Removes .map_err() error context from merge_field
- Replaces unreachable!() messages in oneof merge with no-arg version

prost-build: add Config::skip_field_names() API, context query method, and code_generator attribute emission (mirroring skip_debug pattern).