### PR TITLE
fix(prost-derive): avoid UTF-8 panic for enumeration names

### DIFF
--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -483,8 +483,8 @@ impl Ty {
             "bool" => Ty::Bool,
             "string" => Ty::String,
             "bytes" => Ty::Bytes(BytesTy::Vec),
-            s if let Some(s) = s.strip_prefix("enumeration") => {
-                let s = s.trim();
+            s if s.starts_with("enumeration") => {
+                let s = s.strip_prefix("enumeration").unwrap().trim();
                 match s.chars().next() {
                     Some('<') | Some('(') => (),
                     _ => return error,

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -466,7 +466,6 @@ impl Ty {
     }
 
     pub fn from_str(s: &str) -> Result<Ty, Error> {
-        let enumeration_len = "enumeration".len();
         let error = Err(anyhow!("invalid type: {s}"));
         let ty = match s.trim() {
             "float" => Ty::Float,
@@ -484,11 +483,8 @@ impl Ty {
             "bool" => Ty::Bool,
             "string" => Ty::String,
             "bytes" => Ty::Bytes(BytesTy::Vec),
-            s if s.len() > enumeration_len
-                && s.is_char_boundary(enumeration_len)
-                && &s[..enumeration_len] == "enumeration" =>
-            {
-                let s = &s[enumeration_len..].trim();
+            s if let Some(s) = s.strip_prefix("enumeration") => {
+                let s = s.trim();
                 match s.chars().next() {
                     Some('<') | Some('(') => (),
                     _ => return error,

--- a/prost-derive/src/field/scalar.rs
+++ b/prost-derive/src/field/scalar.rs
@@ -484,7 +484,10 @@ impl Ty {
             "bool" => Ty::Bool,
             "string" => Ty::String,
             "bytes" => Ty::Bytes(BytesTy::Vec),
-            s if s.len() > enumeration_len && &s[..enumeration_len] == "enumeration" => {
+            s if s.len() > enumeration_len
+                && s.is_char_boundary(enumeration_len)
+                && &s[..enumeration_len] == "enumeration" =>
+            {
                 let s = &s[enumeration_len..].trim();
                 match s.chars().next() {
                     Some('<') | Some('(') => (),
@@ -833,5 +836,10 @@ mod tests {
         let ty = Ty::Enumeration(parse_str::<Path>("ExampleEnum").unwrap());
         let lit = parse_str::<Lit>("\"not-valid!\"").unwrap();
         assert!(DefaultValue::from_lit(&ty, lit).is_err());
+    }
+
+    #[test]
+    fn from_str_rejects_non_ascii_prefix_without_panic() {
+        assert!(Ty::from_str("éééééé").is_err());
     }
 }


### PR DESCRIPTION
The enumeration prefix probe in `Ty::from_str` slices the input by byte index and panics on non-ASCII strings whose byte length exceeds `"enumeration".len()` but whose 11th byte is mid-codepoint (e.g. `"éééééé"` from a `#[prost(map = ...)]` attribute). Adding an `is_char_boundary` guard lets such inputs fall through to the existing `invalid type` error path.

Closes #1417