### PR TITLE
fix(prost-build): use Display instead of Debug for quoted string

### DIFF
--- a/prost-build/src/code_generator.rs
+++ b/prost-build/src/code_generator.rs
@@ -1064,7 +1064,7 @@ impl<'b> CodeGenerator<'_, 'b> {
             Type::Group => Cow::Borrowed("group"),
             Type::Message => Cow::Borrowed("message"),
             Type::Enum => Cow::Owned(format!(
-                "enumeration = {:?}",
+                "enumeration = \"{}\"",
                 self.resolve_ident(field.type_name())
             )),
         }


### PR DESCRIPTION
Prevents the generation of broken code in case the fmt-debug unstable feature is used.

Fixes #1418