### PR TITLE
fix: Prevent panic for service generator in empty module

### DIFF
--- a/prost-build/src/config.rs
+++ b/prost-build/src/config.rs
@@ -1136,10 +1136,6 @@ impl Config {
                 .entry(request_module.clone())
                 .or_insert_with(String::new);
             CodeGenerator::generate(&mut context, request_fd, buf);
-            if buf.is_empty() {
-                // Did not generate any code, remove from list to avoid inclusion in include file or output file list
-                modules.remove(&request_module);
-            }
         }
 
         if let Some(service_generator) = context.service_generator_mut() {
@@ -1148,6 +1144,9 @@ impl Config {
                 service_generator.finalize_package(&package, buf);
             }
         }
+
+        // Modules without generated code should be removed from list to avoid inclusion in include file or output file list
+        modules.retain(|_module, buf| !buf.is_empty());
 
         #[cfg(feature = "format")]
         if self.fmt {

--- a/prost-build/src/fixtures/helloworld/hello.proto
+++ b/prost-build/src/fixtures/helloworld/hello.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 import "types.proto";
 
-package helloworld;
+package helloworld.greetings;
 
 service Greeting {
   rpc Hello (Message) returns (Response) {}

--- a/prost-build/src/lib.rs
+++ b/prost-build/src/lib.rs
@@ -375,6 +375,7 @@ mod tests {
         fn finalize_package(&mut self, package: &str, _buf: &mut String) {
             let mut state = self.state.borrow_mut();
             state.package_names.push(package.to_string());
+            state.package_names.sort();
         }
     }
 
@@ -429,7 +430,10 @@ mod tests {
 
         let state = state.borrow();
         assert_eq!(&state.service_names, &["Greeting", "Farewell"]);
-        assert_eq!(&state.package_names, &["helloworld"]);
+        assert_eq!(
+            &state.package_names,
+            &["helloworld", "helloworld.greetings"]
+        );
         assert_eq!(state.finalized, 3);
     }
 


### PR DESCRIPTION
A package with a service but without any messages, cause a panic as the module is removed before `finalize_package` is called on the module.