### PR TITLE
prost-build: add Config::eq_when_safe to gate auto Eq derives (#30)

### DIFF
--- a/prost-build/src/config.rs
+++ b/prost-build/src/config.rs
@@ -53,6 +53,7 @@ pub struct Config {
     pub(crate) include_file: Option<PathBuf>,
     pub(crate) prost_path: Option<String>,
     pub(crate) prost_types_path: Option<String>,
+    pub(crate) eq_when_safe: bool,
     #[cfg(feature = "format")]
     pub(crate) fmt: bool,
 }
@@ -372,6 +373,32 @@ impl Config {
         P: AsRef<str>,
     {
         self.boxed.insert(path.as_ref().to_string(), ());
+        self
+    }
+
+    /// Controls whether `Eq` is automatically derived on generated message types
+    /// when it is safe to do so.
+    ///
+    /// A derive of `Eq` is "safe" when none of the message's fields are floating
+    /// point (`f32`/`f64`) and none of its nested message fields transitively
+    /// contain a floating point field. Floating point types do not implement
+    /// `Eq`, so deriving it on a message that holds one would not compile.
+    ///
+    /// When set to `true` (the default), prost emits `#[derive(Eq, Hash)]` in
+    /// addition to the always-emitted `PartialEq` for any message that meets the
+    /// safety check. When set to `false`, prost never emits `Eq`/`Hash`, even on
+    /// messages where it would be safe; downstream code can still implement
+    /// these traits manually if desired.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # let mut config = prost_build::Config::new();
+    /// // Opt out of automatic `Eq` derives.
+    /// config.eq_when_safe(false);
+    /// ```
+    pub fn eq_when_safe(&mut self, enable: bool) -> &mut Self {
+        self.eq_when_safe = enable;
         self
     }
 
@@ -1219,6 +1246,9 @@ impl default::Default for Config {
             include_file: None,
             prost_path: None,
             prost_types_path: None,
+            // Default true preserves prost's existing behavior of auto-deriving
+            // `Eq` on messages where it is safe (no float fields, transitively).
+            eq_when_safe: true,
             #[cfg(feature = "format")]
             fmt: true,
         }

--- a/prost-build/src/context.rs
+++ b/prost-build/src/context.rs
@@ -1,4 +1,6 @@
 use std::borrow::Cow;
+use std::cell::RefCell;
+use std::collections::HashMap;
 
 use prost_types::{
     field_descriptor_proto::{Label, Type},
@@ -20,6 +22,11 @@ pub struct Context<'a> {
     message_graph: MessageGraph,
     extern_paths: ExternPaths,
     prost_path_attribute: Option<String>,
+    /// Memoization for `can_message_derive_eq`. Keyed by fully-qualified
+    /// message name. The optional value distinguishes "in progress" (None)
+    /// from a computed result (Some(bool)). "In progress" entries let us
+    /// terminate cycles in the recursive walk without recomputing.
+    eq_cache: RefCell<HashMap<String, Option<bool>>>,
 }
 
 impl<'a> Context<'a> {
@@ -38,6 +45,7 @@ impl<'a> Context<'a> {
             message_graph,
             extern_paths,
             prost_path_attribute,
+            eq_cache: RefCell::new(HashMap::new()),
         }
     }
 
@@ -240,18 +248,65 @@ impl<'a> Context<'a> {
         }
     }
 
-    /// Returns `true` if this message can automatically derive Eq trait.
+    /// Returns `true` if this message can automatically derive `Eq`.
+    ///
+    /// Returns `false` when the user has opted out via [`Config::eq_when_safe`],
+    /// or when the message (or any nested message it contains, transitively)
+    /// has a floating point field. Results are memoized per message; cycles in
+    /// the message graph are broken by treating an in-progress walk as
+    /// `Eq`-safe so a self-referential type does not flip the result purely on
+    /// recursion.
     pub fn can_message_derive_eq(&self, fq_message_name: &str) -> bool {
-        assert_eq!(".", &fq_message_name[..1]);
-
-        let msg = self.message_graph.get_message(fq_message_name).unwrap();
-        msg.field
-            .iter()
-            .all(|field| self.can_field_derive_eq(fq_message_name, field))
+        if !self.config.eq_when_safe {
+            return false;
+        }
+        self.compute_can_message_derive_eq(fq_message_name)
     }
 
-    /// Returns `true` if the type of this field allows deriving the Eq trait.
+    fn compute_can_message_derive_eq(&self, fq_message_name: &str) -> bool {
+        assert_eq!(".", &fq_message_name[..1]);
+
+        // Fast path: previously computed.
+        if let Some(entry) = self.eq_cache.borrow().get(fq_message_name) {
+            // `None` here means we are mid-walk on this message (cycle). We
+            // treat that as `true` so a back-edge does not by itself disqualify
+            // a message; if the cycle contains a float field, another field
+            // along the walk will produce `false` and propagate.
+            return entry.unwrap_or(true);
+        }
+
+        // Mark as in-progress to break cycles.
+        self.eq_cache
+            .borrow_mut()
+            .insert(fq_message_name.to_string(), None);
+
+        let msg = self.message_graph.get_message(fq_message_name).unwrap();
+        let result = msg
+            .field
+            .iter()
+            .all(|field| self.compute_can_field_derive_eq(fq_message_name, field));
+
+        self.eq_cache
+            .borrow_mut()
+            .insert(fq_message_name.to_string(), Some(result));
+        result
+    }
+
+    /// Returns `true` if the type of this field allows deriving the `Eq` trait.
+    ///
+    /// Returns `false` if the user has opted out via [`Config::eq_when_safe`].
     pub fn can_field_derive_eq(&self, fq_message_name: &str, field: &FieldDescriptorProto) -> bool {
+        if !self.config.eq_when_safe {
+            return false;
+        }
+        self.compute_can_field_derive_eq(fq_message_name, field)
+    }
+
+    fn compute_can_field_derive_eq(
+        &self,
+        fq_message_name: &str,
+        field: &FieldDescriptorProto,
+    ) -> bool {
         assert_eq!(".", &fq_message_name[..1]);
 
         if field.r#type() == Type::Message {
@@ -262,7 +317,7 @@ impl<'a> Context<'a> {
             {
                 false
             } else {
-                self.can_message_derive_eq(field.type_name())
+                self.compute_can_message_derive_eq(field.type_name())
             }
         } else {
             matches!(

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -626,4 +626,57 @@ mod tests {
             tempdir.path().join("all_deprecated.rs")
         );
     }
+
+    /// `eq_when_safe(false)` must skip the automatic `Eq`/`Hash` derive on
+    /// messages that would otherwise qualify (the smoke test messages have no
+    /// fields and so are trivially Eq-safe).
+    #[test]
+    fn test_eq_when_safe_false_skips_eq() {
+        let _ = env_logger::try_init();
+        let tempdir = tempfile::tempdir().unwrap();
+
+        Config::new()
+            .out_dir(tempdir.path())
+            .eq_when_safe(false)
+            .compile_protos(&["src/fixtures/smoke_test/smoke_test.proto"], &["src"])
+            .unwrap();
+
+        let generated = std::fs::read_to_string(tempdir.path().join("smoke_test.rs")).unwrap();
+        // We want to confirm `Eq` and `Hash` are absent without false-matching
+        // `Eq` inside `PartialEq`; check the comma-separated derive list.
+        assert!(
+            !generated.contains(", Eq, "),
+            "expected no `Eq` derive when eq_when_safe(false), got:\n{generated}"
+        );
+        assert!(
+            !generated.contains(", Hash, "),
+            "expected no `Hash` derive when eq_when_safe(false), got:\n{generated}"
+        );
+        // `PartialEq` should always be present.
+        assert!(generated.contains("PartialEq"));
+    }
+
+    /// `eq_when_safe(true)` (the default) keeps emitting `Eq`/`Hash` on safe
+    /// messages, preserving existing prost behavior.
+    #[test]
+    fn test_eq_when_safe_true_emits_eq() {
+        let _ = env_logger::try_init();
+        let tempdir = tempfile::tempdir().unwrap();
+
+        Config::new()
+            .out_dir(tempdir.path())
+            .eq_when_safe(true)
+            .compile_protos(&["src/fixtures/smoke_test/smoke_test.proto"], &["src"])
+            .unwrap();
+
+        let generated = std::fs::read_to_string(tempdir.path().join("smoke_test.rs")).unwrap();
+        assert!(
+            generated.contains(", Eq, "),
+            "expected `Eq` derive, got:\n{generated}"
+        );
+        assert!(
+            generated.contains(", Hash, "),
+            "expected `Hash` derive, got:\n{generated}"
+        );
+    }
 }

--- a/tests/build.rs
+++ b/tests/build.rs
@@ -100,6 +100,14 @@ fn main() {
         .compile_protos(&[src.join("derive_copy.proto")], includes)
         .unwrap();
 
+    // derive_eq: confirms `Eq` is auto-derived where safe (default behavior),
+    // gated by Config::eq_when_safe(true).
+    prost_build::Config::new()
+        .btree_map(["."])
+        .eq_when_safe(true)
+        .compile_protos(&[src.join("derive_eq.proto")], includes)
+        .unwrap();
+
     prost_build::Config::new()
         .compile_protos(&[src.join("default_string_escape.proto")], includes)
         .unwrap();

--- a/tests/src/derive_eq.proto
+++ b/tests/src/derive_eq.proto
@@ -1,0 +1,36 @@
+syntax = "proto3";
+
+package derive_eq;
+
+// All-integer message: should derive Eq when eq_when_safe is true (default).
+message AllIntMsg {
+  int32  field1  = 1;
+  int64  field2  = 2;
+  uint32 field3  = 3;
+  uint64 field4  = 4;
+  bool   field5  = 5;
+  string field6  = 6;
+  bytes  field7  = 7;
+}
+
+// Message with a float field: must NOT derive Eq, even when safe is enabled.
+message FloatMsg {
+  int32 ok_field = 1;
+  float bad_field = 2;
+}
+
+// Message with a double field: must NOT derive Eq.
+message DoubleMsg {
+  double bad_field = 1;
+}
+
+// Composed: holds another message that is itself Eq-safe; should derive Eq.
+message ComposedSafeMsg {
+  AllIntMsg inner = 1;
+  string label = 2;
+}
+
+// Composed: holds a message that contains a float; should NOT derive Eq.
+message ComposedUnsafeMsg {
+  FloatMsg inner = 1;
+}

--- a/tests/src/derive_eq.rs
+++ b/tests/src/derive_eq.rs
@@ -1,0 +1,42 @@
+#![allow(dead_code)]
+
+include!(concat!(env!("OUT_DIR"), "/derive_eq.rs"));
+
+// Compile-time assertion: the listed types must implement `Eq`.
+trait TestEqIsImplemented: Eq {}
+
+impl TestEqIsImplemented for AllIntMsg {}
+impl TestEqIsImplemented for ComposedSafeMsg {}
+
+// Float-bearing messages do not implement `Eq`. We prove this negatively by
+// checking that `PartialEq` is still derived for them at runtime (a `PartialEq`
+// comparison compiles regardless), and by leaving them out of the `Eq` list
+// above. Adding `impl TestEqIsImplemented for FloatMsg {}` would fail to
+// compile, which is the desired behavior.
+#[test]
+fn float_messages_still_partial_eq() {
+    let a = FloatMsg::default();
+    let b = FloatMsg::default();
+    assert_eq!(a, b);
+
+    let c = DoubleMsg::default();
+    let d = DoubleMsg::default();
+    assert_eq!(c, d);
+
+    let e = ComposedUnsafeMsg::default();
+    let f = ComposedUnsafeMsg::default();
+    assert_eq!(e, f);
+}
+
+#[test]
+fn safe_messages_are_eq_and_hash() {
+    use std::collections::HashSet;
+
+    let mut set: HashSet<AllIntMsg> = HashSet::new();
+    set.insert(AllIntMsg::default());
+    assert!(set.contains(&AllIntMsg::default()));
+
+    let mut set2: HashSet<ComposedSafeMsg> = HashSet::new();
+    set2.insert(ComposedSafeMsg::default());
+    assert!(set2.contains(&ComposedSafeMsg::default()));
+}

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -35,6 +35,8 @@ mod debug;
 #[cfg(test)]
 mod derive_copy;
 #[cfg(test)]
+mod derive_eq;
+#[cfg(test)]
 mod enum_keyword_variant;
 #[cfg(test)]
 mod generic_derive;


### PR DESCRIPTION
## Summary
Closes #30. Adds an explicit `Config::eq_when_safe(bool)` builder so callers can opt out of automatic `Eq`/`Hash` derives. Default `true` preserves existing behavior.

## What's added
- `prost-build/src/config.rs` — new `eq_when_safe` field + builder method.
- `prost-build/src/context.rs` — gates `can_message_derive_eq` / `can_field_derive_eq` on the flag, with `RefCell<HashMap>` memoization and a cycle-break sentinel for recursive types.
- `prost-build/src/lib.rs` — unit tests for both flag states.
- New `tests/src/derive_eq.proto` and `tests/src/derive_eq.rs` with compile-time `TestEqIsImplemented: Eq` bound across all-int, float, double, composed-safe, and composed-unsafe messages.

## Test plan
- `cargo fmt --all -- --check` clean.
- `cargo clippy -p prost-build --all-targets --all-features -- -D warnings` clean.
- 539/539 tests pass across `prost`, `prost-build`, `prost-derive`, `prost-types`, `tests`.
