### PR TITLE
build: Increase MSRV to 1.85

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,4 +227,4 @@ jobs:
       - name: Verify that Prost version is up to date in README
         run: grep -q "$(sed '/^version = /!d' Cargo.toml | head -n1)" README.md
       - name: Verify that MSRV version is up to date in README
-        run: grep -q "supports $(sed -n 's/rust-version = "\(.*\)"/\1/p' Cargo.toml)\." README.md
+        run: grep -q "The current MSRV is $(sed -n 's/rust-version = "\(.*\)"/\1/p' Cargo.toml)\." README.md

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ authors = [
 ]
 license = "Apache-2.0"
 repository = "https://github.com/tokio-rs/prost"
-rust-version = "1.82"
+rust-version = "1.85"
 edition = "2021"
 
 [profile.bench]

--- a/README.md
+++ b/README.md
@@ -47,10 +47,9 @@ See the [snazzy repository][snazzy] for a simple start-to-finish example.
 
 ### MSRV
 
-`prost` follows the `tokio-rs` project's MSRV model and supports 1.82. For more
-information on the tokio msrv policy you can check it out [here][tokio msrv]
-
-[tokio msrv]: https://github.com/tokio-rs/tokio/#supported-rust-versions
+`prost` will keep a rolling MSRV (minimum supported rust version) policy of at least 6 months. 
+When increasing the MSRV, the new Rust version must have been released at least six months ago. 
+The current MSRV is 1.85.
 
 ## Generated Code
 


### PR DESCRIPTION
Rust 1.85 was released on 20 February, 2025 (15 months ago at this time). Our transitive dependency `indexmap` has recently increased their MSRV. The path of least resistance is to follow this decision.