### PR TITLE
fix: correct typos in comments

### DIFF
--- a/prost-types/src/compiler.rs
+++ b/prost-types/src/compiler.rs
@@ -56,7 +56,7 @@ pub struct CodeGeneratorResponse {
     /// This should be used to indicate errors in .proto files which prevent the
     /// code generator from generating correct code.  Errors which indicate a
     /// problem in protoc itself -- such as the input CodeGeneratorRequest being
-    /// unparseable -- should be reported by writing a message to stderr and
+    /// unparsable -- should be reported by writing a message to stderr and
     /// exiting with a non-zero status code.
     #[prost(string, optional, tag = "1")]
     pub error: ::core::option::Option<::prost::alloc::string::String>,

--- a/tests/src/lib.rs
+++ b/tests/src/lib.rs
@@ -165,7 +165,7 @@ where
 
     let encoded_len = all_types.encoded_len();
 
-    // TODO: Reenable this once sign-extension in negative int32s is figured out.
+    // TODO: Re-enable this once sign-extension in negative int32s is figured out.
     // assert!(encoded_len <= data.len(), "encoded_len: {}, len: {}, all_types: {:?}",
     //         encoded_len, data.len(), all_types);
 


### PR DESCRIPTION
Fix two typos found by codespell in `.rs` files:

- `unparseable` -> `unparsable` in `prost-types/src/compiler.rs` (line 59)
- `Reenable` -> `Re-enable` in `tests/src/lib.rs` (line 168)