### PR TITLE
style: use variables directly in `format!()`

### DIFF
--- a/benchmarks/benches/dataset.rs
+++ b/benchmarks/benches/dataset.rs
@@ -37,7 +37,7 @@ fn benchmark_dataset<M>(criterion: &mut Criterion, name: &str, dataset: &'static
 where
     M: prost::Message + Default + 'static,
 {
-    let mut group = criterion.benchmark_group(format!("dataset/{}", name));
+    let mut group = criterion.benchmark_group(format!("dataset/{name}"));
 
     group.bench_function("merge", move |b| {
         let dataset = load_dataset(dataset).unwrap();

--- a/prost/benches/varint.rs
+++ b/prost/benches/varint.rs
@@ -8,7 +8,7 @@ use rand::{rngs::StdRng, seq::SliceRandom, SeedableRng};
 fn benchmark_varint(criterion: &mut Criterion, name: &str, mut values: Vec<u64>) {
     // Shuffle the values in a stable order.
     values.shuffle(&mut StdRng::seed_from_u64(0));
-    let name = format!("varint/{}", name);
+    let name = format!("varint/{name}");
 
     let encoded_len = values
         .iter()

--- a/protobuf/build.rs
+++ b/protobuf/build.rs
@@ -63,7 +63,7 @@ include(FetchContent)
 FetchContent_Declare(
   protobuf
   GIT_REPOSITORY https://github.com/protocolbuffers/protobuf.git
-  GIT_TAG {tag}
+  GIT_TAG {PROTOBUF_TAG}
   GIT_SHALLOW TRUE
 )
 
@@ -73,7 +73,7 @@ set(ABSL_PROPAGATE_CXX_STD ON)
 set(ABSL_USE_EXTERNAL_GOOGLETEST ON)
 set(ABSL_BUILD_TESTING OFF)
 set(ABSL_ENABLE_INSTALL ON)
-set(protobuf_BUILD_CONFORMANCE {conformance})
+set(protobuf_BUILD_CONFORMANCE {build_conformance})
 set(protobuf_BUILD_TESTS OFF)
 set(protobuf_ABSL_PROVIDER "module")
 
@@ -100,10 +100,7 @@ FetchContent_MakeAvailable(protobuf)
 if(_SAVED_APPLE)
   set(APPLE "${{_SAVED_APPLE}}" CACHE BOOL "" FORCE)
 endif()
-"#,
-        system_processor = system_processor,
-        tag = PROTOBUF_TAG,
-        conformance = build_conformance
+"#
     );
 
     fs::write(build_dir.join("CMakeLists.txt"), cmake_content)


### PR DESCRIPTION
Prevent clippy warnings like:
```
error: variables can be used directly in the `format!` string
  --> benchmarks/benches/dataset.rs:40:47
   |
40 |     let mut group = criterion.benchmark_group(format!("dataset/{}", name));
   |                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
   = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::uninlined_format_args)]`
help: change this to
   |
40 -     let mut group = criterion.benchmark_group(format!("dataset/{}", name));
40 +     let mut group = criterion.benchmark_group(format!("dataset/{name}"));
   |
```