### PR TITLE
style: remove explicit `.into_iter()`

### DIFF
--- a/prost-build/src/extern_paths.rs
+++ b/prost-build/src/extern_paths.rs
@@ -110,7 +110,7 @@ impl ExternPaths {
                                 to_snake(segment)
                             }
                         })
-                        .chain(ident_type.into_iter())
+                        .chain(ident_type)
                         .join("::"),
                 );
             }

--- a/prost-derive/src/field/mod.rs
+++ b/prost-derive/src/field/mod.rs
@@ -232,9 +232,7 @@ fn prost_attrs(attrs: Vec<Attribute>) -> Result<Vec<Meta>, Error> {
         if let Meta::List(meta_list) = &attr.meta {
             if meta_list.path.is_ident("prost") {
                 result.extend(
-                    meta_list
-                        .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?
-                        .into_iter(),
+                    meta_list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?,
                 )
             }
         }

--- a/prost-derive/src/lib.rs
+++ b/prost-derive/src/lib.rs
@@ -533,9 +533,7 @@ fn prost_attrs(attrs: Vec<Attribute>) -> Result<Vec<Meta>, Error> {
         if let Meta::List(meta_list) = &attr.meta {
             if meta_list.path.is_ident("prost") {
                 result.extend(
-                    meta_list
-                        .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?
-                        .into_iter(),
+                    meta_list.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?,
                 )
             }
         }


### PR DESCRIPTION
Prevent clippy warnings like:
```
error: explicit call to `.into_iter()` in function argument accepting `IntoIterator`
   --> prost-derive/src/field/mod.rs:235:21
    |
235 | /                     meta_list
236 | |                         .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?
237 | |                         .into_iter(),
    | |____________________________________^
    |
note: this parameter accepts any `IntoIterator`, so you don't need to call `.into_iter()`
   --> /rustc/59807616e1fa2540724bfbac14d7976d7e4a3860/library/core/src/iter/traits/collect.rs:416:17
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.95.0/index.html#useless_conversion
    = note: `-D clippy::useless-conversion` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::useless_conversion)]`
help: consider removing the `.into_iter()`
    |
236 -                         .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?
237 -                         .into_iter(),
236 +                         .parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated)?,
    |
```